### PR TITLE
Issue 216 fixes - part 2

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_boston.py
+++ b/polling_stations/apps/data_collection/management/commands/import_boston.py
@@ -16,7 +16,7 @@ class Command(BaseShpImporter):
     def district_record_to_dict(self, record):
         return {
             'internal_council_id': record[0],
-            'name': record[1],
+            'name': "%s - %s" % (record[1], record[0]),
             'polling_station_id': record[0]
         }
 

--- a/polling_stations/apps/data_collection/management/commands/import_boston.py
+++ b/polling_stations/apps/data_collection/management/commands/import_boston.py
@@ -24,10 +24,14 @@ class Command(BaseShpImporter):
             location = Point(int(record.easting), int(record.northing), srid=self.srid)
         except ValueError:
             location = Point(float(record.easting), float(record.northing), srid=self.srid)
+
+        address_parts = [x.strip() for x in record.address.split(',')]
+        address = "\n".join(address_parts[:-1])
+        postcode = address_parts[-1]
+
         return {
             'internal_council_id': record.internal_id,
-            'postcode'           : record.address.split(',')[-1],
-            'address'            : "\n".join(record.address.split(',')[:-1]),
+            'postcode'           : postcode,
+            'address'            : address,
             'location'           : location
         }
-    

--- a/polling_stations/apps/data_collection/management/commands/import_boston.py
+++ b/polling_stations/apps/data_collection/management/commands/import_boston.py
@@ -1,9 +1,9 @@
 """
 Import Boston
 """
+import os
 from django.contrib.gis.geos import Point
-
-from data_collection.management.commands import BaseShpImporter
+from data_collection.management.commands import BaseShpImporter, CsvHelper
 
 class Command(BaseShpImporter):
     """
@@ -17,9 +17,24 @@ class Command(BaseShpImporter):
         return {
             'internal_council_id': record[0],
             'name': record[1],
+            'polling_station_id': record[0]
         }
 
-    def station_record_to_dict(self, record):
+    # station_record_to_dicts() returns an array of dicts in this script
+    def import_polling_stations(self):
+        stations_file = os.path.join(self.base_folder_path, self.stations_name)
+
+        helper = CsvHelper(stations_file, self.csv_encoding)
+        data = helper.parseCsv()
+        for row in data:
+            stations = self.station_record_to_dicts(row)
+            for station in stations:
+                if 'council' not in station:
+                    station['council'] = self.council
+
+                self.add_polling_station(station)
+
+    def station_record_to_dicts(self, record):
         try:
             location = Point(int(record.easting), int(record.northing), srid=self.srid)
         except ValueError:
@@ -29,9 +44,26 @@ class Command(BaseShpImporter):
         address = "\n".join(address_parts[:-1])
         postcode = address_parts[-1]
 
-        return {
-            'internal_council_id': record.internal_id,
-            'postcode'           : postcode,
-            'address'            : address,
-            'location'           : location
-        }
+        """
+        In this data, sometimes a single polling station serves several
+        districts. For simplicity, if record.internal_id is something like "AB,AC" 
+        return the same polling station address/point multiple times with different IDs
+        """
+        internal_ids = record.internal_id.split(",")
+        if (len(internal_ids) == 1):
+            return [{
+                'internal_council_id': record.internal_id,
+                'postcode'           : postcode,
+                'address'            : address,
+                'location'           : location
+            }]
+        else:
+            stations = []
+            for id in internal_ids:
+                stations.append({
+                    'internal_council_id': id,
+                    'postcode'           : postcode,
+                    'address'            : address,
+                    'location'           : location
+                })
+            return stations

--- a/polling_stations/apps/data_collection/management/commands/import_islington.py
+++ b/polling_stations/apps/data_collection/management/commands/import_islington.py
@@ -16,8 +16,9 @@ class Command(BaseShpImporter):
     def district_record_to_dict(self, record):
         return {
             'council': self.council,
-            'internal_council_id': record[7],
+            'internal_council_id': record[3],
             'name': record[0],
+            'polling_station_id': record[3]
         }
 
     def station_record_to_dict(self, record):
@@ -27,10 +28,11 @@ class Command(BaseShpImporter):
             location = Point(float(record.easting), float(record.northing), srid=self.srid)
         return {
             'council': self.council,
-            'internal_council_id': record.u_polldid,
+            'internal_council_id': record.rec_pd,
             'postcode': record.postcode,
             'address': "\n".join([record.stat_title, record.stat_addr1]),
-            'location': location
+            'location': location,
+            'polling_district_id': record.rec_pd
         }
     
     def import_polling_stations(self):

--- a/polling_stations/apps/data_collection/management/commands/import_lambeth.py
+++ b/polling_stations/apps/data_collection/management/commands/import_lambeth.py
@@ -19,7 +19,7 @@ class Command(BaseJasonImporter):
             council=self.council,
             internal_council_id=properties['DISTRICT_C'],
             extra_id=properties['OBJECTID'],
-            name=properties['WARD'],
+            name="%s - %s" % (properties['WARD'], properties['DISTRICT_C']),
             polling_station_id=properties['DISTRICT_C']
         )
 

--- a/polling_stations/apps/data_collection/management/commands/import_lambeth.py
+++ b/polling_stations/apps/data_collection/management/commands/import_lambeth.py
@@ -17,8 +17,10 @@ class Command(BaseJasonImporter):
         properties = record['properties']
         return dict(
             council=self.council,
-            internal_council_id=properties['OBJECTID'],
+            internal_council_id=properties['DISTRICT_C'],
+            extra_id=properties['OBJECTID'],
             name=properties['WARD'],
+            polling_station_id=properties['DISTRICT_C']
         )
 
     def station_record_to_dict(self, record):
@@ -28,5 +30,6 @@ class Command(BaseJasonImporter):
             internal_council_id=record.district_code,
             postcode=record.postcode,
             address="\n".join([record.venue, record.address]),
-            location=location
+            location=location,
+            polling_district_id=record.district_code
         )

--- a/polling_stations/apps/data_collection/management/commands/import_reading.py
+++ b/polling_stations/apps/data_collection/management/commands/import_reading.py
@@ -16,14 +16,14 @@ class Command(BaseShpShpImporter):
     def district_record_to_dict(self, record):
         return {
             'internal_council_id': record[0],
-            'name': record[1],
+            'name': "%s - %s" % (record[1], record[0]),
         }
 
     def station_record_to_dict(self, record):
+        district_id = record[3].split(" ")[-1].strip()
         return {
             'internal_council_id': record[0],
             'postcode'           : record[-1],
             'address'            : "\n".join(record[2:-1]),
+            'polling_district_id': district_id
         }
-    
- 

--- a/polling_stations/apps/data_collection/management/commands/import_salford.py
+++ b/polling_stations/apps/data_collection/management/commands/import_salford.py
@@ -25,11 +25,17 @@ class Command(BaseShpImporter):
             location = Point(int(record.easting), int(record.northing), srid=self.srid)
         except ValueError:
             location = Point(float(record.easting), float(record.northing), srid=self.srid)
+
+        address_parts = [x.strip() for x in record.location.split(' ')]
+        postcode = "%s %s" % (address_parts[-2], address_parts[-1])
+        del(address_parts[-1])
+        del(address_parts[-1])
+        address = " ".join(address_parts)
+
         return {
             'internal_council_id': record.id,
-            'postcode'           : record.location.split(',')[-1],
-            'address'            : "\n".join(record.location.split(',')[:-1]),
+            'postcode'           : postcode,
+            'address'            : address,
             'location'           : location,
             'polling_district_id': record.polling_district_code
         }
-    

--- a/polling_stations/apps/data_collection/management/commands/import_salford.py
+++ b/polling_stations/apps/data_collection/management/commands/import_salford.py
@@ -29,6 +29,7 @@ class Command(BaseShpImporter):
             'internal_council_id': record.id,
             'postcode'           : record.location.split(',')[-1],
             'address'            : "\n".join(record.location.split(',')[:-1]),
-            'location'           : location
+            'location'           : location,
+            'polling_district_id': record.polling_district_code
         }
     

--- a/polling_stations/apps/data_collection/management/commands/import_south_cambridge.py
+++ b/polling_stations/apps/data_collection/management/commands/import_south_cambridge.py
@@ -23,7 +23,7 @@ class Command(BaseShpShpImporter):
     def station_record_to_dict(self, record):
         return {
             'internal_council_id': record[0],
-            'postcode'           : self.postcode_from_address(record[0]),
+            'postcode'           : self.postcode_from_address(record[0]).strip(),
             'address'            : self.string_to_newline_addr(record[0])
         }
     

--- a/polling_stations/apps/data_collection/management/commands/import_tower_hamlets.py
+++ b/polling_stations/apps/data_collection/management/commands/import_tower_hamlets.py
@@ -22,10 +22,20 @@ class Command(BaseShpShpImporter):
         }
 
     def station_record_to_dict(self, record):
+
+        address_parts = [x.strip() for x in record[5].split(',')]
+        address = "\n".join(address_parts[:-1])
+        postcode = address_parts[-1]
+        if postcode == 'Blackwall Way':
+            address = "%s\n%s" % (address, postcode)
+            postcode = ''
+        if postcode[:6] == 'London':
+            address = "%s\n%s" % (address, 'London')
+            postcode = "%s %s" % (postcode.split(' ')[-2], postcode.split(' ')[-1])
+
         return {
             'internal_council_id': record[3],
-            'postcode'           : self.postcode_from_address(record[-1]),
-            'address'            : "\n".join(record[-1].split(',')[:-1]),
+            'postcode'           : postcode,
+            'address'            : address,
             'polling_district_id': record[3]
         }
-    

--- a/polling_stations/apps/data_collection/management/commands/import_tower_hamlets.py
+++ b/polling_stations/apps/data_collection/management/commands/import_tower_hamlets.py
@@ -15,14 +15,17 @@ class Command(BaseShpShpImporter):
 
     def district_record_to_dict(self, record):
         return {
-            'internal_council_id': record[0],
+            'internal_council_id': record[3],
             'name': record[4],
+            'extra_id': record[0],
+            'polling_station_id': record[3]
         }
 
     def station_record_to_dict(self, record):
         return {
-            'internal_council_id': record[0],
+            'internal_council_id': record[3],
             'postcode'           : self.postcode_from_address(record[-1]),
-            'address'            : "\n".join(record[-1].split(',')[:-1])
+            'address'            : "\n".join(record[-1].split(',')[:-1]),
+            'polling_district_id': record[3]
         }
     


### PR DESCRIPTION
This chunk is enough for one PR.

* Boston is the substantial change - it now handles stations serving multiple districts correctly.
* South Cambridgeshire is another ropey one like Pembrokeshire. There are less polling stations than districts but no IDs to link them, so we'll end up providing less than 100% coverage, but it is as good as it can be given the data provided.
* Tower Hamlets, Islington, Lambeth, Salford and Reading are efficiency/formatting improvements only.

Refs #216