### PR TITLE
Retire 2015 scripts, tag scripts with election IDs, add unique constraints

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import.py
+++ b/polling_stations/apps/data_collection/management/commands/import.py
@@ -1,0 +1,63 @@
+import glob, os
+from importlib.machinery import SourceFileLoader
+from django.core.management.base import BaseCommand
+
+"""
+Run all of the import scripts relating to a particular election or elections
+"""
+class Command(BaseCommand):
+
+    summary = []
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-e',
+            '--elections',
+            nargs='+',
+            help='<Required> List of one or more election ids to import data for',
+            required=True
+        )
+
+    def importer_covers_these_elections(self, args_elections, importer_elections):
+        for election in args_elections:
+            if election in importer_elections:
+                return True
+        return False
+
+    def output_summary(self):
+        for line in self.summary:
+            if line[0] == 'INFO':
+                self.stdout.write(line[1])
+            elif line[0] == 'WARNING':
+                self.stdout.write(self.style.ERROR(line[1]))
+            else:
+                self.stdout.write(line[1])
+
+    def handle(self, *args, **kwargs):
+
+        files = glob.glob(
+            os.path.abspath('polling_stations/apps/data_collection/management/commands') + '/import_*.py'
+        )
+        # loop over all the import scripts
+        for f in files:
+            head, tail = os.path.split(f)
+            try:
+                command = SourceFileLoader("module.name", f).load_module()
+            except:
+                # usually we want to handle a specific exception, but in in this situation
+                # if there is any issue (at all) trying to load the module,
+                # we just want to log it and move on to the next script
+                self.summary.append(('WARNING', "%s could not be loaded!" % tail))
+                continue
+
+            cmd = command.Command()
+            if hasattr(cmd, 'elections'):
+                if self.importer_covers_these_elections(kwargs['elections'], cmd.elections):
+                    # run the import script
+                    self.summary.append(('INFO', "Ran import script %s" % tail))
+                    opts = {}
+                    cmd.handle(**opts)
+            else:
+                self.summary.append(('WARNING', "%s does not contain elections property!" % tail))
+
+        self.output_summary()

--- a/polling_stations/apps/data_collection/management/commands/import_boston.py
+++ b/polling_stations/apps/data_collection/management/commands/import_boston.py
@@ -12,6 +12,7 @@ class Command(BaseShpImporter):
     council_id = 'E07000136'
     districts_name = 'Polling Districts May 2015_region'
     stations_name = 'pollingstations.csv'
+    elections = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_bournemouth.py
+++ b/polling_stations/apps/data_collection/management/commands/import_bournemouth.py
@@ -12,6 +12,7 @@ class Command(BaseJasonImporter):
     council_id     = 'E06000028'
     districts_name = 'Bournemouth_Polling_Districts.geojson'
     stations_name  = 'Polling Stations.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         properties = record['properties']

--- a/polling_stations/apps/data_collection/management/commands/import_braintree.py
+++ b/polling_stations/apps/data_collection/management/commands/import_braintree.py
@@ -10,6 +10,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E07000067'
     districts_name = 'Polling_Districts'
     stations_name  = 'Polling_Stations.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_brent.py
+++ b/polling_stations/apps/data_collection/management/commands/import_brent.py
@@ -13,6 +13,7 @@ class Command(BaseShpImporter):
     council_id     = 'E09000005'
     districts_name = 'polling_districts'
     stations_name  = 'polling_places.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_bromsgrove.py
+++ b/polling_stations/apps/data_collection/management/commands/import_bromsgrove.py
@@ -12,6 +12,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E07000234'
     districts_name = 'Electoral Boundaries 2'
     stations_name  = 'Bromsgrove DC and Redditch BC Polling Stations - May 2015 Elections.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_camden.py
+++ b/polling_stations/apps/data_collection/management/commands/import_camden.py
@@ -26,6 +26,12 @@ class Command(BaseGenericApiImporter, BaseImporter):
     districts_url    = 'https://opendata.camden.gov.uk/api/views/ta65-2szc/rows.json?accessType=DOWNLOAD'
     # This is just a bespoke XML format
     stations_url     = 'https://opendata.camden.gov.uk/api/views/5rhh-fxna/rows.xml?accessType=DOWNLOAD'
+    elections        = [
+        'gla.c.2016-05-05',
+        'gla.a.2016-05-05',
+        'mayor.london.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def convert_linestring_to_multiploygon(self, linestring):
         points = linestring.coords

--- a/polling_stations/apps/data_collection/management/commands/import_cardiff.py
+++ b/polling_stations/apps/data_collection/management/commands/import_cardiff.py
@@ -15,6 +15,12 @@ class Command(BaseShpShpImporter):
     council_id     = 'W06000015'
     districts_name = 'Polling Districts_region'
     stations_name  = 'Polling Stations_font_point.shp'
+    elections      = [
+        'pcc.2016-05-05',
+        'naw.c.2016-05-05',
+        'naw.r.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def district_record_to_dict(self, record):
         if type(record[1]) == str:

--- a/polling_stations/apps/data_collection/management/commands/import_chorley.py
+++ b/polling_stations/apps/data_collection/management/commands/import_chorley.py
@@ -14,6 +14,7 @@ class Command(BaseKamlImporter):
     council_id     = 'E07000118'
     districts_name = 'Chorley Polling Districts.kmz'
     stations_name  = 'Chorley_Polling_Stations.csv'
+    elections      = ['parl.2015-05-07']
 
     def station_record_to_dict(self, record):
         try:

--- a/polling_stations/apps/data_collection/management/commands/import_city_of_london.py
+++ b/polling_stations/apps/data_collection/management/commands/import_city_of_london.py
@@ -18,6 +18,12 @@ class Command(BaseApiKmlKmlImporter):
     These aren't actually KML - they're QML (hence use of SRID 27700)
     but gdal.DataSource will just deal with them for us :)
     """
+    elections = [
+        'gla.c.2016-05-05',
+        'gla.a.2016-05-05',
+        'mayor.london.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def district_record_to_dict(self, record):
         geojson = record.geom.geojson

--- a/polling_stations/apps/data_collection/management/commands/import_denbighshire.py
+++ b/polling_stations/apps/data_collection/management/commands/import_denbighshire.py
@@ -14,6 +14,12 @@ class Command(BaseAddressCsvImporter):
     addresses_name  = 'PropertyPostCodePollingStationWebLookup-2016-02-09.CSV'
     stations_name   = 'PollingStations-2016-02-09.csv'
     csv_encoding    = 'latin-1'
+    elections       = [
+        'pcc.2016-05-05',
+        'naw.c.2016-05-05',
+        'naw.r.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def station_record_to_dict(self, record):
 

--- a/polling_stations/apps/data_collection/management/commands/import_dover.py
+++ b/polling_stations/apps/data_collection/management/commands/import_dover.py
@@ -16,6 +16,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E07000108'
     districts_name = 'Dover_Polling_Boundaries'
     stations_name  = 'Dover_Polling_Stations.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_dundee.py
+++ b/polling_stations/apps/data_collection/management/commands/import_dundee.py
@@ -12,6 +12,7 @@ class Command(BaseJasonImporter):
     council_id     = 'S12000042'
     districts_name = 'polling_districts.bng.geo.json'
     stations_name  = 'SV_POLLING_STATIONS.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         properties = record['properties']

--- a/polling_stations/apps/data_collection/management/commands/import_ealing.py
+++ b/polling_stations/apps/data_collection/management/commands/import_ealing.py
@@ -19,6 +19,12 @@ class Command(BaseApiKmlKmlImporter):
     because it is made from magic and awesome! :D
     """
     stations_url     = 'http://inspire.misoportal.com/geoserver/london_borough_of_ealing_polling_station_location_point/ows?VERSION=1.1.1&REQUEST=GetMap&SERVICE=WMS&LAYERS=london_borough_of_ealing_polling_station_location_point&STYLES=&BBOX=-0.61059285604864,51.410208305472,0.022513608765178,51.630693143964&SRS=EPSG%3A4258&WIDTH=1005&HEIGHT=349&FORMAT=application/vnd.google-earth.kml+xml&TRANSPARENT=TRUE'
+    elections        = [
+        'gla.c.2016-05-05',
+        'gla.a.2016-05-05',
+        'mayor.london.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def extract_info_from_district_description(self, description):
         # lxml needs everything to be enclosed in one root element

--- a/polling_stations/apps/data_collection/management/commands/import_east_riding.py
+++ b/polling_stations/apps/data_collection/management/commands/import_east_riding.py
@@ -12,6 +12,7 @@ class Command(BaseShpImporter):
     council_id     = 'E06000011'
     districts_name = 'Polling_Districts.shpn'
     stations_name  = 'FOI6287_polling-stations.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_edinburgh.py
+++ b/polling_stations/apps/data_collection/management/commands/import_edinburgh.py
@@ -22,6 +22,11 @@ class Command(BaseShpShpImporter):
     This will provide coverage for all but one of the districts.
     """
     stations_name  = 'rev02-2016/polling district boundaries 2016.shp'
+    elections      = [
+        'sp.c.2016-05-05',
+        'sp.r.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_guildford.py
+++ b/polling_stations/apps/data_collection/management/commands/import_guildford.py
@@ -19,6 +19,7 @@ class Command(BaseKamlImporter):
     # so we work with a version that has been repaired so it will parse properly
     districts_name = 'GuildfordBoroughCouncilPollingDistricts20150325-fixed.kml'
     stations_name  = 'GuildfordBoroughCouncilPollingPlaces20150325.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         # this kml has no altitude co-ordinates so the data is ok as it stands

--- a/polling_stations/apps/data_collection/management/commands/import_islington.py
+++ b/polling_stations/apps/data_collection/management/commands/import_islington.py
@@ -12,6 +12,7 @@ class Command(BaseShpImporter):
     council_id = 'E09000019'
     districts_name = 'POLLING_AREA'
     stations_name = 'PollingStations.csv'
+    elections = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_kingston.py
+++ b/polling_stations/apps/data_collection/management/commands/import_kingston.py
@@ -14,7 +14,7 @@ class Command(BaseKamlImporter):
     council_id     = 'E09000021'
     districts_name = 'Polling_districts.kmz'
     stations_name  = 'Polling_stations.csv'
-
+    elections      = ['parl.2015-05-07']
     csv_encoding   = 'latin-1'
 
     def station_record_to_dict(self, record):

--- a/polling_stations/apps/data_collection/management/commands/import_lambeth.py
+++ b/polling_stations/apps/data_collection/management/commands/import_lambeth.py
@@ -12,6 +12,7 @@ class Command(BaseJasonImporter):
     council_id     = 'E09000022'
     districts_name = 'LambethPollingDistricts.json'
     stations_name  = 'LambethPollingStations_0.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         properties = record['properties']

--- a/polling_stations/apps/data_collection/management/commands/import_lichfield.py
+++ b/polling_stations/apps/data_collection/management/commands/import_lichfield.py
@@ -12,6 +12,7 @@ class Command(BaseShpImporter):
     council_id     = 'E07000194'
     districts_name = 'Lichfield_District_Council_Polling_Districts'
     stations_name  = 'Lichfield_District_Council_Polling_Station_Locations.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_mid_sussex.py
+++ b/polling_stations/apps/data_collection/management/commands/import_mid_sussex.py
@@ -13,6 +13,7 @@ class Command(BaseKamlImporter):
     council_id     = 'E07000228'
     districts_name = 'msdc_3830_pollingdistricts_polygon.kmz'
     stations_name  = 'R3900_pollingstations.csv'
+    elections      = ['parl.2015-05-07']
 
     def extract_msercode_from_description(self, description):
         html = etree.HTML(str(description).replace('&', '&amp;'))

--- a/polling_stations/apps/data_collection/management/commands/import_north_tyneside.py
+++ b/polling_stations/apps/data_collection/management/commands/import_north_tyneside.py
@@ -13,6 +13,7 @@ class Command(BaseShpImporter):
     council_id     = 'E08000022'
     districts_name = 'NT_Polling_Districts_2014'
     stations_name  = 'NT_Polling_Stations_2015.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {
@@ -41,7 +42,7 @@ class Command(BaseShpImporter):
         Insert them in the DB with address = "Address not supplied"
         on the basis we can still provide directions to the grid ref.
         """
-        if address = '' and postcode = '':
+        if address == '' and record.place_pcod == '':
             address = "Address not supplied"
 
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_oadby.py
+++ b/polling_stations/apps/data_collection/management/commands/import_oadby.py
@@ -15,6 +15,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E07000135'
     districts_name = 'Polling Districts'
     stations_name  = 'Polling_Stations.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_pembrokeshire.py
+++ b/polling_stations/apps/data_collection/management/commands/import_pembrokeshire.py
@@ -14,6 +14,12 @@ class Command(BaseApiKmlKmlImporter):
     council_id       = 'W06000009'
     districts_url    = 'http://www.pembrokeshire.gov.uk/geoserver/maps/live/wms?LAYERS=tblPollingDistrict&FORMAT=application/vnd.google-earth.kml+xml&TRANSPARENT=TRUE&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&SRS=EPSG%3A27700&BBOX=162666.9591241047,187007.85481671634,234800.000001,260094.71375428123&WIDTH=256&HEIGHT=256'
     stations_url     = 'http://www.pembrokeshire.gov.uk/geoserver/maps/live/wms?LAYERS=tblPollingStation&FORMAT=application/vnd.google-earth.kml+xml&TRANSPARENT=TRUE&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&SRS=EPSG%3A27700&BBOX=162666.9591241047,187007.85481671634,234800.000001,260094.71375428123&WIDTH=256&HEIGHT=256'
+    elections        = [
+        'pcc.2016-05-05',
+        'naw.c.2016-05-05',
+        'naw.r.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def extract_info_from_district_description(self, description):
         # lxml needs everything to be enclosed in one root element

--- a/polling_stations/apps/data_collection/management/commands/import_plymouth.py
+++ b/polling_stations/apps/data_collection/management/commands/import_plymouth.py
@@ -17,6 +17,7 @@ class Command(BaseKamlImporter):
     council_id     = 'E06000026'
     districts_name = 'Plymouth_Polling_Districts.kml'
     stations_name  = 'Plymouth Polling Stations.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         # this kml has no altitude co-ordinates so the data is ok as it stands

--- a/polling_stations/apps/data_collection/management/commands/import_rct.py
+++ b/polling_stations/apps/data_collection/management/commands/import_rct.py
@@ -19,6 +19,12 @@ class Command(BaseAddressCsvImporter):
     council_id      = 'W06000016'
     addresses_name  = 'PROPERTYLISTINGFORDEMOCRACYCLUB.csv'
     stations_name   = 'POLLINGSTATIONS8MARCH2016.csv'
+    elections       = [
+        'pcc.2016-05-05',
+        'naw.c.2016-05-05',
+        'naw.r.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def station_record_to_dict(self, record):
 

--- a/polling_stations/apps/data_collection/management/commands/import_reading.py
+++ b/polling_stations/apps/data_collection/management/commands/import_reading.py
@@ -12,6 +12,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E06000038'
     districts_name = 'polling_districts'
     stations_name  = 'polling_stations.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_runnymede.py
+++ b/polling_stations/apps/data_collection/management/commands/import_runnymede.py
@@ -12,6 +12,7 @@ class Command(BaseShpImporter):
     council_id     = 'E07000212'
     districts_name = 'RBC_Polling_Districts'
     stations_name  = 'RBC_Polling_Stations.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_salford.py
+++ b/polling_stations/apps/data_collection/management/commands/import_salford.py
@@ -13,6 +13,7 @@ class Command(BaseShpImporter):
     council_id     = 'E08000006'
     districts_name = 'Salford_Polling_Districts'
     stations_name  = 'Polling_Stations.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_sheffield.py
+++ b/polling_stations/apps/data_collection/management/commands/import_sheffield.py
@@ -10,6 +10,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E08000019'
     districts_name = 'SCCPollingDistricts2015'
     stations_name  = 'SCCPollingStations2015.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_south_cambridge.py
+++ b/polling_stations/apps/data_collection/management/commands/import_south_cambridge.py
@@ -13,6 +13,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E07000012'
     districts_name = 'Polling Districts for Twitter_region'
     stations_name  = 'Polling Stations for Twitter_point.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_south_tyneside.py
+++ b/polling_stations/apps/data_collection/management/commands/import_south_tyneside.py
@@ -12,6 +12,7 @@ class Command(BaseShpImporter):
     council_id     = 'E08000023'
     districts_name = 'Polling Districts_region'
     stations_name  = 'Polling Sites.csv'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_spelthorne.py
+++ b/polling_stations/apps/data_collection/management/commands/import_spelthorne.py
@@ -14,6 +14,7 @@ class Command(BaseKamlImporter):
     council_id     = 'E07000213'
     districts_name = 'Polling_Districts.kmz'
     stations_name  = 'Polling_Stations.csv'
+    elections      = ['parl.2015-05-07']
 
     def station_record_to_dict(self, record):
         try:

--- a/polling_stations/apps/data_collection/management/commands/import_telford.py
+++ b/polling_stations/apps/data_collection/management/commands/import_telford.py
@@ -11,6 +11,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E06000020'
     districts_name = 'Polling_Districts'
     stations_name  = 'Polling_Stations.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_tower_hamlets.py
+++ b/polling_stations/apps/data_collection/management/commands/import_tower_hamlets.py
@@ -12,6 +12,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E09000030'
     districts_name = 'Polling_Districts_2015'
     stations_name  = 'Polling_Stations_2015.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_vale_of_glamorgan.py
+++ b/polling_stations/apps/data_collection/management/commands/import_vale_of_glamorgan.py
@@ -10,6 +10,12 @@ class Command(BaseShpShpImporter):
     council_id     = 'W06000014'
     districts_name = 'Polling Districts'
     stations_name  = 'Polling Stations.shp'
+    elections      = [
+        'pcc.2016-05-05',
+        'naw.c.2016-05-05',
+        'naw.r.2016-05-05',
+        'ref.2016-06-23'
+    ]
 
     def district_record_to_dict(self, record):
 

--- a/polling_stations/apps/data_collection/management/commands/import_watford.py
+++ b/polling_stations/apps/data_collection/management/commands/import_watford.py
@@ -10,6 +10,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E07000103'
     districts_name = 'Watford_Polling_Districts'
     stations_name  = 'Watford_Polling_Stations.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_westberks.py
+++ b/polling_stations/apps/data_collection/management/commands/import_westberks.py
@@ -11,6 +11,7 @@ class Command(BaseShpShpImporter):
     council_id     = 'E06000037'
     districts_name = 'polling_districts'
     stations_name  = 'polling_places.shp'
+    elections      = ['parl.2015-05-07']
 
     def district_record_to_dict(self, record):
         return {

--- a/polling_stations/apps/data_collection/management/commands/import_wokingham.py
+++ b/polling_stations/apps/data_collection/management/commands/import_wokingham.py
@@ -11,6 +11,7 @@ class Command(BaseShpImporter):
     council_id     = 'E06000041'
     districts_name = ''
     stations_name  = 'POLLING_STATIONS_font_point.shp'
+    elections      = ['parl.2015-05-07']
 
     def import_polling_districts(self):
         # Because we don't have them :(

--- a/polling_stations/apps/data_collection/management/commands/teardown.py
+++ b/polling_stations/apps/data_collection/management/commands/teardown.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+from pollingstations.models import PollingStation, PollingDistrict, ResidentialAddress
+
+"""
+Clear PollingDistrict, PollingStation and ResidentialAddress models
+Clear report, num_addresses, num_districts and num_stations
+fields in DataQuality model
+"""
+class Command(BaseCommand):
+
+    def handle(self, *args, **kwargs):
+        PollingDistrict.objects.all().delete()
+        PollingStation.objects.all().delete()
+        ResidentialAddress.objects.all().delete()
+        # use raw SQL so we don't have to loop over every single record one-by-one
+        cursor = connection.cursor()
+        cursor.execute("UPDATE data_collection_dataquality SET report='', num_addresses=0, num_districts=0, num_stations=0")

--- a/polling_stations/apps/pollingstations/fixtures/test_polling_stations_station_id.json
+++ b/polling_stations/apps/pollingstations/fixtures/test_polling_stations_station_id.json
@@ -58,18 +58,6 @@
     {
         "fields": {
             "location": "",
-            "address": "Baz Community Centre, Bar Town",
-            "internal_council_id": "2",
-            "council": "X01000001",
-            "postcode": "",
-            "polling_district_id": ""
-        },
-        "model": "pollingstations.pollingstation",
-        "pk": 3
-    },
-    {
-        "fields": {
-            "location": "",
             "address": "St Norf's Church Hall, Qux Town",
             "internal_council_id": "1",
             "council": "X01000002",
@@ -77,7 +65,7 @@
             "polling_district_id": ""
         },
         "model": "pollingstations.pollingstation",
-        "pk": 4
+        "pk": 3
     },
     {
         "fields": {

--- a/polling_stations/apps/pollingstations/migrations/0010_auto_20160417_1416.py
+++ b/polling_stations/apps/pollingstations/migrations/0010_auto_20160417_1416.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('pollingstations', '0006_residentialaddress_slug'),
+        ('pollingstations', '0009_customfinder'),
     ]
 
     operations = [

--- a/polling_stations/apps/pollingstations/migrations/0010_auto_20160417_1416.py
+++ b/polling_stations/apps/pollingstations/migrations/0010_auto_20160417_1416.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pollingstations', '0006_residentialaddress_slug'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='pollingdistrict',
+            unique_together=set([('council', 'internal_council_id')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='pollingstation',
+            unique_together=set([('council', 'internal_council_id')]),
+        ),
+    ]

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -19,6 +19,9 @@ class PollingDistrict(models.Model):
     # the point of import
     polling_station_id  = models.CharField(blank=True, max_length=255)
 
+    class Meta:
+        unique_together = (("council", "internal_council_id"))
+
     objects = models.GeoManager()
 
     def __unicode__(self):
@@ -84,6 +87,9 @@ class PollingStation(models.Model):
     # This is NOT a FK, as we might not have the polling district at
     # the point of import
     polling_district_id  = models.CharField(blank=True, max_length=255)
+
+    class Meta:
+        unique_together = (("council", "internal_council_id"))
 
     objects = PollingStationManager()
 

--- a/polling_stations/apps/pollingstations/tests/test_polling_station_manager.py
+++ b/polling_stations/apps/pollingstations/tests/test_polling_station_manager.py
@@ -40,6 +40,9 @@ class PollingStationsTestBase:
 class PollingStationsStationIdTest(TestCase, PollingStationsTestBase):
     fixtures = ['test_polling_stations_station_id.json']
 
+    def test_multiple_matches(self):
+        pass
+
 # test lookup when PollingStation.district_id is set
 class PollingStationsDistrictIdTest(TestCase, PollingStationsTestBase):
     fixtures = ['test_polling_stations_district_id.json']


### PR DESCRIPTION
As discussed in the standup on Tusday, I've tagged all the import scripts with the election IDs they relate to and added a management command which can be used to run all of the import scripts relating to a list of election ids

e.g:

```
python manage.py import -e gla.c.2016-05-05 gla.a.2016-05-05 naw.r.2016-05-05
```

would import all of the data relating to elections `gla.c.2016-05-05`, `gla.a.2016-05-05` or `naw.r.2016-05-05`.

This now allows us to conveniently tear down the DB (using the `teardown` management command also added in this PR), apply the unique constraints and import any current data.

Notes:


## Tags/IDs

* As suggested, I've tagged all of the scripts relating to last year's data with `parl.2015-05-07` only. If there's any areas where you want to include the 2015 data, edit the `elections` property, or let me know and I'll make the changes. The one where you might want to include the old data is Salford as I'm aware you've had a [mention](http://salfordstar.com/article.asp?id=3174) there, so it would be nice to serve up data for them. Perhaps it would be better to request new data from Salford? West Berkshire have provided updated data (issue #228) so leave that one tagged as `parl.2015-05-07` - I'll update it when I look at #228. Same with South Cambs (although there's no data/issue in the repo for that yet).
* I've intentionally left some scripts un-tagged because they don't run. This will mean they get ignored (rather than attempting to run them, throwing an exception and leaving you in an inconsistent state) if you run `python manage.py import -e parl.2015-05-07`. I've intentionally set it up so that we can run that if we want to - e.g: for dev/testing setup.
* I **think** I've tagged all the current scripts with the correct election IDs, but you might want to give them a quick check.


## Data

I haven't done anything about tagging/versioning data files - just the import scripts. I think it is ok to leave re-organising the data files until another time.


## Dependencies - how the hell do I actually deploy/merge all this?

This PR, PR #239 and PR #240 should all merge to master without conflict, but in order to get all the migrations I've added to run correctly, I've had to make them all depend on each other. 0ff1538 means this PR depends on #240, which in turn depends on #239 due to cba49af.
Additionally:
* The teardown script references fields added in #239
* You can't apply migration 0010 until the teardown script has been run due to duplicates, so what you're going to need to do is either:

### Option 1
* Merge PR #239
* Merge PR #240
* `python manage.py migrate` (apply changes to DataQuality model, add CustomFinder model)
* Merge this PR
* `python manage.py teardown` (clear relevent DB fields/tables)
* `python manage.py migrate` (apply unique constraints)
* `python manage.py import -e ref.2016-06-23` (This will import everything current because all the recent import scripts are taged with `ref.2016-06-23` and the 2015 ones aren't. It will also fix the league_table output)

### Option 2
* Merge all 3 PRs
* `python manage.py migrate pollingstations 0009` (apply changes to DataQuality model, add CustomFinder model but don't apply 0010 yet)
* `python manage.py teardown` (clear relevent DB fields/tables)
* `python manage.py migrate` (apply unique constraints)
* `python manage.py import -e ref.2016-06-23` (This will import everything current because all the recent import scripts are taged with `ref.2016-06-23` and the 2015 ones aren't. It will also fix the league_table output)

Sorry this has all turned into a bit of a tangled web of migrations :(
Additionally, Travis is now marking the tests as failing on this PR and #240 because it can't apply the migrations. I have checked them on a branch with all 3 of these PRs merged on to it though and they do pass with the mods in 8195219 applied.


## Old issues

Given we're not going to serve up any of the 2015 data, are you happy for me to clean up the issue tracker by closing down all the old 'Import X01000001-Area Name' issues relating to 2015 data? I think the psychological edge of closing down ~50 issues would be beneficial :)


## Init fixture
The initial_data.json in the repo should probably be either updated, or just removed?


Closes #216
Closes #238