### PR TITLE
Replace register to vote text (w/7th June date)

### DIFF
--- a/locale/cy_GB/LC_MESSAGES/django.po
+++ b/locale/cy_GB/LC_MESSAGES/django.po
@@ -108,10 +108,15 @@ msgstr "\n<h3>Nid yw cerdyn pleidleisio yn angenrheidiol er mwyn pleidleisio</h3
 msgid ""
 "\n"
 "        <h3>You need to be registered in order to vote</h3>\n"
-"        <p>If you aren’t registered to vote visit <a href=\"https://www.gov.uk/register-to-vote\">https://www.gov.uk/register-to-vote</a> <strong>before the 18th of April</strong>.</p>\n"
+"        <p>If you aren’t registered to vote visit <a href=\"https://www.gov.uk/register-to-vote\">https://www.gov.uk/register-to-vote</a>"
+msgstr "\n<h3>Rhaid eich bod wedi cofrestru i bleidleisio</h3>\n<p>Os nad ydych wedi cofrestru i bleidleisio ewch i <a href=\"https://www.gov.uk/cofrestru-i-bleidleisio\">https://www.gov.uk/cofrestru-i-bleidleisio</a>"
+
+#: polling_stations/templates/postcode_view.html:158
+msgid ""
 "\n"
+"        <strong>before the 18th of April</strong>.</p>\n"
 "        "
-msgstr "\n<h3>Rhaid eich bod wedi cofrestru i bleidleisio</h3>\n<p>Os nad ydych wedi cofrestru i bleidleisio ewch i <a href=\"https://www.gov.uk/cofrestru-i-bleidleisio\">https://www.gov.uk/cofrestru-i-bleidleisio</a> <strong>cyn y 18fed o Ebrill 2016</strong>.</p>"
+msgstr "\n<strong>cyn y 18fed o Ebrill 2016</strong>.</p>\n        "
 
 #: polling_stations/templates/postcode_view.html:88
 msgid "Council Contact info"

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -154,8 +154,9 @@
     <div class="card">
         {% blocktrans %}
         <h3>You need to be registered in order to vote</h3>
-        <p>If you aren’t registered to vote visit <a href="https://www.gov.uk/register-to-vote">https://www.gov.uk/register-to-vote</a> <strong>before the 7th of June</strong>.</p>
-
+        <p>If you aren’t registered to vote visit <a href="https://www.gov.uk/register-to-vote">https://www.gov.uk/register-to-vote</a>{% endblocktrans %}
+        {% blocktrans %}
+        <strong>before the 7th of June</strong>.</p>
         {% endblocktrans %}
     </div>
 

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -156,7 +156,7 @@
         <h3>You need to be registered in order to vote</h3>
         <p>If you aren’t registered to vote visit <a href="https://www.gov.uk/register-to-vote">https://www.gov.uk/register-to-vote</a>{% endblocktrans %}
         {% blocktrans %}
-        <strong>before the 7th of June</strong>.</p>
+        <strong>before 7 June</strong>.</p>
         {% endblocktrans %}
     </div>
 

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -151,23 +151,23 @@
         {% endblocktrans %}
     </div>
 
-    {# <div class="card"> #}
-    {#     {% blocktrans %} #}
-    {#     <h3>You need to be registered in order to vote</h3> #}
-    {#     <p>If you aren’t registered to vote visit <a href="https://www.gov.uk/register-to-vote">https://www.gov.uk/register-to-vote</a> <strong>before the 18th of April</strong>.</p> #}
-    {#  #}
-    {#     {% endblocktrans %} #}
-    {# </div> #}
-
     <div class="card">
         {% blocktrans %}
-        <h3>Information on your candidates</h3>
-        <p>You can find information on your candidates at <a href="https://whocanivotefor.co.uk/elections/{{ postcode }}">
-          WhoCanIVoteFor.co.uk
-        </a></p>
+        <h3>You need to be registered in order to vote</h3>
+        <p>If you aren’t registered to vote visit <a href="https://www.gov.uk/register-to-vote">https://www.gov.uk/register-to-vote</a> <strong>before the 7th of June</strong>.</p>
 
         {% endblocktrans %}
     </div>
+
+    {# <div class="card"> #}
+    {#     {% blocktrans %} #}
+    {#     <h3>Information on your candidates</h3> #}
+    {#     <p>You can find information on your candidates at <a href="https://whocanivotefor.co.uk/elections/{{ postcode }}"> #}
+    {#       WhoCanIVoteFor.co.uk #}
+    {#     </a></p> #}
+    {#  #}
+    {#     {% endblocktrans %} #}
+    {# </div> #}
 
 
     {% if council.address or council.postcode or council.phone or council.email %}


### PR DESCRIPTION
Put the 'You need to be registered in order to vote' text back in with registration deadline for EU Referendum.

Note: because I've changed the date, the English text for this `blocktrans` has changed so we'll need to update the translation accordingly for the Welsh version