### PR TITLE
Copy clean-up for polling stations campaign sign-up

### DIFF
--- a/polling_stations/templates/campaign_signup.html
+++ b/polling_stations/templates/campaign_signup.html
@@ -2,7 +2,7 @@
 {% if request.brand == 'democracyclub' %}
 <div class="card" id="campaign_form">
   {% blocktrans %}
-  <p>We think everyone should be able to find this information online. If you
+  <p>We think everyone should be able to find their polling station online. If you
   agree, please sign up below. If enough people in your local area sign up, we
   will contact the head of your council on your behalf. We won’t share your
   email address with them or anyone else.</p>
@@ -22,7 +22,7 @@
 
     <label for="join" style="display: inline;">
     {% blocktrans %}Yes, I’d like to join Democracy Club (it’s free!) to help
-    make democracy work better for everyone. (Joins Full Mailing List){% endblocktrans %}
+    make democracy work better for everyone.{% endblocktrans %}
     </label>
     </div>
 


### PR DESCRIPTION
Changed 'this' for 'find their polling station'. 

Removed the bit about full mailing list.