### PR TITLE
Add ability to switch to between tile layers easily

### DIFF
--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -91,6 +91,7 @@ class BasePollingStationView(
 
     def get_context_data(self, **context):
         context['tile_layer'] = settings.TILE_LAYER
+        context['mq_key'] = settings.MQ_KEY
 
         try:
             l = self.get_location()

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -4,6 +4,7 @@ import requests
 
 from operator import itemgetter
 
+from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, Http404
@@ -89,6 +90,8 @@ class BasePollingStationView(
             return None
 
     def get_context_data(self, **context):
+        context['tile_layer'] = settings.TILE_LAYER
+
         try:
             l = self.get_location()
         except PostcodeError as e:

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -1,4 +1,4 @@
-import sys
+import os, sys
 from os.path import join, abspath, dirname
 
 # PATH vars
@@ -209,6 +209,19 @@ LOGGING = {
         },
     }
 }
+
+"""
+Set a shell environment variable TILE_LAYER
+to configure which tile layer is used by leaflet.
+
+Default to map quest tiles.
+
+Supported values are:
+'MapQuestOpen' (default)
+'OpenStreetMap'
+"""
+TILE_LAYER = os.environ.get('TILE_LAYER', 'MapQuestOpen')
+
 
 from django.utils.translation import ugettext_lazy as _
 LANGUAGE_CODE = 'en'

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -211,16 +211,23 @@ LOGGING = {
 }
 
 """
+Map config:
+-----------
+
 Set a shell environment variable TILE_LAYER
 to configure which tile layer is used by leaflet.
 
-Default to map quest tiles.
-
 Supported values are:
 'MapQuestOpen' (default)
+'MapQuestSDK'
 'OpenStreetMap'
 """
 TILE_LAYER = os.environ.get('TILE_LAYER', 'MapQuestOpen')
+"""
+Set a shell environment variable MQ_KEY
+to specify MapQuestSDK API key.
+"""
+MQ_KEY = os.environ.get('MQ_KEY', None)
 
 
 from django.utils.translation import ugettext_lazy as _

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -178,12 +178,20 @@
       // map.doubleClickZoom.disable();
       map.scrollWheelZoom.disable();
 
-      L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}', {
+      {% if tile_layer == 'OpenStreetMap' %}
+      tiles = L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+        subdomains: 'abc'
+      });
+      {% else %}
+      tiles = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}', {
         type: 'map',
         ext: 'jpg',
         attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
         subdomains: '1234'
-      }).addTo(map); 
+      });
+      {% endif %}
+      tiles.addTo(map);
 
       {% if directions.route %}
       var pointList = [

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -178,20 +178,28 @@
       // map.doubleClickZoom.disable();
       map.scrollWheelZoom.disable();
 
-      {% if tile_layer == 'OpenStreetMap' %}
-      tiles = L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        subdomains: 'abc'
-      });
+      var tiles;
+      {% if tile_layer == 'MapQuestSDK' and mq_key %}
+        $.getScript("http://www.mapquestapi.com/sdk/leaflet/v2.s/mq-map.js?key={{ mq_key }}").done(function() {
+          tiles = MQ.tileLayer();
+          tiles.addTo(map);
+        });
       {% else %}
-      tiles = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}', {
-        type: 'map',
-        ext: 'jpg',
-        attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-        subdomains: '1234'
-      });
+        {% if tile_layer == 'OpenStreetMap' %}
+        tiles = L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+            subdomains: 'abc'
+        });
+        {% else %}
+        tiles = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.{ext}', {
+            type: 'map',
+            ext: 'jpg',
+            attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+            subdomains: '1234'
+        });
+        {% endif %}
+        tiles.addTo(map);
       {% endif %}
-      tiles.addTo(map);
 
       {% if directions.route %}
       var pointList = [


### PR DESCRIPTION
Add ability to switch to between tile layers easily

This PR adds the ability to control which tile layer is used by setting environment variables. It should merge cleanly with PR #253.

Options are:

* To use the MapQuest Open tile layer, either do nothing (this is the default behaviour) or set env var `TILE_LAYER='MapQuestOpen'`
* To use the OpenStreetMap tile layer, set env var `TILE_LAYER='OpenStreetMap'`
* To use the MapQuest developer API, [sign up for an free API key](https://developer.mapquest.com/plan_purchase/steps/business_edition/business_edition_free/register) and set env vars `TILE_LAYER='MapQuestSDK'` and `MQ_KEY='your api key'`

# Advantages/disadvantages:

## MapQuestOpen

* The MapQuestOpen tile layer is limited to 15,000 transactions per month. If/when we hit that limit, it will just stop working - we won't get a notification.
* Usage will be identified by referrer in http header. One thing I'm not clear on is if this means it will count hits from http://wheredoivote.wales/ http://bleibleidleisio.cymru/ and http://pollingstations.democracyclub.org.uk/ as being 3 different sites, or if it will count them as one site because they all resolve to the same IP. There isn't really any way to know that - it is kind of a closed box..

## MapQuest developer

* The MapQuest developer API is also limited to 15,000 transactions. If you sign up for an API key, you'll get an email notification at 12,000 and 13,500 transactions, providing a warning to switch to another layer.
* If you use the MapQuest developer API, all 3 sites will (presumably) be sharing the same API key so that allowance of 15,000 transactions will definitely be shared across the various domains.
* Wierdly the MapQuest developer API doesn't use the same tiles as MapQuestOpen - it uses the MapBox tiles. They seem to now be working [in partnership](http://techcrunch.com/2015/06/09/mapquest-confirms-mapbox-partnership/). I think they are still cleaner/less busy than the OSM tiles. You may like them more or less.

## OSM Tiles

* OSM tiles are subject to a [usage policy](http://wiki.openstreetmap.org/wiki/Tile_usage_policy#Requirements) but there's no hard limit. They are probably the least aesthetically pleasing.


..so there's some swings and roundabouts there. I'll leave it to you to decide what you want to do, but now you at least have some options and a way to quickly fix things if the site maxes out the MapQuest limit.

I'm going to deal with some other stuff (Neath PT import script, email signup, looking into performance considerations) first, but after that if I have some time I will have a go at setting up a VM with NGNIX on it and see if we can work some cache magic with `try_files`. I've never used NGNIX before though so if I don't manage anything, this should allow you to keep the lights on.
