### PR TITLE
Change to MapQuest tiles

### DIFF
--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -121,9 +121,12 @@
       // map.doubleClickZoom.disable();
       map.scrollWheelZoom.disable();
 
-      L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
-      }).addTo(map);
+      L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}', {
+        type: 'map',
+        ext: 'jpg',
+        attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        subdomains: '1234'
+      }).addTo(map); 
 
       window.map = map;
       window.polling_station_location = polling_station_location;


### PR DESCRIPTION
I think the MapQuest style tiles are less confusing, but this could be controversial. User testing required.

Before:

![image](https://cloud.githubusercontent.com/assets/103349/13928786/0bd5fe32-ef8f-11e5-97e2-b16421c188d6.png)

After:

![image](https://cloud.githubusercontent.com/assets/103349/13928798/14630586-ef8f-11e5-864f-53ab7d060a83.png)

You could also worry about their usage/SLA: http://wiki.openstreetmap.org/wiki/MapQuest#MapQuest-hosted_map_tiles