### PR TITLE
Add front-end for using ResidentialAddresss data

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/__init__.py
+++ b/polling_stations/apps/data_collection/management/commands/__init__.py
@@ -5,6 +5,7 @@ import csv
 import json
 import glob
 import os
+import re
 import shapefile
 import sys
 import tempfile
@@ -273,10 +274,17 @@ class BaseKamlImporter(BaseImporter):
 class BaseAddressCsvImporter(BaseImporter):
 
     def add_residential_address(self, address_info):
+
+        """
+        strip all whitespace from postcode and convert to uppercase
+        this will make it easier to query this based on user-supplied postcode
+        """
+        postcode = re.sub('[^A-Z0-9]', '', address_info['postcode'].upper())
+
         ResidentialAddress.objects.update_or_create(
             council=self.council,
             address=address_info['address'],
-            postcode=address_info['postcode'],
+            postcode=postcode,
             polling_station_id=address_info['polling_station_id'],
         )
 

--- a/polling_stations/apps/data_finder/forms.py
+++ b/polling_stations/apps/data_finder/forms.py
@@ -4,3 +4,16 @@ from localflavor.gb.forms import GBPostcodeField
 
 class PostcodeLookupForm(forms.Form):
     postcode = GBPostcodeField(label="Enter your postcode")
+
+class AddressSelectForm(forms.Form):
+    address = forms.ChoiceField(
+        choices = (),
+        label = "",
+        initial = "",
+        widget = forms.Select(attrs={'class' : 'input-lg form-control'}),
+        required=True
+    )
+
+    def __init__(self, choices, *args, **kwargs):
+        super(AddressSelectForm, self).__init__(*args, **kwargs)
+        self.fields['address'].choices = choices

--- a/polling_stations/templates/address_select.html
+++ b/polling_stations/templates/address_select.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {% if not is_whitelabel %}
+  <div class="page-header">
+    <h1>Where is my Polling Station?</h1>
+  </div>
+  {% endif %}
+  <h2>
+    Choose Your Address / Street
+  </h2>
+
+  <form method=post class="form form-inline">
+    {% csrf_token %}
+    <div class="form-group">
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-lg btn-success" id="submit-address"
+                data-loading-text="Find your Polling Station">
+          Find your Polling Station
+        </button>
+    </div>
+  </form>
+
+{% endblock content %}

--- a/polling_stations/urls.py
+++ b/polling_stations/urls.py
@@ -7,7 +7,14 @@ from django.conf.urls.static import static
 from django.views.generic import TemplateView
 
 from polling_stations.api import router
-from data_finder.views import HomeView, CouncilView, PostcodeView, CoverageView
+from data_finder.views import (
+    HomeView,
+    CouncilView,
+    PostcodeView,
+    CoverageView,
+    AddressView,
+    AddressFormView
+)
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -19,6 +26,10 @@ core_patterns = patterns(
     url(r'^council/(?P<pk>.+)/$', CouncilView.as_view(), name='council'),
     url(r'^postcode/(?P<postcode>.+)/$',
         PostcodeView.as_view(), name='postcode_view'),
+    url(r'^address/(?P<address_id>.+)/$',
+        AddressView.as_view(), name='address_view'),
+    url(r'^address_select/(?P<postcode>.+)/$',
+        AddressFormView.as_view(), name='address_select_view'),
     url(r'^$', HomeView.as_view(), name='home'),
 )
 


### PR DESCRIPTION
Here's the UI mods to allow us to use the data from Denbighshire and RCT. There's quite a few notes/points on this one:

I've modified `BaseAddressCsvImporter` to strip non alphanumeric characters from postcodes when inserting a `ResidentialAddress` object to make this easier to query. If you've already imported Denbighsire and RCT, you'll need to re-run those import scripts.

Having thought this through a bit more clearly, we are going to have to deal with a mix of:
* address data with UPRNs
* full address data without UPRNs (as we've got from RCT)
* partial address data e.g: street name only (as we've got from Denbighsire)

As such, we are going to need to assign each `ResidentialAddress` record its' own internal ID and use that instead of being able to rely on UPRN - so that's the approach I've taken. We will have to either treat UPRN as optional meta-data rather than a canonical ID or treat data with and without UPRNs separately.

As discussed on Slack, you are looking to make some modifications to the website design and text, so I've kept everything very close to the current layout to minimise any additional work you'll need to do. The one thing I've done that you will probably need to change is `{'class' : 'input-lg form-control'}` [here](https://github.com/chris48s/UK-Polling-Stations/commit/4583a4ceff162795cee8a41692e56c38b6b46d59#diff-533f0d761b152d27f4dabc34e39cab49R13).

I've left `context['areas'] = areas` commented out [here](https://github.com/chris48s/UK-Polling-Stations/commit/4583a4ceff162795cee8a41692e56c38b6b46d59#diff-78a9fc588889ef751c68b530b1af1e80R184) so no map will be displayed when using the `address` endpoint. If you uncomment that line, you'll get a map with the home point and polling station point on it, but zoomed out to the local authority boundary (i.e: a massive boundary with 2 points practically on top of each other - which isn't that useful).
I thought about constructing a smaller (invisible) bounding box based on the 2 points and zooming the map to that, but as you were saying on slack that you may end up ditching the map entirely, I haven't bothered with that for the moment. If you want me to add this, let me know.

This adds the front end mods to allow this data to be served up through the **wesbite**, but it doesn't allow us to serve it up via the **API**. Adding a `/api/residentialaddresses` endpoint in the same style as the existing endpoints will just take a long time to dump out a a lot of data, so I haven't addressed this.

Closes #156, #165
