### PR TITLE
Import scripts for Pembrokeshire and City of London

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_city_of_london.py
+++ b/polling_stations/apps/data_collection/management/commands/import_city_of_london.py
@@ -1,0 +1,56 @@
+"""
+Imports City of London
+"""
+from django.contrib.gis.geos import GEOSGeometry
+from data_collection.management.commands import BaseApiKmlKmlImporter
+
+class Command(BaseApiKmlKmlImporter):
+    """
+    Imports the Polling Station data from City of London Corporation
+    """
+    srid             = 27700
+    districts_srid   = 27700
+    council_id       = 'E09000001'
+    districts_url    = 'http://www.mapping2.cityoflondon.gov.uk/arcgis/services/INSPIRE/MapServer/WFSServer?request=GetFeature&version=1.1.0&service=wfs&typeNames=INSPIRE:UK_Parliamentary_General_Election_Polling_Districts'
+    stations_url     = 'http://www.mapping2.cityoflondon.gov.uk/arcgis/services/INSPIRE/MapServer/WFSServer?request=GetFeature&version=1.1.0&service=wfs&typeNames=INSPIRE:UK_Parliamentary_General_Election_Polling_Places'
+    """
+    note:
+    These aren't actually KML - they're GML (hence use of SRID 27700)
+    but gdal.DataSource will just deal with them for us :)
+    """
+
+    def district_record_to_dict(self, record):
+        geojson = record.geom.geojson
+        poly = self.clean_poly(GEOSGeometry(geojson, srid=self.get_srid('districts')))
+
+        return {
+            'internal_council_id': record['OBJECTID'],
+            'name'               : record['POLLING_DISTRICT'],
+            'area'               : poly
+        }
+
+    def station_record_to_dict(self, record):
+        geojson = record.geom.geojson
+        location = GEOSGeometry(geojson, srid=self.get_srid())
+
+
+        # format address and postcode
+        address = str(record['Address'])
+        address_parts = address.split(', ')
+        postcode = address_parts[-1]
+
+        if postcode[:1] == 'E':
+            del(address_parts[-1])
+        else:
+            postcode = address_parts[-1][-8:]
+            address_parts[-1] = address_parts[-1][:-9]
+
+        address = "\n".join(address_parts)
+
+
+        return {
+            'internal_council_id': record['OBJECTID'],
+            'postcode':            postcode,
+            'address':             address,
+            'location':            location
+        }

--- a/polling_stations/apps/data_collection/management/commands/import_pembrokeshire.py
+++ b/polling_stations/apps/data_collection/management/commands/import_pembrokeshire.py
@@ -1,0 +1,71 @@
+"""
+Imports Pembrokeshire
+"""
+from lxml import etree
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+from data_collection.management.commands import BaseApiKmlKmlImporter
+
+class Command(BaseApiKmlKmlImporter):
+    """
+    Imports the Polling Station data from Pembrokeshire
+    """
+    srid             = 4326
+    districts_srid   = 4326
+    council_id       = 'W06000009'
+    districts_url    = 'http://www.pembrokeshire.gov.uk/geoserver/maps/live/wms?LAYERS=tblPollingDistrict&FORMAT=application/vnd.google-earth.kml+xml&TRANSPARENT=TRUE&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&SRS=EPSG%3A27700&BBOX=162666.9591241047,187007.85481671634,234800.000001,260094.71375428123&WIDTH=256&HEIGHT=256'
+    stations_url     = 'http://www.pembrokeshire.gov.uk/geoserver/maps/live/wms?LAYERS=tblPollingStation&FORMAT=application/vnd.google-earth.kml+xml&TRANSPARENT=TRUE&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&SRS=EPSG%3A27700&BBOX=162666.9591241047,187007.85481671634,234800.000001,260094.71375428123&WIDTH=256&HEIGHT=256'
+
+    def extract_info_from_district_description(self, description):
+        # lxml needs everything to be enclosed in one root element
+        html = etree.XML('<div>' + str(description).replace('&', '&amp;') + '</div>')
+        return {
+            'district_id':   html[1][0][1].text,
+            'district_code': html[1][1][1].text,
+            'name_en':       html[1][2][1].text,
+            'name_cy':       html[1][3][1].text,
+        }
+
+    def district_record_to_dict(self, record):
+        geojson = record.geom.geojson
+        geometry_collection = self.clean_poly(GEOSGeometry(geojson, srid=self.get_srid('districts')))
+
+        try:
+            poly = MultiPolygon(geometry_collection[-1])
+        except TypeError:
+            poly = geometry_collection[-1]
+
+        info = self.extract_info_from_district_description(record['description'])
+
+        return {
+            'internal_council_id': info['district_code'],
+            'name'               : "%s / %s" % (info['name_en'], info['name_cy']),
+            'extra_id'           : info['district_id'],
+            'area'               : poly
+        }
+
+
+    def extract_info_from_station_description(self, description):
+        # lxml needs everything to be enclosed in one root element
+        html = etree.XML('<div>' + str(description).replace('&', '&amp;') + '</div>')
+        data = {
+            'id':      html[1][0][1].text,
+            'name_en': html[1][1][1].text,
+            'name_cy': html[1][2][1].text,
+        }
+        return data
+
+    def station_record_to_dict(self, record):
+        geojson = record.geom.geojson
+        location = GEOSGeometry(geojson, srid=self.get_srid())
+        info = self.extract_info_from_station_description(record['description'])
+        internal_id = record['Name'].value.split(".")[1]
+
+        # address data is too poor to produce useful results using geocoding
+        postcode = ''
+
+        return {
+            'internal_council_id': internal_id,
+            'postcode':            postcode,
+            'address':             "%s / %s" % (info['name_en'], info['name_cy']),
+            'location':            location
+        }

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -95,12 +95,11 @@ class PostcodeView(TemplateView):
 
         stations = PollingStation.objects.filter(
             location__within=areas['polling_district'].area)
+
         if stations:
             return stations
 
-        return PollingStation.objects.filter(
-            location__within=areas['council'].area)
-
+        return []
 
 
     def get_context_data(self, **context):

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -96,7 +96,7 @@ class PostcodeView(TemplateView):
         stations = PollingStation.objects.filter(
             location__within=areas['polling_district'].area)
 
-        if stations:
+        if len(stations) == 1:
             return stations
 
         return []

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,7 @@ django-model-utils==2.3.1
 djangorestframework==3.2.3
 fastkml==0.11
 git+git://github.com/geomet/geomet.git
+lxml==3.5.0
 markdown==2.6.2
 Pillow==2.9.0
 psycopg2==2.6.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -2,5 +2,4 @@
 
 mock
 model-mommy
-lxml
 python-Levenshtein


### PR DESCRIPTION
Adds:
- base class we can use to import from councils serving up KML boundaries via an API
- import script for City of London
- import script for Pembrokeshire
- some front-end mods to help cope better with ambiguous data

As discussed on slack, this won't provide 100% coverage for Pembrokeshire but will return data in the majority of cases where there is a 1-to-1 mapping between district and station and throw "we don't know where you should vote" in other cases.

Closes #8
Closes #176
refs #175