### PR TITLE
Add postcode-not-found response, issue #103

### DIFF
--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -8,6 +8,8 @@ from django.contrib.gis.geos import Point
 
 from data_collection import constants
 
+class PostcodeError(Exception):
+    pass
 
 def geocode(postcode):
     """
@@ -15,10 +17,14 @@ def geocode(postcode):
     """
     res = requests.get("%s/postcode/%s" % (constants.MAPIT_URL, postcode))
     res_json = res.json()
-    return {
-        'wgs84_lon': res_json['wgs84_lon'],
-        'wgs84_lat': res_json['wgs84_lat'],
-    }
+
+    if 'error' in res_json:
+        raise PostcodeError("Mapit error {}: {}".format(res_json['code'], res_json['error']))
+    else:
+        return {
+            'wgs84_lon': res_json['wgs84_lon'],
+            'wgs84_lat': res_json['wgs84_lat'],
+        }
 
 
 Directions = namedtuple('Directions', ['walk_time', 'walk_dist', 'route'])

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -21,12 +21,12 @@ from whitelabel.views import WhiteLabelTemplateOverrideMixin
 from .forms import PostcodeLookupForm, AddressSelectForm
 from .helpers import (
     geocode,
+    PostcodeError,
     get_ors_route,
     get_google_route,
     OrsDirectionsApiError,
     GoogleDirectionsApiError,
 )
-
 
 # sort a list of tuples by key in natural/human order
 def natural_sort(l, key):
@@ -139,7 +139,12 @@ class PostcodeView(BasePollingStationView):
         return directions 
 
     def get_context_data(self, **context):
-        l = geocode(self.kwargs['postcode'])
+        try:
+            l = geocode(self.kwargs['postcode'])
+        except PostcodeError as e:
+            context['error'] = e
+            return context
+
         context['location'] = Point(l['wgs84_lon'], l['wgs84_lat'])
 
         context['council'] = Council.objects.get(

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -17,7 +17,9 @@
       <label class="card_header">{% trans "Enter Your Postcode" %}
         <input id="id_postcode" name="postcode" type="text" aria-describedby="postcode_help_text" autofocus >
       </label>
-      <p class="help-text" id="postcode_help_text">{% trans 'e.g. <a href="/postcode/CF105AJ/">CF10 5AJ</a>' %}</p>
+      <p class="help-text" id="postcode_help_text">
+        {% trans 'e.g.' %} <a href="{% url 'postcode_view' postcode="CF105AJ" %}">CF10 5AJ</a>
+      </p>
       <button type="submit" class="button" id="submit-postcode">{% trans "Find your Polling Station" %}</button>
     </form>
   </div>

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -17,7 +17,7 @@
       <label class="card_header">{% trans "Enter Your Postcode" %}
         <input id="id_postcode" name="postcode" type="text" aria-describedby="postcode_help_text" autofocus >
       </label>
-      <p class="help-text" id="postcode_help_text">{% trans 'e.g. <a href="postcode/CF105AJ/">CF10 5AJ</a>' %}</p>
+      <p class="help-text" id="postcode_help_text">{% trans 'e.g. <a href="/postcode/CF105AJ/">CF10 5AJ</a>' %}</p>
       <button type="submit" class="button" id="submit-postcode">{% trans "Find your Polling Station" %}</button>
     </form>
   </div>

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -32,12 +32,14 @@
 
       <h2>Sorry, we can't find {{ postcode }}</h2>
       <p>This doesn't appear to be a valid postcode.</p>
-      <form method="post" action="/" class="form form-inline">
+      <form method="post" action="{% url 'home' %}" class="form form-inline">
           {% csrf_token %}
           <label class="card_header">{% trans "Enter Your Postcode" %}
             <input id="id_postcode" name="postcode" type="text" aria-describedby="postcode_help_text" autofocus >
           </label>
-          <p class="help-text" id="postcode_help_text">{% trans 'e.g. <a href="/postcode/CF105AJ/">CF10 5AJ</a>' %}</p>
+          <p class="help-text" id="postcode_help_text">
+            {% trans 'e.g.' %} <a href="{% url 'postcode_view' postcode="CF105AJ" %}">CF10 5AJ</a>
+          </p>
           <button type="submit" class="button" id="submit-postcode">{% trans "Find your Polling Station" %}</button>
       </form>
 

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -24,13 +24,25 @@
 
 {% block base_title %}{% trans "Your Polling Station" %}{% endblock base_title %}
 
-
 {% block content %}
-{{ route }}
-
 <div class="row">
   <div class="columns large-8">
     <div class="card">
+    {% if error %}
+
+      <h2>Sorry, we can't find {{ postcode }}</h2>
+      <p>This doesn't appear to be a valid postcode.</p>
+      <form method="post" action="/" class="form form-inline">
+          {% csrf_token %}
+          <label class="card_header">{% trans "Enter Your Postcode" %}
+            <input id="id_postcode" name="postcode" type="text" aria-describedby="postcode_help_text" autofocus >
+          </label>
+          <p class="help-text" id="postcode_help_text">{% trans 'e.g. <a href="/postcode/CF105AJ/">CF10 5AJ</a>' %}</p>
+          <button type="submit" class="button" id="submit-postcode">{% trans "Find your Polling Station" %}</button>
+      </form>
+
+    {% else %}
+
       <h2>
         {% if we_know_where_you_should_vote %}
           {% trans "Your polling station" %}
@@ -72,6 +84,8 @@
       {% if we_know_where_you_should_vote %}
       <div id="area_map" class="card_inset"></div>
       {% endif %}
+
+    {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
This is a fairly hacky fix for #103. Currently you get an error if you put in something that looks like a postcode but actually isn't. This adds an exception and a branch in the template.

It should probably do the checking in the form validation code, but currently that'd invoke two postcode lookups, requiring caching. This'll do for a fairly rare error.

![image](https://cloud.githubusercontent.com/assets/103349/13923151/4d508cb4-ef77-11e5-9630-738978ee2595.png)
