### PR TITLE
Remove link to WhoCanIVoteFor in sidebar

### DIFF
--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -166,15 +166,15 @@
     {#     {% endblocktrans %} #}
     {# </div> #}
 
-    <div class="card">
-        {% blocktrans %}
-        <h3>Information on your candidates</h3>
-        <p>You can find information on your candidates at <a href="https://whocanivotefor.co.uk/elections/{{ postcode }}">
-          WhoCanIVoteFor.co.uk
-        </a></p>
-
-        {% endblocktrans %}
-    </div>
+    {# <div class="card"> #}
+    {#     {% blocktrans %} #}
+    {#     <h3>Information on your candidates</h3> #}
+    {#     <p>You can find information on your candidates at <a href="https://whocanivotefor.co.uk/elections/{{ postcode }}"> #}
+    {#       WhoCanIVoteFor.co.uk #}
+    {#     </a></p> #}
+    {#  #}
+    {#     {% endblocktrans %} #}
+    {# </div> #}
 
 
     {% if council.address or council.postcode or council.phone or council.email %}


### PR DESCRIPTION
WCIVF isn’t relevant for the EU ref, and shouldn’t be mentioned.