### PR TITLE
Add ability to serve custom content for specific areas

### DIFF
--- a/polling_stations/api.py
+++ b/polling_stations/api.py
@@ -6,7 +6,7 @@ from django.utils.encoding import smart_str
 from rest_framework import routers, serializers, viewsets, views
 from councils.models import Council
 from pollingstations.models import (PollingStation, PollingDistrict,
-    ResidentialAddress)
+    ResidentialAddress, CustomFinder)
 
 # Fields define serialization of complex field types (GEO)
 class PointField(serializers.Field):
@@ -148,6 +148,14 @@ class PostcodeViewSet(viewsets.ViewSet):
             ret['polling_station_known'] = True
             ret['polling_station'] = PollingStationSerializer(
                 polling_station, context={'request': self.request}).data
+
+        if not ret['polling_station_known']:
+            finder = CustomFinder.objects.get_custom_finder(l['gss_codes'], postcode)
+            if finder.base_url:
+                ret['custom_finder'] = {}
+                ret['custom_finder']['base_url'] = finder.base_url
+                ret['custom_finder']['can_pass_postcode'] = finder.can_pass_postcode
+                ret['custom_finder']['encoded_postcode'] = finder.encoded_postcode
 
         return Response(ret)
 

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -25,9 +25,14 @@ def geocode(postcode):
     if 'error' in res_json:
         raise PostcodeError("Mapit error {}: {}".format(res_json['code'], res_json['error']))
     else:
+        gss_codes = []
+        for area in res_json['areas']:
+            if 'gss' in res_json['areas'][area]['codes']:
+                gss_codes.append(res_json['areas'][area]['codes']['gss'])
         return {
             'wgs84_lon': res_json['wgs84_lon'],
             'wgs84_lat': res_json['wgs84_lat'],
+            'gss_codes': gss_codes,
         }
 
 

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -15,7 +15,8 @@ from councils.models import Council
 from data_finder.models import LoggedPostcode
 from pollingstations.models import (
     PollingStation,
-    ResidentialAddress
+    ResidentialAddress,
+    CustomFinder
 )
 from whitelabel.views import WhiteLabelTemplateOverrideMixin
 from .forms import PostcodeLookupForm, AddressSelectForm
@@ -110,6 +111,12 @@ class BasePollingStationView(
         context['station'] = self.station
         context['directions'] = self.directions
         context['we_know_where_you_should_vote'] = self.station
+
+        if not context['we_know_where_you_should_vote']:
+            if l is None:
+                context['custom'] = None
+            else:
+                context['custom'] = CustomFinder.objects.get_custom_finder(l['gss_codes'], self.postcode)
 
         self.log_postcode(self.postcode, context)
         return context

--- a/polling_stations/apps/pollingstations/migrations/0009_customfinder.py
+++ b/polling_stations/apps/pollingstations/migrations/0009_customfinder.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('pollingstations', '0006_residentialaddress_slug'),
+        ('pollingstations', '0008_auto_20160415_1854'),
     ]
 
     operations = [

--- a/polling_stations/apps/pollingstations/migrations/0009_customfinder.py
+++ b/polling_stations/apps/pollingstations/migrations/0009_customfinder.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pollingstations', '0006_residentialaddress_slug'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CustomFinder',
+            fields=[
+                ('area_code', models.CharField(serialize=False, max_length=9, primary_key=True)),
+                ('base_url', models.CharField(max_length=255, blank=True)),
+                ('can_pass_postcode', models.BooleanField(default=False)),
+                ('message', models.TextField(blank=True)),
+            ],
+        ),
+    ]

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -101,3 +101,42 @@ class ResidentialAddress(models.Model):
     council            = models.ForeignKey(Council, null=True)
     polling_station_id = models.CharField(blank=True, max_length=100)
     slug               = models.SlugField(blank=False, null=False, db_index=True, unique=True, max_length=255)
+
+
+"""
+Store details of areas that have their own
+custom polling station finders
+and/or a message that we might want to show.
+
+
+Example content:
+
+record = CustomFinder(
+    area_code='E07000082'
+    base_url='https://stroud.maps.arcgis.com/apps/webappviewer/index.html?id=ea6bf4b3655542c1a05c8d7e87d32bb1'
+    can_pass_postcode=False
+    message="Stroud District Council has its' own polling station finder:"
+)
+record.save()
+
+record = CustomFinder(
+    area_code='W06000008'
+    base_url=''
+    can_pass_postcode=False
+    message='<h3>We're working on it!</h3>Ceredigion Council have provided polling station data. It will be available soon.'
+)
+record.save()
+
+record = CustomFinder(
+    area_code='N07000001'
+    base_url='http://www.eoni.org.uk/Offices/Postcode-Search-Results?postcode='
+    can_pass_postcode=True
+    message='The Electoral Office of Northern Ireland has its' own polling station finder:'
+)
+record.save()
+"""
+class CustomFinder(models.Model):
+    area_code = models.CharField(max_length=9, primary_key=True)
+    base_url = models.CharField(blank=True, max_length=255)
+    can_pass_postcode = models.BooleanField(default=False)
+    message = models.TextField(blank=True)

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -45,48 +45,73 @@
 
     {% else %}
 
-      <h2>
-        {% if we_know_where_you_should_vote %}
-          {% trans "Your polling station" %}
+      {% if custom %}
+
+        <div>{{ custom.message|safe }}</div>
+        {% if custom.base_url and custom.can_pass_postcode %}
+
+            <p><a href="{{ custom.base_url }}{{ custom.encoded_postcode }}">{% trans "Find your polling station" %}</a></p>
+            {% blocktrans with council_phone=council.phone council_name=council.name %}
+            <p>Alternatively, contact {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
+            {% endblocktrans %}
+
         {% else %}
-          {% blocktrans with council.name as council_name %}Contact {{ council_name }}{% endblocktrans %}
-        {% endif %}
-      </h2>
+            {% if custom.base_url %}
 
-      {% if we_know_where_you_should_vote %}
-      {% blocktrans %}The polling station for <strong>{{ postcode }}</strong> is:{% endblocktrans %}
-        <div>
-          <address>
-            {{ station.formatted_address|linebreaksbr }}<br />
-            {% if station.postcode %}
-              {% if not station.postcode in station.address %}
-                {{ station.postcode }}
-              {% endif %}
+                <p><a href="{{ custom.base_url }}">{% trans "Find your polling station" %}</a></p>
+                {% blocktrans with council_phone=council.phone council_name=council.name %}
+                <p>Alternatively, contact {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
+                {% endblocktrans %}
+
             {% endif %}
-          </address>
-        </div>
-        {% if directions.walk_time %}
-        <div id="directions">
-          <p>
-            {% blocktrans with directions.walk_time as walk_time and directions.walk_dist as walk_dist %}
-              It's about {{ walk_dist }} away or a {{ walk_time }} walk from {{ postcode }}.
-            {% endblocktrans %}</p>
-          <a href="https://www.google.com/maps/dir/{{postcode}}/{{ station.location.y }},{{ station.location.x }}">
-            {% trans "Get walking directions" %}
-          </a>
-        </div>
         {% endif %}
-      {% else %}
-        {% blocktrans with council.phone as council_phone %}
-        <p>We don't have data for your area.</p>
-        
-        <p>It may be listed on your polling card, which is delivered by post before an election.</p>
-        <p>Or, you need to contact the council. You can call them on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
-        {% endblocktrans %}
-      {% endif %}
 
-      {% if we_know_where_you_should_vote and station.location %}
-      <div id="area_map" class="card_inset"></div>
+      {% else %}
+
+        <h2>
+            {% if we_know_where_you_should_vote %}
+            {% trans "Your polling station" %}
+            {% else %}
+            {% blocktrans with council.name as council_name %}Contact {{ council_name }}{% endblocktrans %}
+            {% endif %}
+        </h2>
+
+        {% if we_know_where_you_should_vote %}
+        {% blocktrans %}The polling station for <strong>{{ postcode }}</strong> is:{% endblocktrans %}
+            <div>
+            <address>
+                {{ station.formatted_address|linebreaksbr }}<br />
+                {% if station.postcode %}
+                {% if not station.postcode in station.address %}
+                    {{ station.postcode }}
+                {% endif %}
+                {% endif %}
+            </address>
+            </div>
+            {% if directions.walk_time %}
+            <div id="directions">
+            <p>
+                {% blocktrans with directions.walk_time as walk_time and directions.walk_dist as walk_dist %}
+                It's about {{ walk_dist }} away or a {{ walk_time }} walk from {{ postcode }}.
+                {% endblocktrans %}</p>
+            <a href="https://www.google.com/maps/dir/{{postcode}}/{{ station.location.y }},{{ station.location.x }}">
+                {% trans "Get walking directions" %}
+            </a>
+            </div>
+            {% endif %}
+        {% else %}
+            {% blocktrans with council.phone as council_phone %}
+            <p>We don't have data for your area.</p>
+
+            <p>It may be listed on your polling card, which is delivered by post before an election.</p>
+            <p>Or, you need to contact the council. You can call them on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
+            {% endblocktrans %}
+        {% endif %}
+
+        {% if we_know_where_you_should_vote and station.location %}
+        <div id="area_map" class="card_inset"></div>
+        {% endif %}
+
       {% endif %}
 
     {% endif %}

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -51,17 +51,21 @@
         {% if custom.base_url and custom.can_pass_postcode %}
 
             <p><a href="{{ custom.base_url }}{{ custom.encoded_postcode }}">{% trans "Find your polling station" %}</a></p>
-            {% blocktrans with council_phone=council.phone council_name=council.name %}
-            <p>Alternatively, contact {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
-            {% endblocktrans %}
+            {% if council.phone %}
+              {% blocktrans with council_phone=council.phone council_name=council.name %}
+              <p>Alternatively, contact {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
+              {% endblocktrans %}
+            {% endif %}
 
         {% else %}
             {% if custom.base_url %}
 
                 <p><a href="{{ custom.base_url }}">{% trans "Find your polling station" %}</a></p>
-                {% blocktrans with council_phone=council.phone council_name=council.name %}
-                <p>Alternatively, contact {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
-                {% endblocktrans %}
+                {% if council.phone %}
+                  {% blocktrans with council_phone=council.phone council_name=council.name %}
+                  <p>Alternatively, contact {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong></p>
+                  {% endblocktrans %}
+                {% endif %}
 
             {% endif %}
         {% endif %}
@@ -143,6 +147,7 @@
     </div>
 
 
+    {% if council.address or council.postcode or council.phone or council.email %}
     <div class="card">
       <h3>{% trans "Council Contact info" %}</h3>
       <address>
@@ -153,6 +158,7 @@
         <a href="mailto:{{ council.email }}">{{ council.email }}</a>
       </address>
     </div>
+    {% endif %}
 
   </div>
 </div>


### PR DESCRIPTION
I've generalised this feature a bit so that as well as covering custom polling station finders (Issues #179, #174, GLA tool), it can also be used to show a custom message (e.g: "coming soon") as requested in #199.

Notes on this:

Seed data
----
I haven't provided any seed data for this - just some rough examples of how you might populate the DB in this comment: https://github.com/chris48s/UK-Polling-Stations/blob/152f0ca8e1cac16cfd15986b51bbd883ab4713b7/polling_stations/apps/pollingstations/models.py#L135
I'll leave the finer points of which areas you want to include and how you want to word the copy to you. When you decide what you're putting in there, could you let me know/commit a migration/send me a SQL dump or something so I can mirror the same content in my dev db.

Translations
----
This commit adds text which will need to br translated. Also you'll need to get translations for any text which goes into the `CustomFinder.message` field. I've marked it for translation using `ugettext`.

Order of precedence
----
I didn't get any feedback on my request for comment in #179, so I have made an assumption and set this up so that if a custom finder/message exists for an area where we hold data, it will prefer our data. This means if you add a record for the GLA's finder with the code `E15000007` and a user puts in a postcode in a London local authority where we have recent data (e.g: Camden, City of London, Ealing), etc we will serve up the 'we know where you should vote' output and only direct users to the GLA's finder in areas where we don't hold data. If you want it to work the other way round and always prefer the GLA site in this situation, let me know and I'll modify the logic accordingly.

API
----
Hopefully the way I've done the API output is sensible in terms of how you want to use it?

Other custom finders
----
In terms of organisations that have their own polling station finders (other than Northern Ireland and probably GLA), the ones I'm aware of and think are worth linking to are Stroud and Bristol:
Stroud's is at
https://stroud.maps.arcgis.com/apps/webappviewer/index.html?id=ea6bf4b3655542c1a05c8d7e87d32bb1
but doesn't accept postcodes as a URL param.
Bristol's is at
https://www.bristol.gov.uk/voting-elections/polling-station-finder
and you can feed a postcode into it like this:
https://www.bristol.gov.uk/voting-elections/polling-station-finder?execution=e1s7&p_p_id=bccpollingstationfinder_WAR_bccpollingstationfinderportlet&_eventId_lookupAddress=&postCode=AA1+1AA
(will accept postcode with a space, but doesn't require it like NI's does). That would also mean we don't have to deal with the data I managed to find, which I think will be problematic - see issue #231.
I think all of these:
https://www.lbhf.gov.uk/polling-stations-search
http://ilocal.carmarthenshire.gov.uk/my-nearest/
http://www.map.hackney.gov.uk/lbhackneymap/
are not worth linking to. I haven't really come across any others, but there are probably more out there. Is it worth asking in Slack/on twitter/on your mailing list/somewhere if anyone knows if their local council has one that is any good now that we can actually link to them?


Closes #174
Closes #179
Closes #199
Refs #231