### PR TITLE
Import script for Camden

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/__init__.py
+++ b/polling_stations/apps/data_collection/management/commands/__init__.py
@@ -283,7 +283,7 @@ class BaseKamlImporter(BaseImporter):
             tmp.close()
 
 
-class BaseApiKmlKmlImporter(BaseKamlImporter):
+class BaseGenericApiImporter:
     srid             = 4326
     districts_srid   = 4326
     districts_url    = None
@@ -319,14 +319,27 @@ class BaseApiKmlKmlImporter(BaseKamlImporter):
     def import_polling_districts(self):
         with tempfile.NamedTemporaryFile() as tmp:
             req = urllib.request.urlretrieve(self.districts_url, tmp.name)
-            self.add_kml_district(tmp.name)
+            self.add_districts(tmp.name)
         return
 
     def import_polling_stations(self):
         with tempfile.NamedTemporaryFile() as tmp:
             req = urllib.request.urlretrieve(self.stations_url, tmp.name)
-            self.add_kml_station(tmp.name)
+            self.add_stations(tmp.name)
         return
+
+    def add_districts(self, filename):
+        raise NotImplementedError
+
+    def add_stations(self, filename):
+        raise NotImplementedError
+
+
+class BaseApiKmlKmlImporter(BaseGenericApiImporter, BaseKamlImporter):
+    def add_districts(self, filename):
+        self.add_kml_district(filename)
+    def add_stations(self, filename):
+        self.add_kml_station(filename)
 
 
 class BaseAddressCsvImporter(BaseImporter):

--- a/polling_stations/apps/data_collection/management/commands/import_camden.py
+++ b/polling_stations/apps/data_collection/management/commands/import_camden.py
@@ -1,0 +1,84 @@
+"""
+Imports Camden
+"""
+import json
+from lxml import etree
+from django.contrib.gis.geos import (
+    GEOSGeometry,
+    MultiPolygon,
+    Point,
+    Polygon,
+    LinearRing
+)
+from data_collection.management.commands import (
+    BaseGenericApiImporter,
+    BaseImporter
+)
+
+class Command(BaseGenericApiImporter, BaseImporter):
+    """
+    Imports the Polling Station data from Camden Council
+    """
+    srid             = 4326
+    districts_srid   = 4326
+    council_id       = 'E09000007'
+    # This isn't GeoJSON - it is JSON with serialised WKT strings embedded in it
+    districts_url    = 'https://opendata.camden.gov.uk/api/views/ta65-2szc/rows.json?accessType=DOWNLOAD'
+    # This is just a bespoke XML format
+    stations_url     = 'https://opendata.camden.gov.uk/api/views/5rhh-fxna/rows.xml?accessType=DOWNLOAD'
+
+    def convert_linestring_to_multiploygon(self, linestring):
+        points = linestring.coords
+
+        # close the LineString so we can transform to LinearRing
+        points = list(points)
+        points.append(points[0])
+        ring = LinearRing(points)
+
+        # now we have a LinearRing we can make a Polygon.. and the rest is simple
+        poly = Polygon(ring)
+        multipoly = MultiPolygon(poly)
+        return multipoly
+
+    def add_districts(self, filename):
+        districts = json.load(open(filename))
+        for district in districts['data']:
+            district_info = self.district_record_to_dict(district)
+            district_info['council'] = self.council
+            self.add_polling_district(district_info)
+        return
+
+    def district_record_to_dict(self, record):
+        poly = GEOSGeometry(record[8], srid=self.get_srid('districts'))
+        # poly is a LineString, but we need to convert it to a MultiPolygon so it will import
+        poly = self.convert_linestring_to_multiploygon(poly)
+
+        return {
+            'internal_council_id': record[-1],
+            'extra_id': record[-2],
+            'name': 'Camden - %s' % (record[-1]),
+            'area': poly,
+            'polling_station_id': record[-1]
+        }
+
+    def add_stations(self, filename):
+        xml = etree.parse(filename)
+        stations = xml.getroot()[0]
+        for station in stations:
+            station_info = self.station_record_to_dict(station)
+            station_info['council'] = self.council
+            self.add_polling_station(station_info)
+        return
+
+    def station_record_to_dict(self, record):
+        info = {}
+        for tag in record:
+            info[tag.tag] = tag.text
+        location = Point(float(info['longitude']), float(info['latitude']), srid=self.get_srid())
+
+        return {
+            'internal_council_id': info['polling_district_name'],
+            'postcode': info['postcode'],
+            'address': "\n".join([info['organisation'], info['street']]),
+            'location': location
+        }


### PR DESCRIPTION
Given the number of formats Camden publish, I thought this would be easy, but I couldn't get their KMZ output to parse in GEOS. The KML would parse, but the metadata was stored in `ExtendedData` tags with no schema definition in the head, so GEOS wouldn't parse anything other than the boundaries.. In the end, I went for their 'JSON with WKT strings embedded in it' (if only some kind of specialised JSON-based format for geographic data existed!) and XML outputs. Maybe it would have been quicker to just download the SHP and CSV files, but hopefully the `BaseGenericApiImporter` class will be useful in the future and this will be easier to update when they publish new data.

The meta-data says this is the polling data for "GLA Mayoral and Assembly Elections - Thursday 5 May 2016" so it is probably worth checking back on this before the EU Referendum.

We're missing a station for district ED - I checked the outputs in other formats, but it is missing from all of them :(

Closes #171
Refs #175