### PR TITLE
Change default MAPIT_URL to http://mapit.democracyclub.org.uk/

### DIFF
--- a/polling_stations/apps/data_collection/constants.py
+++ b/polling_stations/apps/data_collection/constants.py
@@ -2,7 +2,7 @@ import os
 
 from django.conf import settings
 
-MAPIT_URL = os.environ.get('MAPIT_URL', "http://mapit.mysociety.org/")
+MAPIT_URL = os.environ.get('MAPIT_URL', "http://mapit.democracyclub.org.uk/")
 MAPIT_UA = os.environ.get('MAPIT_UA', None)
 
 GOV_UK_LA_URL = "https://www.registertovote.service.gov.uk/register-to-vote/local-authority/"

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-with-address-picker/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-with-address-picker/then-i-submit-the-only-form.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.7.0 CPython/3.4.3 Darwin/15.2.0]
     method: GET
-    uri: http://mapit.mysociety.org//postcode/BB11BB
+    uri: http://mapit.democracyclub.org.uk//postcode/BB11BB
   response:
     body:
       string: !!binary |

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-without-address-picker/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-without-address-picker/then-i-submit-the-only-form.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.7.0 CPython/3.4.3 Darwin/15.2.0]
     method: GET
-    uri: http://mapit.mysociety.org//postcode/NP205GN
+    uri: http://mapit.democracyclub.org.uk//postcode/NP205GN
   response:
     body:
       string: !!binary |


### PR DESCRIPTION
Anonymous usage of Mysociety's Mapit is now rate-limited to 10 calls per minute: http://mapit.mysociety.org/account/signup/

I've proposed switching the default to DC's mapit as this is what I'm using in dev at the moment. Possibly we want to add the ability to specify a mapit key? Can discuss when we catch up..


Just to give you a quick update on the bigger picture, I know I've been quiet for a bit, but I've got some major changes to the base import classes in progress - just not ready for a PR yet. I am on the case though :)


