### PR TITLE
Look up polling station by ID before covers

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_westberks.py
+++ b/polling_stations/apps/data_collection/management/commands/import_westberks.py
@@ -16,6 +16,7 @@ class Command(BaseShpShpImporter):
         return {
             'internal_council_id': record[4],
             'name': record[2],
+            'polling_station_id': record[6]
         }
 
     def station_record_to_dict(self, record):

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -42,8 +42,13 @@ class PostcodeView(TemplateView):
             context['has_polling_district'] = False
 
         if context['has_polling_district']:
-            context['points'] = PollingStation.objects.filter(
-                location__within=areas['polling_district'].area)
+            try:
+                context['points'] = PollingStation.objects.filter(
+                    internal_council_id=
+                    areas['polling_district'].polling_station_id)
+            except PollingStation.DoesNotExist:
+                context['points'] = PollingStation.objects.filter(
+                    location__within=areas['polling_district'].area)
         else:
             context['points'] = PollingStation.objects.filter(
                 location__within=areas['council'].area)

--- a/polling_stations/apps/pollingstations/migrations/0002_pollingdistrict_polling_station_id.py
+++ b/polling_stations/apps/pollingstations/migrations/0002_pollingdistrict_polling_station_id.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pollingstations', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='pollingdistrict',
+            name='polling_station_id',
+            field=models.CharField(max_length=255, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -22,6 +22,9 @@ class PollingDistrict(models.Model):
     internal_council_id = models.CharField(blank=True, max_length=100)
     extra_id            = models.CharField(blank=True, null=True, max_length=100)
     area                = models.MultiPolygonField(null=True, blank=True)
+    # This is NOT a FK, as we might not have the polling station aat
+    # the point of import
+    polling_station_id  = models.CharField(blank=True, max_length=255)
 
     objects = models.GeoManager()
 


### PR DESCRIPTION
Fixes #106 

This is because sometimes the shapefile contains information
about the actual polling station, and it's not always within
the district itself.

Here's an example:

![screen shot 2015-04-27 at 15 28 27](https://cloud.githubusercontent.com/assets/242329/7349587/1eb7ca76-ecf2-11e4-92a7-cc3ee814f467.png)
