### PR TITLE
Change default tile layer to OSM

### DIFF
--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -227,7 +227,7 @@ Supported values are:
 'MapQuestSDK'
 'OpenStreetMap'
 """
-TILE_LAYER = os.environ.get('TILE_LAYER', 'MapQuestOpen')
+TILE_LAYER = os.environ.get('TILE_LAYER', 'OpenStreetMap')
 """
 Set a shell environment variable MQ_KEY
 to specify MapQuestSDK API key.


### PR DESCRIPTION
Should fix #345 in prod if you haven't manually set an env var `TILE_LAYER`