### PR TITLE
Zoom initial view to bounding box of route

### DIFF
--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -176,7 +176,11 @@
         'clickable': true,
       }).addTo(map);
 
+      {% if directions.route %}
+      map.fitBounds(firstpolyline.getBounds(), {maxZoom: 16});
+      {% else %}
       map.setView([{{ station.location.1 }}, {{ station.location.0 }}],15);
+      {% endif %}
     };
 
     var point = [{{ location.1 }}, {{ location.0 }}];


### PR DESCRIPTION
Initial view now zooms to bounding box of a given route, with the maximum zoom of 16 - so it doesn't get too close in and lose context.

![image](https://cloud.githubusercontent.com/assets/103349/13962802/8ae54630-f05a-11e5-9969-d465a11fe28d.png)