### PR TITLE
More fixes to get_polling_station() logic

### DIFF
--- a/polling_stations/apps/data_collection/constants.py
+++ b/polling_stations/apps/data_collection/constants.py
@@ -8,3 +8,6 @@ COUNCIL_TYPES = [
     "LGD",
     "UTA",
 ]
+
+BASE_GOOGLE_URL = "https://maps.googleapis.com/maps/api/directions/json?mode=walking&units=imperial&origin="
+ORS_ROUTE_URL_TEMPLATE = "http://openls.geog.uni-heidelberg.de/route?start={},{}&end={},{}&via=&lang=en&distunit=MI&routepref=Pedestrian&weighting=Fastest&avoidAreas=&useTMC=false&noMotorways=false&noTollways=false&noUnpavedroads=false&noSteps=false&noFerries=false&instructions=false"

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -1,4 +1,10 @@
 import requests
+import re
+import lxml.etree
+from collections import namedtuple
+
+from django.utils.translation import ugettext as _
+from django.contrib.gis.geos import Point
 
 from data_collection import constants
 
@@ -13,3 +19,85 @@ def geocode(postcode):
         'wgs84_lon': res_json['wgs84_lon'],
         'wgs84_lat': res_json['wgs84_lat'],
     }
+
+
+Directions = namedtuple('Directions', ['walk_time', 'walk_dist', 'route'])
+
+
+class OrsDirectionsApiError(Exception):
+    pass
+
+
+re_time = re.compile("PT([0-9]+)M([0-9]+)S")
+
+def get_ors_route(longlat_from, longlat_to):
+    url = constants.ORS_ROUTE_URL_TEMPLATE.format(longlat_from.x, longlat_from.y, longlat_to.x, longlat_to.y)
+
+    resp = requests.get(url)
+    
+    root = lxml.etree.fromstring(resp.content)
+
+    ns = {
+        "xls": "http://www.opengis.net/xls",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "gml": "http://www.opengis.net/gml",
+    }
+
+    ps = [
+        [float(x) for x in pos.text.split()]
+        for pos in root.xpath('//xls:RouteGeometry/gml:LineString/gml:pos', namespaces=ns)
+    ]
+
+    walk_dist = "{} {}".format(
+        root.xpath('//xls:RouteSummary/xls:TotalDistance/@value', namespaces=ns)[0],
+        _('miles'),        
+    )
+    
+    time_text = root.xpath('//xls:RouteSummary/xls:TotalTime/text()', namespaces=ns)[0]
+    matches = re_time.match(
+        time_text,
+    )
+    if matches is not None:
+        walk_time = "{} {}".format(matches.group(1), _('minute'))
+    else:
+        walk_time = None
+
+    return Directions(walk_time, walk_dist, ps)
+
+
+class GoogleDirectionsApiError(Exception):
+    pass
+
+
+def get_google_route(postcode, end):
+    url = "{base_url}{postcode}&destination={destination}".format(
+            base_url=constants.BASE_GOOGLE_URL,
+            postcode=postcode,
+            destination="{0},{1}".format(end.y, end.x),
+        )
+
+    directions = requests.get(url).json()
+        
+    if directions['status'] != 'OK':
+        raise GoogleDirectionsApiError("Google Directions API error: {}".format(directions['status']))
+
+    start_points = [
+        Point(x['start_location']['lng'], x['start_location']['lat'])
+        for x in directions['routes'][0]['legs'][0]['steps']
+    ]
+
+    end_points = [
+        Point(x['end_location']['lng'], x['end_location']['lat'])
+        for x in directions['routes'][0]['legs'][0]['steps']
+    ]
+    
+    walk_time = str(
+        directions['routes'][0]['legs'][0]['duration']['text']
+    ).replace('mins', _('minute'))
+
+    walk_dist = str(
+        directions['routes'][0]['legs'][0]['distance']['text']
+    ).replace('mi', _('miles'))
+
+    return Directions(walk_time, walk_dist, start_points[:] + end_points[-1:])
+

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -8,6 +8,8 @@ from django.contrib.gis.geos import Point
 
 from data_collection import constants
 
+class PostcodeError(Exception):
+    pass
 
 def geocode(postcode):
     """
@@ -15,10 +17,14 @@ def geocode(postcode):
     """
     res = requests.get("%s/postcode/%s" % (constants.MAPIT_URL, postcode))
     res_json = res.json()
-    return {
-        'wgs84_lon': res_json['wgs84_lon'],
-        'wgs84_lat': res_json['wgs84_lat'],
-    }
+
+    if 'error' in res_json:
+        raise PostcodeError("Mapit error {}: {}".format(res_json['code'], res_json['error']))
+    else:
+        return {
+            'wgs84_lon': res_json['wgs84_lon'],
+            'wgs84_lat': res_json['wgs84_lat'],
+        }
 
 
 Directions = namedtuple('Directions', ['walk_time', 'walk_dist', 'route'])

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -21,12 +21,12 @@ from whitelabel.views import WhiteLabelTemplateOverrideMixin
 from .forms import PostcodeLookupForm, AddressSelectForm
 from .helpers import (
     geocode,
+    PostcodeError,
     get_ors_route,
     get_google_route,
     OrsDirectionsApiError,
     GoogleDirectionsApiError,
 )
-
 
 # sort a list of tuples by key in natural/human order
 def natural_sort(l, key):
@@ -139,7 +139,12 @@ class PostcodeView(BasePollingStationView):
         return directions 
 
     def get_context_data(self, **context):
-        l = geocode(self.kwargs['postcode'])
+        try:
+            l = geocode(self.kwargs['postcode'])
+        except PostcodeError as e:
+            context['error'] = e
+            return context
+
         context['location'] = Point(l['wgs84_lon'], l['wgs84_lat'])
 
         context['council'] = Council.objects.get(

--- a/polling_stations/apps/nus_wales/templates/nus_wales/base.html
+++ b/polling_stations/apps/nus_wales/templates/nus_wales/base.html
@@ -20,12 +20,12 @@
     <footer class="footer">
       <div class="row">
         <div class="columns large-12">
-          <img src="{% static 'images/nus_logo.jpg' %}" width=200>
+          <img src="{% static 'images/nus_logo.jpg' %}" width=200 alt="NUS logo">
           <a href="https://democracyclub.org.uk">
           {% if LANGUAGE_CODE == 'cy-gb' %}
-          <img src="{% static 'images/logo-cy.png' %}" width=200>
+          <img src="{% static 'images/logo-cy.png' %}" width=200 alt="Clwb Democratiaeth">
           {% else %}
-          <img src="{% static 'images/logo-with-text.png' %}" width=200>
+          <img src="{% static 'images/logo-with-text.png' %}" width=200 alt="Democracy Club">
           {% endif %}</a>
         </div>
       </div>

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -9,26 +9,6 @@ from django.contrib.gis.db import models
 from councils.models import Council
 
 
-class PollingStation(models.Model):
-    council             = models.ForeignKey(Council, null=True)
-    internal_council_id = models.CharField(blank=True, max_length=100)
-    postcode            = models.CharField(blank=True, null=True, max_length=100)
-    address             = models.TextField(blank=True, null=True)
-    location            = models.PointField(null=True, blank=True)
-    # This is NOT a FK, as we might not have the polling district at
-    # the point of import
-    polling_district_id  = models.CharField(blank=True, max_length=255)
-
-    objects = models.GeoManager()
-
-    def __str__(self):
-        return "{0} ({1})".format(self.internal_council_id, self.council)
-
-    @property
-    def formatted_address(self):
-        return "\n".join([x[0] for x in groupby(self.address.split(','))])
-
-
 class PollingDistrict(models.Model):
     name                = models.CharField(blank=True, null=True, max_length=255)
     council             = models.ForeignKey(Council, null=True)
@@ -44,6 +24,69 @@ class PollingDistrict(models.Model):
     def __unicode__(self):
         name = self.name or "Unnamed"
         return "%s (%s)" % (name, self.council)
+
+
+class PollingStationManager(models.GeoManager):
+    def get_polling_station(self, location, council_id):
+        try:
+            polling_district = PollingDistrict.objects.get(
+                area__covers=location)
+        except PollingDistrict.DoesNotExist:
+            return None
+
+        if polling_district.internal_council_id:
+            # always attempt to look up district id in stations table
+            station = self.filter(
+                polling_district_id=polling_district.internal_council_id,
+                council_id=council_id
+            )
+            if len(station) == 1:
+                return station[0]
+
+        if polling_district.polling_station_id:
+            # only try to look up station id if it is a sensible value
+            station = self.filter(
+                internal_council_id=polling_district.polling_station_id,
+                council_id=council_id
+            )
+            if len(station) == 1:
+                return station[0]
+            else:
+                # if polling_station_id is set and we don't get a station back
+                # or it maps to more than one station due to dodgy data
+                # do not fall back and attempt point within polygon lookup
+                return None
+        else:
+            # only try a point within polygon lookup
+            # if polling_station_id is not set
+            station = self.filter(
+                location__within=polling_district.area)
+            if len(station) == 1:
+                return station[0]
+            else:
+                # make this explicit rather than implied
+                return None
+
+
+class PollingStation(models.Model):
+    council             = models.ForeignKey(Council, null=True)
+    internal_council_id = models.CharField(blank=True, max_length=100)
+    postcode            = models.CharField(blank=True, null=True, max_length=100)
+    address             = models.TextField(blank=True, null=True)
+    location            = models.PointField(null=True, blank=True)
+    # This is NOT a FK, as we might not have the polling district at
+    # the point of import
+    polling_district_id  = models.CharField(blank=True, max_length=255)
+
+    objects = PollingStationManager()
+
+    def __str__(self):
+        return "{0} ({1})".format(self.internal_council_id, self.council)
+
+    @property
+    def formatted_address(self):
+        return "\n".join([x[0] for x in groupby(self.address.split(','))])
+
 
 class ResidentialAddress(models.Model):
     address            = models.TextField(blank=True, null=True)

--- a/polling_stations/templates/base.html
+++ b/polling_stations/templates/base.html
@@ -9,7 +9,7 @@
 
 {% block ga_tracking_code %}
 {% if not debug %}
-<script>
+<script type="text/javascript">
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/polling_stations/templates/base_embed.html
+++ b/polling_stations/templates/base_embed.html
@@ -11,7 +11,7 @@
           <p>
             Built by
             <a href="http://democracyclub.org.uk">
-              <img src="{% static 'images/logo-with-text.png' %}" class="dc-logo">
+              <img src="{% static 'images/logo-with-text.png' %}" class="dc-logo" alt="Democracy Club logo">
             </a>
           </p>
       </div>

--- a/polling_stations/templates/coverage.html
+++ b/polling_stations/templates/coverage.html
@@ -3,14 +3,14 @@
   <div class="page-header">
     <h1>Polling Station Coverage</h1>
   </div>
-  <main>
+  <div>
     <h2>
       {{ num_district_councils }} / {{ num_councils }} ({{ perc_districts }}) with Polling Districts
     </h2>
     <h2>
       {{ num_station_councils }} / {{ num_councils }} ({{ perc_stations }}) with Polling Stations
     </h2>
-  </main>
+  </div>
 {% endblock %}
 
 

--- a/polling_stations/templates/data_collection/dataquality_list.html
+++ b/polling_stations/templates/data_collection/dataquality_list.html
@@ -3,6 +3,7 @@
 {% block content %}
 <table class="table table-striped">
     <thead>
+      <tr>
         <th>Rating</th>
         <th>ID</th>
         <th>Council</th>
@@ -12,6 +13,7 @@
         {% if request.user.is_staff %}
         <th>Edit</th>
         {% endif %}
+      </tr>
     </thead>
     <tbody>
     {% for council in object_list %}

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -17,7 +17,9 @@
       <label class="card_header">{% trans "Enter Your Postcode" %}
         <input id="id_postcode" name="postcode" type="text" aria-describedby="postcode_help_text" autofocus >
       </label>
-      <p class="help-text" id="postcode_help_text">{% trans 'e.g. <a href="postcode/CF105AJ/">CF10 5AJ</a>' %}</p>
+      <p class="help-text" id="postcode_help_text">
+        {% trans 'e.g.' %} <a href="{% url 'postcode_view' postcode="CF105AJ" %}">CF10 5AJ</a>
+      </p>
       <button type="submit" class="button" id="submit-postcode">{% trans "Find your Polling Station" %}</button>
     </form>
   </div>

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -128,9 +128,12 @@
       // map.doubleClickZoom.disable();
       map.scrollWheelZoom.disable();
 
-      L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
-      }).addTo(map);
+      L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}', {
+        type: 'map',
+        ext: 'jpg',
+        attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        subdomains: '1234'
+      }).addTo(map); 
 
       window.map = map;
       window.polling_station_location = polling_station_location;

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -24,13 +24,27 @@
 
 {% block base_title %}{% trans "Your Polling Station" %}{% endblock base_title %}
 
-
 {% block content %}
-{{ route }}
-
 <div class="row">
   <div class="columns large-8">
     <div class="card">
+    {% if error %}
+
+      <h2>Sorry, we can't find {{ postcode }}</h2>
+      <p>This doesn't appear to be a valid postcode.</p>
+      <form method="post" action="{% url 'home' %}" class="form form-inline">
+          {% csrf_token %}
+          <label class="card_header">{% trans "Enter Your Postcode" %}
+            <input id="id_postcode" name="postcode" type="text" aria-describedby="postcode_help_text" autofocus >
+          </label>
+          <p class="help-text" id="postcode_help_text">
+            {% trans 'e.g.' %} <a href="{% url 'postcode_view' postcode="CF105AJ" %}">CF10 5AJ</a>
+          </p>
+          <button type="submit" class="button" id="submit-postcode">{% trans "Find your Polling Station" %}</button>
+      </form>
+
+    {% else %}
+
       <h2>
         {% if we_know_where_you_should_vote %}
           {% trans "Your polling station" %}
@@ -72,6 +86,8 @@
       {% if we_know_where_you_should_vote %}
       <div id="area_map" class="card_inset"></div>
       {% endif %}
+
+    {% endif %}
     </div>
   </div>
 

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -78,8 +78,10 @@
         {% endif %}
       {% else %}
         {% blocktrans with council.phone as council_phone %}
-        <p>We don't have data for your area, so you need to contact the council.</p>
-        <p>You can call them on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
+        <p>We don't have data for your area.</p>
+        
+        <p>It may be listed on your polling card, which is delivered by post before an election.</p>
+        <p>Or, you need to contact the council. You can call them on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
         {% endblocktrans %}
       {% endif %}
 

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -26,6 +26,7 @@
 
 
 {% block content %}
+{{ route }}
 
 <div class="row">
   <div class="columns large-8">
@@ -50,10 +51,10 @@
             {% endif %}
           </address>
         </div>
-        {% if directions.routes.0.legs.0.duration.text %}
+        {% if directions.walk_time %}
         <div id="directions">
           <p>
-            {% blocktrans with walk_time as walk_time and walk_dist as walk_dist %}
+            {% blocktrans with directions.walk_time as walk_time and directions.walk_dist as walk_dist %}
               It's about {{ walk_dist }} away or a {{ walk_time }} walk from {{ postcode }}.
             {% endblocktrans %}</p>
           <a href="https://www.google.com/maps/dir/{{postcode}}/{{ station.location.y }},{{ station.location.x }}">
@@ -135,12 +136,30 @@
         subdomains: '1234'
       }).addTo(map); 
 
+      {% if directions.route %}
+      var pointList = [
+      {% for p in directions.route %}
+          new L.LatLng({{p.1}}, {{p.0}}){% if not loop.last %},{% endif %}
+      {% endfor %}
+      ];
+
+      var firstpolyline = new L.Polyline(pointList, {
+        color: 'red',
+        weight: 3,
+        opacity: 1.0,
+        smoothFactor: 1,
+        dashArray: "5, 5"
+      });
+      firstpolyline.addTo(map);
+      {% endif %}
+
       window.map = map;
       window.polling_station_location = polling_station_location;
 
       L.marker([{{ station.location.1 }}, {{ station.location.0 }}], {
-      'clickable': true,
+        'clickable': true,
       }).addTo(map);
+
       map.setView([{{ station.location.1 }}, {{ station.location.0 }}],15);
     };
 

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -5,6 +5,21 @@
 
 {% block extra_page_css %}
 <link rel="stylesheet" href="{% static "css/map.css" %}" />
+<style>
+  .council_location_icon {
+    background-color:black;
+    border-radius: 50%;
+    height:2px;
+    width:2px;
+  }
+  address {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    font-size: inherit;
+    line-height: 1.6;
+    text-rendering: optimizeLegibility;
+  }
+</style>
 {% endblock extra_page_css %}
 
 {% block base_title %}{% trans "Your Polling Station" %}{% endblock base_title %}
@@ -25,16 +40,16 @@
 
       {% if we_know_where_you_should_vote %}
       {% blocktrans %}The polling station for <strong>{{ postcode }}</strong> is:{% endblocktrans %}
-        <p>
+        <div>
           <address>
-            {{ station.formatted_address|linebreaksbr }}<br>
+            {{ station.formatted_address|linebreaksbr }}<br />
             {% if station.postcode %}
               {% if not station.postcode in station.address %}
                 {{ station.postcode }}
               {% endif %}
             {% endif %}
           </address>
-        </p>
+        </div>
         {% if directions.routes.0.legs.0.duration.text %}
         <div id="directions">
           <p>
@@ -100,15 +115,7 @@
 {% endblock content %}
 
 {% block in_page_javascript %}
-  <style>
-    .council_location_icon {
-    background-color:black;
-    border-radius: 50%;
-    height:2px;
-    width:2px;
-    }
-  </style>
-  <script>
+  <script type="text/javascript">
 
     // Maps
     window.create_area_map = function(point) {
@@ -132,7 +139,7 @@
       'clickable': true,
       }).addTo(map);
       map.setView([{{ station.location.1 }}, {{ station.location.0 }}],15);
-    }
+    };
 
     var point = [{{ location.1 }}, {{ location.0 }}];
 
@@ -156,6 +163,5 @@
             }
           }
         );
-    </script>
-<script src=""></script>
+</script>
 {% endblock extra_javascript %}

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -176,7 +176,11 @@
         'clickable': true,
       }).addTo(map);
 
+      {% if directions.route %}
+      map.fitBounds(firstpolyline.getBounds(), {maxZoom: 16});
+      {% else %}
       map.setView([{{ station.location.1 }}, {{ station.location.0 }}],15);
+      {% endif %}
     };
 
     var point = [{{ location.1 }}, {{ location.0 }}];


### PR DESCRIPTION
Polling Station IDs and Polling District IDs are only unique within councils - they're not unique on a national basis so I've constrained the lookups by id within the relevant local authority boundary.
This does not actually cause a bug right now, but it will probably save someone a headache in future when we inevitably encounter a collision.