### PR TITLE
Publish data quality reports on website

### DIFF
--- a/polling_stations/apps/data_collection/data_quality_report.py
+++ b/polling_stations/apps/data_collection/data_quality_report.py
@@ -307,6 +307,7 @@ class DataQualityReportBuilder():
 
     def __init__(self, council_id):
         self.council_id = council_id
+        self.report = []
 
     def build_header(self):
         self.report.append({ 'style': None,

--- a/polling_stations/apps/data_collection/data_quality_report.py
+++ b/polling_stations/apps/data_collection/data_quality_report.py
@@ -289,86 +289,194 @@ class ResidentialAddressReport():
         return results[0][0]
 
 
-# generate all the stats and output to console
+# generate all the stats
 class DataQualityReport():
 
     council_id = None
+    report = []
 
     def __init__(self, council_id):
         self.council_id = council_id
 
-    def output_header(self):
-        print("==================================")
-        OutputFormatter.print_bold("        DATA QUALITY REPORT")
-        print("==================================\n")
+    def build_header(self):
+        self.report.append({ 'style': None,
+            'text': "=================================="
+        })
+        self.report.append({ 'style': 'bold',
+            'text': "        DATA QUALITY REPORT"
+        })
+        self.report.append({ 'style': None,
+            'text': "==================================\n"
+        })
 
-    def output_station_report(self):
+    def build_station_report(self):
         stations_report = StationReport(self.council_id)
 
         stations_imported = stations_report.get_stations_imported()
         if stations_imported > 0:
-            OutputFormatter.print_bold("STATIONS IMPORTED                : %i" % (stations_imported))
-            print("----------------------------------")
+            self.report.append({ 'style': 'bold',
+                'text': "STATIONS IMPORTED                : %i" % (stations_imported)
+            })
+            self.report.append({ 'style': None,
+                'text': "----------------------------------"
+            })
+
             district_ids = stations_report.get_stations_with_district_id()
             if district_ids > 0:
-                OutputFormatter.print_ok_bold(" - with district id              : %i" % (district_ids))
-                OutputFormatter.print_ok("   - valid district id refs      : %i" % (stations_report.get_stations_with_valid_district_id_ref()))
-                OutputFormatter.print_warning("   - invalid district id refs    : %i" % (stations_report.get_stations_with_invalid_district_id_ref()))
+                self.report.append({ 'style': 'ok_bold',
+                    'text': " - with district id              : %i" % (district_ids)
+                })
+                self.report.append({ 'style': 'ok',
+                    'text': "   - valid district id refs      : %i" % (stations_report.get_stations_with_valid_district_id_ref())
+                })
+                self.report.append({ 'style': 'warning',
+                    'text': "   - invalid district id refs    : %i" % (stations_report.get_stations_with_invalid_district_id_ref())
+                })
             else:
-                OutputFormatter.print_ok(" - with district id              : %i" % (district_ids))
-            OutputFormatter.print_warning(" - without district id           : %i" % (stations_report.get_stations_without_district_id()))
-            OutputFormatter.print_ok(" - with point                    : %i" % (stations_report.get_stations_with_point()))
-            OutputFormatter.print_warning(" - without point                 : %i" % (stations_report.get_stations_without_point()))
-            OutputFormatter.print_ok(" - with address                  : %i" % (stations_report.get_stations_with_address()))
-            OutputFormatter.print_warning(" - without address               : %i" % (stations_report.get_stations_without_address()))
-            print("----------------------------------")
-            OutputFormatter.print_bold("POLYGON LOOKUPS")
-            OutputFormatter.print_warning("Stations in 0 districts          : %i" % (stations_report.get_stations_in_zero_districts()))
-            OutputFormatter.print_ok("Stations in 1 districts          : %i" % (stations_report.get_stations_in_one_districts()))
-            OutputFormatter.print_warning("Stations in >1 districts         : %i" % (stations_report.get_stations_in_more_districts()))
-            print("\n")
+                self.report.append({ 'style': 'ok',
+                    'text': " - with district id              : %i" % (district_ids)
+                })
 
-    def output_district_report(self):
+            self.report.append({ 'style': 'warning',
+                'text': " - without district id           : %i" % (stations_report.get_stations_without_district_id())
+            })
+            self.report.append({ 'style': 'ok',
+                'text': " - with point                    : %i" % (stations_report.get_stations_with_point())
+            })
+            self.report.append({ 'style': 'warning',
+                'text': " - without point                 : %i" % (stations_report.get_stations_without_point())
+            })
+            self.report.append({ 'style': 'ok',
+                'text': " - with address                  : %i" % (stations_report.get_stations_with_address())
+            })
+            self.report.append({ 'style': 'warning',
+                'text': " - without address               : %i" % (stations_report.get_stations_without_address())
+            })
+            self.report.append({ 'style': None,
+                'text': "----------------------------------"
+            })
+            self.report.append({ 'style': 'bold',
+                'text': "POLYGON LOOKUPS"
+            })
+            self.report.append({ 'style': 'warning',
+                'text': "Stations in 0 districts          : %i" % (stations_report.get_stations_in_zero_districts())
+            })
+            self.report.append({ 'style': 'ok',
+                'text': "Stations in 1 districts          : %i" % (stations_report.get_stations_in_one_districts())
+            })
+            self.report.append({ 'style': 'warning',
+                'text': "Stations in >1 districts         : %i" % (stations_report.get_stations_in_more_districts())
+            })
+            self.report.append({ 'style': None,
+                'text': "\n"
+            })
+
+    def build_district_report(self):
         districts_report = DistrictReport(self.council_id)
 
         districts_imported = districts_report.get_districts_imported()
         if districts_imported > 0:
-            OutputFormatter.print_bold("DISTRICTS IMPORTED               : %i" % (districts_imported))
-            print("----------------------------------")
+            self.report.append({ 'style': 'bold',
+                'text': "DISTRICTS IMPORTED               : %i" % (districts_imported)
+            })
+            self.report.append({ 'style': None,
+                'text': "----------------------------------"
+            })
+
             station_ids = districts_report.get_districts_with_station_id()
             if station_ids > 0:
-                OutputFormatter.print_ok_bold(" - with station id               : %i" % (station_ids))
-                OutputFormatter.print_ok("   - valid station id refs       : %i" % (districts_report.get_districts_with_valid_station_id_ref()))
-                OutputFormatter.print_warning("   - invalid station id refs     : %i" % (districts_report.get_districts_with_invalid_station_id_ref()))
+                self.report.append({ 'style': 'ok_bold',
+                    'text': " - with station id               : %i" % (station_ids)
+                })
+                self.report.append({ 'style': 'ok',
+                    'text': "   - valid station id refs       : %i" % (districts_report.get_districts_with_valid_station_id_ref())
+                })
+                self.report.append({ 'style': 'warning',
+                    'text': "   - invalid station id refs     : %i" % (districts_report.get_districts_with_invalid_station_id_ref())
+                })
             else:
-                OutputFormatter.print_ok(" - with station id               : %i" % (station_ids))
-            OutputFormatter.print_warning(" - without station id            : %i" % (districts_report.get_districts_without_station_id()))
-            print("----------------------------------")
-            OutputFormatter.print_bold("POLYGON LOOKUPS")
-            OutputFormatter.print_warning("Districts containing 0 stations  : %i" % (districts_report.get_districts_containing_zero_stations()))
-            OutputFormatter.print_ok("Districts containing 1 stations  : %i" % (districts_report.get_districts_containing_one_stations()))
-            OutputFormatter.print_warning("Districts containing >1 stations : %i" % (districts_report.get_districts_containing_more_stations()))
-            print("\n")
+                self.report.append({ 'style': 'ok',
+                    'text': " - with station id               : %i" % (station_ids)
+                })
 
-    def output_residential_address_report(self):
+            self.report.append({ 'style': 'warning',
+                'text': " - without station id            : %i" % (districts_report.get_districts_without_station_id())
+            })
+            self.report.append({ 'style': None,
+                'text': "----------------------------------"
+            })
+            self.report.append({ 'style': 'bold',
+                'text': "POLYGON LOOKUPS"
+            })
+            self.report.append({ 'style': 'warning',
+                'text': "Districts containing 0 stations  : %i" % (districts_report.get_districts_containing_zero_stations())
+            })
+            self.report.append({ 'style': 'ok',
+                'text': "Districts containing 1 stations  : %i" % (districts_report.get_districts_containing_one_stations())
+            })
+            self.report.append({ 'style': 'warning',
+                'text': "Districts containing >1 stations : %i" % (districts_report.get_districts_containing_more_stations())
+            })
+            self.report.append({ 'style': None,
+                'text': "\n"
+            })
+
+    def build_residential_address_report(self):
         address_report = ResidentialAddressReport(self.council_id)
 
         addresses_imported = address_report.get_addresses_imported()
         if addresses_imported > 0:
-            OutputFormatter.print_bold("ADDRESSES IMPORTED               : %i" % (addresses_imported))
-            print("----------------------------------")
+            self.report.append({ 'style': 'bold',
+                'text': "ADDRESSES IMPORTED               : %i" % (addresses_imported)
+            })
+            self.report.append({ 'style': None,
+                'text': "----------------------------------"
+            })
+
             station_ids = address_report.get_addresses_with_station_id()
             if station_ids > 0:
-                OutputFormatter.print_ok_bold(" - with station id               : %i" % (station_ids))
-                OutputFormatter.print_ok("   - valid station id refs       : %i" % (address_report.get_addresses_with_valid_station_id_ref()))
-                OutputFormatter.print_warning("   - invalid station id refs     : %i" % (address_report.get_addresses_with_invalid_station_id_ref()))
+                self.report.append({ 'style': 'ok_bold',
+                    'text': " - with station id               : %i" % (station_ids)
+                })
+                self.report.append({ 'style': 'ok',
+                    'text': "   - valid station id refs       : %i" % (address_report.get_addresses_with_valid_station_id_ref())
+                })
+                self.report.append({ 'style': 'warning',
+                    'text': "   - invalid station id refs     : %i" % (address_report.get_addresses_with_invalid_station_id_ref())
+                })
             else:
-                OutputFormatter.print_ok(" - with station id               : %i" % (station_ids))
-            OutputFormatter.print_warning(" - without station id            : %i" % (address_report.get_addresses_without_station_id()))
-            print("\n")
+                self.report.append({ 'style': 'ok',
+                    'text': " - with station id               : %i" % (station_ids)
+                })
 
-    def output_report(self):
-        self.output_header()
-        self.output_district_report()
-        self.output_station_report()
-        self.output_residential_address_report()
+            self.report.append({ 'style': 'warning',
+                'text': " - without station id            : %i" % (address_report.get_addresses_without_station_id())
+            })
+            self.report.append({ 'style': None,
+                'text': "\n"
+            })
+
+    def build_report(self):
+        self.build_header()
+        self.build_district_report()
+        self.build_station_report()
+        self.build_residential_address_report()
+
+    def output_console_report(self):
+        for line in self.report:
+            if line['style'] == 'ok':
+                OutputFormatter.print_ok(line['text'])
+            elif line['style'] == 'warning':
+                OutputFormatter.print_warning(line['text'])
+            elif line['style'] == 'ok_bold':
+                OutputFormatter.print_ok_bold(line['text'])
+            elif line['style'] == 'bold':
+                OutputFormatter.print_bold(line['text'])
+            elif line['style'] is None:
+                print(line['text'])
+
+    def generate_string_report(self):
+        out = ''
+        for line in self.report:
+            out = out + line['text'] + "\n"
+        return out.strip()

--- a/polling_stations/apps/data_collection/data_quality_report.py
+++ b/polling_stations/apps/data_collection/data_quality_report.py
@@ -290,7 +290,7 @@ class ResidentialAddressReport():
 
 
 # generate all the stats
-class DataQualityReport():
+class DataQualityReportBuilder():
 
     council_id = None
     report = []

--- a/polling_stations/apps/data_collection/data_quality_report.py
+++ b/polling_stations/apps/data_collection/data_quality_report.py
@@ -39,6 +39,11 @@ class StationReport():
 
     def __init__(self, council_id):
         self.council_id = council_id
+        self.counts = {
+            '0': 0,
+            '1': 0,
+            '>1': 0
+        }
         self.generate_counts()
 
     def get_stations_imported(self):
@@ -154,6 +159,11 @@ class DistrictReport():
 
     def __init__(self, council_id):
         self.council_id = council_id
+        self.counts = {
+            '0': 0,
+            '1': 0,
+            '>1': 0
+        }
         self.generate_counts()
 
     def get_districts_imported(self):

--- a/polling_stations/apps/data_collection/management/commands/__init__.py
+++ b/polling_stations/apps/data_collection/management/commands/__init__.py
@@ -23,6 +23,7 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
 from councils.models import Council
+from data_collection.data_quality_report import DataQualityReport
 from pollingstations.models import PollingStation, PollingDistrict, ResidentialAddress
 
 
@@ -127,6 +128,11 @@ class BaseImporter(BaseCommand):
     def post_import(self):
         raise NotImplementedError
 
+    def report(self):
+        report = DataQualityReport(self.council_id)
+        report.build_report()
+        report.output_console_report()
+
     def handle(self, *args, **kwargs):
         if self.council_id is None:
             self.council_id = args[0]
@@ -150,6 +156,9 @@ class BaseImporter(BaseCommand):
             self.post_import()
         except NotImplementedError:
             pass
+
+        # save and output data quality report
+        self.report()
 
 
 class BaseShpImporter(BaseImporter):
@@ -311,6 +320,9 @@ class BaseGenericApiImporter:
             self.post_import()
         except NotImplementedError:
             pass
+
+        # save and output data quality report
+        self.report()
 
     def import_data(self):
         # deal with 'stations only' or 'districts only' data

--- a/polling_stations/apps/data_collection/management/commands/__init__.py
+++ b/polling_stations/apps/data_collection/management/commands/__init__.py
@@ -25,11 +25,11 @@ from django.utils.safestring import mark_safe
 from councils.models import Council
 from data_collection.data_quality_report import DataQualityReportBuilder
 from pollingstations.models import (
-    DataQualityReport,
     PollingStation,
     PollingDistrict,
     ResidentialAddress
 )
+from data_collection.models import DataQuality
 
 
 class CsvHelper:
@@ -139,11 +139,11 @@ class BaseImporter(BaseCommand):
         report.build_report()
 
         # save a static copy in the DB that we can serve up on the website
-        record = DataQualityReport(
+        record = DataQuality.objects.get_or_create(
             council_id=self.council_id,
-            report=report.generate_string_report()
         )
-        record.save()
+        record[0].report=report.generate_string_report()
+        record[0].save()
 
         # output to console
         report.output_console_report()
@@ -158,7 +158,6 @@ class BaseImporter(BaseCommand):
         PollingStation.objects.filter(council=self.council).delete()
         PollingDistrict.objects.filter(council=self.council).delete()
         ResidentialAddress.objects.filter(council=self.council).delete()
-        DataQualityReport.objects.filter(council=self.council).delete()
 
         if self.base_folder_path is None:
             self.base_folder_path = os.path.abspath(
@@ -328,7 +327,6 @@ class BaseGenericApiImporter:
         PollingStation.objects.filter(council=self.council).delete()
         PollingDistrict.objects.filter(council=self.council).delete()
         ResidentialAddress.objects.filter(council=self.council).delete()
-        DataQualityReport.objects.filter(council=self.council).delete()
 
         self.import_data()
 

--- a/polling_stations/apps/data_collection/management/commands/data_quality_report.py
+++ b/polling_stations/apps/data_collection/management/commands/data_quality_report.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from data_collection.data_quality_report import DataQualityReport
+from data_collection.data_quality_report import DataQualityReportBuilder
 
 class Command(BaseCommand):
 
@@ -10,6 +10,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):
-        report = DataQualityReport(kwargs['council_id'])
+        report = DataQualityReportBuilder(kwargs['council_id'])
         report.build_report()
         report.output_console_report()

--- a/polling_stations/apps/data_collection/management/commands/data_quality_report.py
+++ b/polling_stations/apps/data_collection/management/commands/data_quality_report.py
@@ -11,4 +11,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         report = DataQualityReport(kwargs['council_id'])
-        report.output_report()
+        report.build_report()
+        report.output_console_report()

--- a/polling_stations/apps/data_collection/migrations/0005_dataquality_report.py
+++ b/polling_stations/apps/data_collection/migrations/0005_dataquality_report.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_collection', '0004_auto_20160121_1522'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dataquality',
+            name='report',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/polling_stations/apps/data_collection/migrations/0006_auto_20160415_1858.py
+++ b/polling_stations/apps/data_collection/migrations/0006_auto_20160415_1858.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_collection', '0005_dataquality_report'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='dataquality',
+            name='id',
+        ),
+        migrations.AlterField(
+            model_name='dataquality',
+            name='council',
+            field=models.OneToOneField(primary_key=True, to='councils.Council', serialize=False),
+        ),
+    ]

--- a/polling_stations/apps/data_collection/migrations/0007_auto_20160415_1931.py
+++ b/polling_stations/apps/data_collection/migrations/0007_auto_20160415_1931.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_collection', '0006_auto_20160415_1858'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dataquality',
+            name='num_addresses',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='dataquality',
+            name='num_districts',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='dataquality',
+            name='num_stations',
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/polling_stations/apps/data_collection/models.py
+++ b/polling_stations/apps/data_collection/models.py
@@ -20,6 +20,9 @@ class DataQuality(models.Model):
     rating = models.DecimalField(blank=True, null=True, max_digits=1,
         help_text="From 0 to 9", decimal_places=0)
     report = models.TextField(blank=True)
+    num_stations = models.IntegerField(default=0)
+    num_districts = models.IntegerField(default=0)
+    num_addresses = models.IntegerField(default=0)
 
     class Meta:
         verbose_name_plural = "Data Quality"

--- a/polling_stations/apps/data_collection/models.py
+++ b/polling_stations/apps/data_collection/models.py
@@ -4,7 +4,7 @@ from councils.models import Council
 
 
 class DataQuality(models.Model):
-    council = models.OneToOneField(Council)
+    council = models.OneToOneField(Council, primary_key=True)
     url = models.URLField(blank=True, verbose_name="URL to the data",
         help_text="(PDF, website, etc)")
     data_format = models.CharField(blank=True, max_length=100,
@@ -19,6 +19,7 @@ class DataQuality(models.Model):
         help_text="Have we heard from them directly?")
     rating = models.DecimalField(blank=True, null=True, max_digits=1,
         help_text="From 0 to 9", decimal_places=0)
+    report = models.TextField(blank=True)
 
     class Meta:
         verbose_name_plural = "Data Quality"

--- a/polling_stations/apps/data_collection/urls.py
+++ b/polling_stations/apps/data_collection/urls.py
@@ -6,6 +6,7 @@ from .views import LeagueTable
 
 urlpatterns = patterns(
     '',
-    url(r'^$',  cache_page(60 * 15)(LeagueTable.as_view()), name='league_table'),
+    url(r'^/$', LeagueTable.as_view(), name='league_table'),
+    url(r'/data_quality/(?P<council_id>.+)/$', 'data_collection.views.data_quality', name='data_quality'),
 )
 

--- a/polling_stations/apps/data_collection/views.py
+++ b/polling_stations/apps/data_collection/views.py
@@ -5,5 +5,8 @@ from .models import DataQuality
 
 class LeagueTable(ListView):
     model = DataQuality
-    queryset = DataQuality.objects.all().select_related('council')\
-        .defer('council__area', 'council__location')
+    queryset = DataQuality.objects\
+        .all()\
+        .select_related('council')\
+        .defer('council__area', 'council__location')\
+        .order_by('council__name')

--- a/polling_stations/apps/data_collection/views.py
+++ b/polling_stations/apps/data_collection/views.py
@@ -1,5 +1,5 @@
+from django.db.models import Case, IntegerField, Q, Value, When
 from django.views.generic import ListView
-
 from .models import DataQuality
 
 
@@ -9,4 +9,10 @@ class LeagueTable(ListView):
         .all()\
         .select_related('council')\
         .defer('council__area', 'council__location')\
-        .order_by('council__name')
+        .annotate(has_report=Case(
+                When(Q(report=''), then=Value(1)),
+                When(~Q(report=''), then=Value(0)),
+                output_field=IntegerField()
+            )
+        )\
+        .order_by('has_report', 'council__name')

--- a/polling_stations/apps/data_collection/views.py
+++ b/polling_stations/apps/data_collection/views.py
@@ -1,4 +1,5 @@
 from django.db.models import Case, IntegerField, Q, Value, When
+from django.shortcuts import get_object_or_404, render
 from django.views.generic import ListView
 from .models import DataQuality
 
@@ -10,9 +11,17 @@ class LeagueTable(ListView):
         .select_related('council')\
         .defer('council__area', 'council__location')\
         .annotate(has_report=Case(
-                When(Q(report=''), then=Value(1)),
-                When(~Q(report=''), then=Value(0)),
+                When(Q(report=''), then=Value(0)),
+                When(~Q(report=''), then=Value(1)),
                 output_field=IntegerField()
             )
         )\
-        .order_by('has_report', 'council__name')
+        .order_by('-has_report', 'council__name')
+
+def data_quality(request, council_id):
+    data = get_object_or_404(DataQuality.objects.select_related('council'),
+        pk=council_id)
+    context = {
+        'summary': data
+    }
+    return render(request, 'data_collection/dataquality_detail.html', context)

--- a/polling_stations/apps/pollingstations/migrations/0007_dataqualityreport.py
+++ b/polling_stations/apps/pollingstations/migrations/0007_dataqualityreport.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('councils', '0002_auto_20160121_1522'),
+        ('pollingstations', '0006_residentialaddress_slug'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DataQualityReport',
+            fields=[
+                ('council', models.OneToOneField(to='councils.Council', primary_key=True, serialize=False)),
+                ('report', models.TextField()),
+            ],
+        ),
+    ]

--- a/polling_stations/apps/pollingstations/migrations/0008_auto_20160415_1854.py
+++ b/polling_stations/apps/pollingstations/migrations/0008_auto_20160415_1854.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pollingstations', '0007_dataqualityreport'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='dataqualityreport',
+            name='council',
+        ),
+        migrations.DeleteModel(
+            name='DataQualityReport',
+        ),
+    ]

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -101,3 +101,8 @@ class ResidentialAddress(models.Model):
     council            = models.ForeignKey(Council, null=True)
     polling_station_id = models.CharField(blank=True, max_length=100)
     slug               = models.SlugField(blank=False, null=False, db_index=True, unique=True, max_length=255)
+
+
+class DataQualityReport(models.Model):
+    council            = models.OneToOneField(Council, primary_key=True)
+    report             = models.TextField(blank=False, null=False)

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -101,8 +101,3 @@ class ResidentialAddress(models.Model):
     council            = models.ForeignKey(Council, null=True)
     polling_station_id = models.CharField(blank=True, max_length=100)
     slug               = models.SlugField(blank=False, null=False, db_index=True, unique=True, max_length=255)
-
-
-class DataQualityReport(models.Model):
-    council            = models.OneToOneField(Council, primary_key=True)
-    report             = models.TextField(blank=False, null=False)

--- a/polling_stations/templates/data_collection/dataquality_detail.html
+++ b/polling_stations/templates/data_collection/dataquality_detail.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>{{ summary.council.name }}</h1>
+<pre>
+{{ summary.report }}
+</pre>
+{% endblock content %}

--- a/polling_stations/templates/data_collection/dataquality_list.html
+++ b/polling_stations/templates/data_collection/dataquality_list.html
@@ -8,8 +8,9 @@
         <th>ID</th>
         <th>Council</th>
         <th>Example</th>
-        <th>Polling Stations?</th>
-        <th>Polling Districts?</th>
+        <th>Polling Stations</th>
+        <th>Polling Districts</th>
+        <th>Addresses</th>
         {% if request.user.is_staff %}
         <th>Edit</th>
         {% endif %}
@@ -33,10 +34,13 @@
             {% endif %}
             </td>
             <td>
-              {{ council.council.pollingstation_set.count }}
+              {{ council.num_stations }}
             </td>
             <td>
-              {{ council.council.pollingdistrict_set.count }}
+              {{ council.num_districts }}
+            </td>
+            <td>
+              {{ council.num_addresses }}
             </td>
             {% if request.user.is_staff %}
             <td>

--- a/polling_stations/templates/data_collection/dataquality_list.html
+++ b/polling_stations/templates/data_collection/dataquality_list.html
@@ -19,7 +19,12 @@
     {% for council in object_list %}
         <tr>
             <td>{{ council.council_id }}</td>
-            <td>{{ council.council.name }}</td>
+            <td>{% if council.has_report %}
+                <a href="{% url "data_quality" council_id=council.council_id %}">{{ council.council.name }}</a>
+                {% else %}
+                {{ council.council.name }}
+                {% endif %}
+            </td>
             <td>
             {% if council.council.postcode %}
             <a href="{% url "postcode_view" postcode=council.council.postcode %}">{{ council.council.postcode }}</a>

--- a/polling_stations/templates/data_collection/dataquality_list.html
+++ b/polling_stations/templates/data_collection/dataquality_list.html
@@ -4,7 +4,6 @@
 <table class="table table-striped">
     <thead>
       <tr>
-        <th>Rating</th>
         <th>ID</th>
         <th>Council</th>
         <th>Example</th>
@@ -19,13 +18,6 @@
     <tbody>
     {% for council in object_list %}
         <tr>
-            <td>
-              {% if council.rating == -1 %}
-                Unrated
-              {% else %}
-                {{ council.rating}}
-              {% endif %}
-            </td>
             <td>{{ council.council_id }}</td>
             <td>{{ council.council.name }}</td>
             <td>


### PR DESCRIPTION
Following on from our conversation in the standup on Tuesday, I've added the data quality report output to the website. At the moment, it is just chucking the same output we send to the console into a text field and rendering it in a `<pre>` tag, but it does the job - we can always tidy up later. Thinking it through, the league table is actually the sensible place for this to be linked so I've made some improvements to that as well.

I've marked this WIP because we probably don't want to merge this (or at least shouldn't deploy it to live) until we tear down and re-run the import scripts because the import scripts will populate the `DataQuality` model with suitable static/cached values.

Closes #237