### PR TITLE
Use slugs instead of ids for /address endpoint

### DIFF
--- a/polling_stations/apps/data_finder/fixtures/test_routing.json
+++ b/polling_stations/apps/data_finder/fixtures/test_routing.json
@@ -20,7 +20,8 @@
             "address": "1 Foo Street, Bar Town",
             "postcode": "AA11AA",
             "polling_station_id": "1",
-            "council": "X01000001"
+            "council": "X01000001",
+            "slug": "1"
         },
         "model": "pollingstations.residentialaddress",
         "pk": 1
@@ -30,7 +31,8 @@
             "address": "2 Foo Street, Bar Town",
             "postcode": "AA11AA",
             "polling_station_id": "1",
-            "council": "X01000001"
+            "council": "X01000001",
+            "slug": "2"
         },
         "model": "pollingstations.residentialaddress",
         "pk": 2
@@ -40,7 +42,8 @@
             "address": "1 Baz Street, Bar Town",
             "postcode": "BB11BB",
             "polling_station_id": "3",
-            "council": "X01000001"
+            "council": "X01000001",
+            "slug": "3"
         },
         "model": "pollingstations.residentialaddress",
         "pk": 3
@@ -50,7 +53,8 @@
             "address": "2 Baz Street, Bar Town",
             "postcode": "BB11BB",
             "polling_station_id": "4",
-            "council": "X01000001"
+            "council": "X01000001",
+            "slug": "4"
         },
         "model": "pollingstations.residentialaddress",
         "pk": 4

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -197,7 +197,7 @@ class RoutingHelper():
             # map to one polling station
             return self.Endpoint(
                 'address_view',
-                {'address_id': self.addresses[0].id}
+                {'address_slug': self.addresses[0].slug}
             )
         if self.route_type == "multiple_addresses":
             # addresses in this postcode map to

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -147,7 +147,7 @@ class AddressView(BasePollingStationView):
     def get(self, request, *args, **kwargs):
         self.address = get_object_or_404(
             ResidentialAddress,
-            pk=self.kwargs['address_id']
+            slug=self.kwargs['address_slug']
         )
         self.postcode = self.address.postcode
         context = self.get_context_data(**kwargs)
@@ -179,7 +179,7 @@ class AddressFormView(FormView):
             postcode=self.kwargs['postcode']
         )
 
-        select_addresses = [(element.id, element.address) for element in addresses]
+        select_addresses = [(element.slug, element.address) for element in addresses]
         select_addresses = natural_sort(select_addresses, itemgetter(1))
 
         if not addresses:
@@ -190,7 +190,7 @@ class AddressFormView(FormView):
     def form_valid(self, form):
         self.success_url = reverse(
             'address_view',
-            kwargs={'address_id': form.cleaned_data['address']}
+            kwargs={'address_slug': form.cleaned_data['address']}
         )
         return super(AddressFormView, self).form_valid(form)
 

--- a/polling_stations/apps/pollingstations/migrations/0006_residentialaddress_slug.py
+++ b/polling_stations/apps/pollingstations/migrations/0006_residentialaddress_slug.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pollingstations', '0005_pollingstation_polling_district_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='residentialaddress',
+            name='slug',
+            field=models.SlugField(max_length=255, default=datetime.datetime(2016, 4, 1, 21, 41, 16, 842753, tzinfo=utc), unique=True),
+            preserve_default=False,
+        ),
+    ]

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -100,3 +100,4 @@ class ResidentialAddress(models.Model):
     postcode           = models.CharField(blank=True, null=True, max_length=100, db_index=True)
     council            = models.ForeignKey(Council, null=True)
     polling_station_id = models.CharField(blank=True, max_length=100)
+    slug               = models.SlugField(blank=False, null=False, db_index=True, unique=True, max_length=255)

--- a/polling_stations/urls.py
+++ b/polling_stations/urls.py
@@ -26,7 +26,7 @@ core_patterns = patterns(
     url(r'^council/(?P<pk>.+)/$', CouncilView.as_view(), name='council'),
     url(r'^postcode/(?P<postcode>.+)/$',
         PostcodeView.as_view(), name='postcode_view'),
-    url(r'^address/(?P<address_id>.+)/$',
+    url(r'^address/(?P<address_slug>.+)/$',
         AddressView.as_view(), name='address_view'),
     url(r'^address_select/(?P<postcode>.+)/$',
         AddressFormView.as_view(), name='address_select_view'),


### PR DESCRIPTION
Because slug is `UNIQUE` and `NOT NULL`, you won't be able to apply the migration with data already in the DB, so you'll need to clear the ResidentialAddress table, apply the migration and re-run `import_denbighshire` and `import_rct`.

Closes #194