### PR TITLE
Use custom mapit install with env vars, handle hitting rate limit

### DIFF
--- a/polling_stations/api.py
+++ b/polling_stations/api.py
@@ -91,7 +91,12 @@ class PollingDistrictViewSet(viewsets.ModelViewSet):
     serializer_class = PollingDistrictSerializer
 
 from rest_framework.response import Response
-from data_finder.helpers import PostcodeError, geocode, RoutingHelper
+from data_finder.helpers import (
+    geocode,
+    PostcodeError,
+    RateLimitError,
+    RoutingHelper
+)
 from django.contrib.gis.geos import Point
 
 
@@ -114,7 +119,7 @@ class PostcodeViewSet(viewsets.ViewSet):
 
         try:
             l = geocode(pk)
-        except PostcodeError as e:
+        except (PostcodeError, RateLimitError) as e:
             ret['error'] = e.args[0]
             return Response(ret)
 

--- a/polling_stations/apps/data_collection/constants.py
+++ b/polling_stations/apps/data_collection/constants.py
@@ -1,4 +1,8 @@
-MAPIT_URL = "http://mapit.mysociety.org/"
+import os
+
+MAPIT_URL = os.environ.get('MAPIT_URL', "http://mapit.mysociety.org/")
+MAPIT_UA = os.environ.get('MAPIT_UA', None)
+
 GOV_UK_LA_URL = "https://www.registertovote.service.gov.uk/register-to-vote/local-authority/"
 
 COUNCIL_TYPES = [

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -1,5 +1,6 @@
 import requests
 import re
+import logging
 import lxml.etree
 from collections import namedtuple
 
@@ -10,12 +11,13 @@ from data_collection import constants
 
 from pollingstations.models import ResidentialAddress
 
-
 class PostcodeError(Exception):
     pass
 
 class RateLimitError(Exception):
-    pass
+    def __init__(self, message):
+        logger = logging.getLogger('django.request')
+        logger.error(message)
 
 
 def geocode(postcode):

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -25,6 +25,7 @@ from .helpers import (
     DirectionsHelper,
     natural_sort,
     PostcodeError,
+    RateLimitError,
     RoutingHelper
 )
 
@@ -91,8 +92,8 @@ class BasePollingStationView(
     def get_context_data(self, **context):
         try:
             l = self.get_location()
-        except PostcodeError as e:
-            context['error'] = e
+        except (PostcodeError, RateLimitError) as e:
+            context['error'] = str(e)
             return context
 
         if l is None:

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -31,11 +31,15 @@
     {% if error %}
 
       {% if error == 'Mapit error 403: Rate limit exceeded' %}
+      {% blocktrans %}
       <h2>Sorry, we're a bit busy right now!</h2>
       <p>Try again in a few minutes.</p>
+      {% endblocktrans %}
       {% else %}
+      {% blocktrans %}
       <h2>Sorry, we can't find {{ postcode }}</h2>
       <p>This doesn't appear to be a valid postcode.</p>
+      {% endblocktrans %}
       <form method="post" action="{% url 'home' %}" class="form form-inline">
           {% csrf_token %}
           <label class="card_header">{% trans "Enter Your Postcode" %}

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -30,6 +30,10 @@
     <div class="card">
     {% if error %}
 
+      {% if error == 'Mapit error 403: Rate limit exceeded' %}
+      <h2>Sorry, we're a bit busy right now!</h2>
+      <p>Try again in a few minutes.</p>
+      {% else %}
       <h2>Sorry, we can't find {{ postcode }}</h2>
       <p>This doesn't appear to be a valid postcode.</p>
       <form method="post" action="{% url 'home' %}" class="form form-inline">
@@ -42,6 +46,7 @@
           </p>
           <button type="submit" class="button" id="submit-postcode">{% trans "Find your Polling Station" %}</button>
       </form>
+      {% endif %}
 
     {% else %}
 


### PR DESCRIPTION
* We can now set environment vars `MAPIT_URL` and `MAPIT_UA` to specify a custom url and user agent for calls to mapit. If not set, the default is http://mapit.mysociety.org/ and blank user agent.

* If using MySociety's mapit install and we hit their rate limit, show a slightly more user-friendly error message.