### PR TITLE
Add BaseMorphApiImporter class

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -14,9 +14,11 @@ from argparse import ArgumentTypeError
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.contrib.gis import geos
+from django.contrib.gis.gdal import DataSource
 from django.contrib.gis.geos import Point, GEOSGeometry
 from django.db import connection
 from django.db import transaction
+from django.utils.encoding import force_bytes
 
 from councils.models import Council
 from data_collection.data_types import (
@@ -367,18 +369,18 @@ class BaseDistrictsImporter(BaseImporter, metaclass=abc.ABCMeta):
                 district_info['council'] = self.council
 
             """
-            If the file type is shp or json, we can usually derive
+            If the file type is shp or geojson, we can usually derive
             'area' automatically, but we can return it if necessary.
             For other file types, we must return the key
             'area' from address_record_to_dict()
             """
             if self.districts_filetype == 'shp':
                 geojson = json.dumps(district.shape.__geo_interface__)
-            if self.districts_filetype == 'json':
+            if self.districts_filetype == 'geojson':
                 geojson = json.dumps(district['geometry'])
             if 'location' not in district_info and\
                     (self.districts_filetype == 'shp' or\
-                     self.districts_filetype == 'json'):
+                     self.districts_filetype == 'geojson'):
                 poly = self.clean_poly(
                     GEOSGeometry(geojson, srid=self.get_srid('districts')))
                 district_info['area'] = poly
@@ -508,11 +510,11 @@ class BaseCsvStationsJsonDistrictsImporter(BaseStationsDistrictsImporter,
                                            CsvMixin):
     """
     Stations in CSV format
-    Districts in JSON format
+    Districts in GeoJSON format
     """
 
     stations_filetype = 'csv'
-    districts_filetype = 'json'
+    districts_filetype = 'geojson'
 
 
 class BaseCsvStationsKmlDistrictsImporter(BaseStationsDistrictsImporter,
@@ -605,3 +607,72 @@ class BaseApiKmlStationsKmlDistrictsImporter(BaseGenericApiImporter):
 
     stations_filetype = 'kml'
     districts_filetype = 'kml'
+
+
+class BaseMorphApiImporter(BaseGenericApiImporter, metaclass=abc.ABCMeta):
+
+    base_url = 'https://api.morph.io/'
+    stations_query = '/data.json?query=select%20*%20from%20%27stations%27%3B'
+    districts_query = '/data.json?query=select%20*%20from%20%27districts%27%3B'
+    stations_filetype = 'json'
+    districts_filetype = 'json'
+    srid = 4326
+    districts_srid = 4326
+
+    @property
+    @abc.abstractmethod
+    def scraper_name(self):
+        pass
+
+    @property
+    def morph_api_key(self):
+        key = getattr(settings, 'MORPH_API_KEY', '')
+        if key == '':
+            raise NotImplementedError('MORPH_API_KEY must be set')
+        return key
+
+    @property
+    def stations_url(self):
+        return "%s%s%s&key=%s" % (
+            self.base_url, self.scraper_name, self.stations_query, self.morph_api_key)
+
+    @property
+    def districts_url(self):
+        return "%s%s%s&key=%s" % (
+            self.base_url, self.scraper_name, self.districts_query, self.morph_api_key)
+
+    def extract_geometry(self, record, format, srid):
+        if format == 'geojson':
+            return self.extract_json_geometry(record, srid)
+        elif format == 'gml':
+            return self.extract_gml_geometry(record, srid)
+        else:
+            raise ValueError("Unsupported format: %s" % (format))
+
+    def extract_json_geometry(self, record, srid):
+        geom = json.loads(record['geometry'])
+        geojson = json.dumps(geom['geometry'])
+        return self.clean_poly(GEOSGeometry(geojson, srid=srid))
+
+    def extract_gml_geometry(self, record, srid):
+        """
+        This is a bit of a hack
+
+        In this version of Django, there is no way to directly create an
+        OGRGeometry or GEOSGeometry object directly from a GML string but we
+        can do it by writing it out to a file and then reading it back in with
+        DataSource().
+
+        This functionality will be added in Django 1.11
+        https://docs.djangoproject.com/en/dev/releases/1.11/#django-contrib-gis
+        """
+
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(force_bytes(record['geometry']))
+            tmp.seek(0)
+            ds = DataSource(tmp.name)
+            if len(ds[0]) == 1:
+                geojson = next(iter(ds[0])).geom.geojson
+                return self.clean_poly(GEOSGeometry(geojson, srid=srid))
+            else:
+                raise ValueError("Expected 1 feature, found %i" % len(ds[0]))

--- a/polling_stations/apps/data_collection/filehelpers.py
+++ b/polling_stations/apps/data_collection/filehelpers.py
@@ -65,9 +65,9 @@ class ShpHelper:
 
 
 """
-Helper class for reading geographic data from (Geo)JSON files
+Helper class for reading geographic data from GeoJSON files
 """
-class JsonHelper:
+class GeoJsonHelper:
 
     def __init__(self, filepath):
         self.filepath = filepath
@@ -75,6 +75,18 @@ class JsonHelper:
     def get_features(self):
         geometries = json.load(open(self.filepath))
         return geometries['features']
+
+
+"""
+Helper class for reading data from JSON files
+"""
+class JsonHelper:
+
+    def __init__(self, filepath):
+        self.filepath = filepath
+
+    def get_features(self):
+        return json.load(open(self.filepath))
 
 
 """
@@ -125,7 +137,9 @@ class FileHelperFactory():
             return ShpHelper(filepath)
         elif (filetype == 'kml'):
             return KmlHelper(filepath)
-        elif (filetype == 'json'):
+        elif (filetype == 'geojson'):
+            return GeoJsonHelper(filepath)
+        elif filetype == 'json':
             return JsonHelper(filepath)
         elif (filetype == 'csv'):
             return CsvHelper(filepath, options['encoding'], options['delimiter'])

--- a/polling_stations/apps/data_collection/management/commands/__init__.py
+++ b/polling_stations/apps/data_collection/management/commands/__init__.py
@@ -6,4 +6,5 @@ from data_collection.base_importers import (
     BaseCsvStationsCsvAddressesImporter,
     BaseShpStationsCsvAddressesImporter,
     BaseApiKmlStationsKmlDistrictsImporter,
+    BaseMorphApiImporter,
 )

--- a/polling_stations/apps/data_collection/management/commands/import_city_of_london.py
+++ b/polling_stations/apps/data_collection/management/commands/import_city_of_london.py
@@ -1,33 +1,22 @@
-"""
-Imports City of London
-"""
-from django.contrib.gis.geos import GEOSGeometry
-from data_collection.management.commands import BaseApiKmlStationsKmlDistrictsImporter
+from data_collection.management.commands import BaseMorphApiImporter
 
-class Command(BaseApiKmlStationsKmlDistrictsImporter):
-    """
-    Imports the Polling Station data from City of London Corporation
-    """
-    srid             = 27700
-    districts_srid   = 27700
-    council_id       = 'E09000001'
-    districts_url    = 'http://www.mapping2.cityoflondon.gov.uk/arcgis/services/INSPIRE/MapServer/WFSServer?request=GetFeature&version=1.1.0&service=wfs&typeNames=INSPIRE:UK_Parliamentary_General_Election_Polling_Districts'
-    stations_url     = 'http://www.mapping2.cityoflondon.gov.uk/arcgis/services/INSPIRE/MapServer/WFSServer?request=GetFeature&version=1.1.0&service=wfs&typeNames=INSPIRE:UK_Parliamentary_General_Election_Polling_Places'
-    """
-    note:
-    These aren't actually KML - they're QML (hence use of SRID 27700)
-    but gdal.DataSource will just deal with them for us :)
-    """
+class Command(BaseMorphApiImporter):
+
+    srid = 27700
+    districts_srid = 27700
+    council_id = 'E09000001'
     elections = [
         'gla.c.2016-05-05',
         'gla.a.2016-05-05',
         'mayor.london.2016-05-05',
-        'ref.2016-06-23'
+        'ref.2016-06-23',
     ]
+    scraper_name = 'wdiv-scrapers/DC-PollingStations-CityOfLondon'
+    geom_type = 'gml'
+
 
     def district_record_to_dict(self, record):
-        geojson = record.geom.geojson
-        poly = self.clean_poly(GEOSGeometry(geojson, srid=self.get_srid('districts')))
+        poly = self.extract_geometry(record, self.geom_type, self.get_srid('districts'))
 
         return {
             'internal_council_id': record['OBJECTID'],
@@ -35,9 +24,9 @@ class Command(BaseApiKmlStationsKmlDistrictsImporter):
             'area'               : poly
         }
 
+
     def station_record_to_dict(self, record):
-        geojson = record.geom.geojson
-        location = GEOSGeometry(geojson, srid=self.get_srid())
+        location = self.extract_geometry(record, self.geom_type, self.get_srid('stations'))
 
 
         # format address and postcode

--- a/polling_stations/apps/data_collection/management/commands/import_ealing.py
+++ b/polling_stations/apps/data_collection/management/commands/import_ealing.py
@@ -1,67 +1,33 @@
-"""
-Imports Ealing
-"""
-from lxml import etree
-from django.contrib.gis.geos import GEOSGeometry
-from data_collection.management.commands import BaseApiKmlStationsKmlDistrictsImporter
+from data_collection.management.commands import BaseMorphApiImporter
 
-class Command(BaseApiKmlStationsKmlDistrictsImporter):
-    """
-    Imports the Polling Station data from Ealing Council
-    """
-    srid             = 4326
-    districts_srid   = 4326
-    council_id       = 'E09000009'
-    districts_url    = 'http://inspire.misoportal.com/geoserver/london_borough_of_ealing_polling_district_polygon/ows?VERSION=1.1.1&REQUEST=GetMap&SERVICE=WMS&LAYERS=london_borough_of_ealing_polling_district_polygon&STYLES=&BBOX=-0.61059285604864,51.410208305472,0.022513608765178,51.630693143964&SRS=EPSG%3A4258&WIDTH=1005&HEIGHT=349&FORMAT=application/rss+xml&TRANSPARENT=TRUE'
-    """
-    districts_url isn't KML - it is GeoRSS
-    but gdal.DataSource will just deal with it
-    because it is made from magic and awesome! :D
-    """
-    stations_url     = 'http://inspire.misoportal.com/geoserver/london_borough_of_ealing_polling_station_location_point/ows?VERSION=1.1.1&REQUEST=GetMap&SERVICE=WMS&LAYERS=london_borough_of_ealing_polling_station_location_point&STYLES=&BBOX=-0.61059285604864,51.410208305472,0.022513608765178,51.630693143964&SRS=EPSG%3A4258&WIDTH=1005&HEIGHT=349&FORMAT=application/vnd.google-earth.kml+xml&TRANSPARENT=TRUE'
-    elections        = [
+class Command(BaseMorphApiImporter):
+
+    srid = 4326
+    districts_srid  = 4326
+    council_id = 'E09000009'
+    elections = [
         'gla.c.2016-05-05',
         'gla.a.2016-05-05',
         'mayor.london.2016-05-05',
-        'ref.2016-06-23'
+        'ref.2016-06-23',
     ]
-
-    def extract_info_from_district_description(self, description):
-        # lxml needs everything to be enclosed in one root element
-        html = etree.XML('<div>' + str(description).replace('&', '&amp;') + '</div>')
-        return {
-            'distcode': html[1][0][1].text,
-            'wardname': html[1][1][1].text
-        }
+    scraper_name = 'wdiv-scrapers/DC-PollingStations-Ealing'
+    geom_type = 'geojson'
 
     def district_record_to_dict(self, record):
-        geojson = record.geom.geojson
-        poly = self.clean_poly(GEOSGeometry(geojson, srid=self.get_srid('districts')))
-        info = self.extract_info_from_district_description(record['description'])
+        poly = self.extract_geometry(record, self.geom_type, self.get_srid('districts'))
         return {
-            'internal_council_id': info['distcode'],
-            'name'               : "%s - %s" % (info['wardname'], info['distcode']),
+            'internal_council_id': record['distcode'],
+            'name'               : "%s - %s" % (record['wardname'], record['distcode']),
             'area'               : poly
         }
 
-    def extract_info_from_station_description(self, description):
-        # lxml needs everything to be enclosed in one root element
-        html = etree.XML('<div>' + str(description).replace('&', '&amp;') + '</div>')
-        data = {
-            'polling_station': html[1][0][1].text,
-            'pollingdistrict': html[1][1][1].text,
-            'mi_ss':           html[1][2][1].text,
-        }
-        return data
-
     def station_record_to_dict(self, record):
-        geojson = record.geom.geojson
-        location = GEOSGeometry(geojson, srid=self.get_srid())
-        info = self.extract_info_from_station_description(record['description'])
+        location = self.extract_geometry(record, self.geom_type, self.get_srid('stations'))
         return {
-            'internal_council_id': info['pollingdistrict'],
+            'internal_council_id': record['pollingdistrict'],
             'postcode':            '',
-            'address':             info['polling_station'],
+            'address':             record['polling_station'],
             'location':            location,
-            'polling_district_id': info['pollingdistrict']
+            'polling_district_id': record['pollingdistrict']
         }

--- a/polling_stations/apps/data_collection/management/commands/import_guildford.py
+++ b/polling_stations/apps/data_collection/management/commands/import_guildford.py
@@ -1,61 +1,28 @@
-"""
-Imports Guildford
-"""
-from django.contrib.gis.geos import Point, GEOSGeometry
+from data_collection.management.commands import BaseMorphApiImporter
 
-from data_collection.management.commands import BaseCsvStationsKmlDistrictsImporter
-from data_collection.google_geocoding_api_wrapper import (
-    GoogleGeocodingApiWrapper,
-    PostcodeNotFoundException
-)
+class Command(BaseMorphApiImporter):
 
-
-class Command(BaseCsvStationsKmlDistrictsImporter):
-    """
-    Imports the Polling Station data from Guildford Council
-    """
-    council_id     = 'E07000209'
-    # KML file originally supplied was malformed
-    # so we work with a version that has been repaired so it will parse properly
-    districts_name = 'GuildfordBoroughCouncilPollingDistricts20150325-fixed.kml'
-    stations_name  = 'GuildfordBoroughCouncilPollingPlaces20150325.csv'
-    elections      = ['parl.2015-05-07']
+    srid = 27700
+    districts_srid  = 27700
+    council_id = 'E07000209'
+    elections = ['local.surrey.2017-05-04']
+    scraper_name = 'wdiv-scrapers/DC-PollingStations-Guildford'
+    geom_type = 'gml'
 
     def district_record_to_dict(self, record):
-        # this kml has no altitude co-ordinates so the data is ok as it stands
-        geojson = record.geom.geojson
-
-        poly = self.clean_poly(GEOSGeometry(geojson, srid=self.get_srid('districts')))
+        poly = self.extract_geometry(record, self.geom_type, self.get_srid('districts'))
         return {
-            'internal_council_id': record['register'].value,
-            'extra_id'           : record['mi_prinx'].value,
-            'name'               : record['pollingdistrictname'].value,
+            'internal_council_id': record['register'],
+            'name'               : record['pollingdistrictname'],
             'area'               : poly,
-            'polling_station_id' : record['register'].value
+            'polling_station_id' : record['register'],
         }
 
     def station_record_to_dict(self, record):
-        location = Point(float(record.easting), float(record.northing), srid=self.get_srid())
-
-        # assemble address and extract postcode if present
-        thoroughfare_parts = record.thoroughfare_name.strip().split(', ')
-        address_tail = thoroughfare_parts[-1]
-        if len(address_tail) >= 6 and len(address_tail) <= 8 and ' ' in address_tail and address_tail != 'Ash Vale':
-            address = "\n".join(record.pollingplace.strip().split(', ') + thoroughfare_parts[:-1])
-            postcode = address_tail
-        else:
-            address = "\n".join(record.pollingplace.strip().split(', ') + thoroughfare_parts)
-
-            # attempt to attach postcode if missing
-            gwrapper = GoogleGeocodingApiWrapper(address + ', Guildford, UK', self.council_id, 'DIS')
-            try:
-                postcode = gwrapper.address_to_postcode()
-            except PostcodeNotFoundException:
-                postcode = ''
-
+        location = self.extract_geometry(record, self.geom_type, self.get_srid('stations'))
         return {
-            'internal_council_id': record.register.strip(),
-            'postcode':            postcode,
-            'address':             address,
-            'location':            location
+            'internal_council_id': record['register'],
+            'postcode':            '',
+            'address':             "%s\n%s" % (record['pollingplace'], record['thoroughfare_name']),
+            'location':            location,
         }

--- a/polling_stations/apps/data_collection/management/commands/import_salford.py
+++ b/polling_stations/apps/data_collection/management/commands/import_salford.py
@@ -1,42 +1,28 @@
-"""
-Import Salford
-"""
-import sys
-from django.contrib.gis.geos import Point
+from data_collection.management.commands import BaseMorphApiImporter
 
-from data_collection.management.commands import BaseCsvStationsShpDistrictsImporter
+class Command(BaseMorphApiImporter):
 
-class Command(BaseCsvStationsShpDistrictsImporter):
-    """
-    Imports the Polling Station data from Salford
-    """
-    council_id     = 'E08000006'
-    districts_name = 'Salford_Polling_Districts'
-    stations_name  = 'Polling_Stations.csv'
-    elections      = ['parl.2015-05-07']
+    srid = 4326
+    districts_srid  = 4326
+    council_id = 'E08000006'
+    elections = ['mayor.greater-manchester.2017-05-04']
+    scraper_name = 'wdiv-scrapers/DC-PollingStations-Salford'
+    geom_type = 'geojson'
 
     def district_record_to_dict(self, record):
+        poly = self.extract_geometry(record, self.geom_type, self.get_srid('districts'))
         return {
-            'internal_council_id': record[0],
-            'name': record[0],
+            'internal_council_id': record['code'],
+            'name'               : record['code'],
+            'area'               : poly
         }
 
     def station_record_to_dict(self, record):
-        try:
-            location = Point(int(record.easting), int(record.northing), srid=self.srid)
-        except ValueError:
-            location = Point(float(record.easting), float(record.northing), srid=self.srid)
-
-        address_parts = [x.strip() for x in record.location.split(' ')]
-        postcode = "%s %s" % (address_parts[-2], address_parts[-1])
-        del(address_parts[-1])
-        del(address_parts[-1])
-        address = " ".join(address_parts)
-
+        location = self.extract_geometry(record, self.geom_type, self.get_srid('stations'))
         return {
-            'internal_council_id': record.id,
-            'postcode'           : postcode,
-            'address'            : address,
-            'location'           : location,
-            'polling_district_id': record.polling_district_code
+            'internal_council_id': record['polling_district'],
+            'postcode':            '',
+            'address':             record['station_location'],
+            'location':            location,
+            'polling_district_id': record['polling_district']
         }

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -270,7 +270,7 @@ WHITELABEL_PREFIXES = (
 INTERNAL_IPS = ('127.0.0.1')
 SITE_TITLE = "Where Do I Vote?"
 
-# Google maps API key used for geocoding in import scripts
+# Google maps API key used by directions helper
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', "")
 
 # Morph API key used for downloading scraped data in import scripts

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -270,8 +270,11 @@ WHITELABEL_PREFIXES = (
 INTERNAL_IPS = ('127.0.0.1')
 SITE_TITLE = "Where Do I Vote?"
 
-
+# Google maps API key used for geocoding in import scripts
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', "")
+
+# Morph API key used for downloading scraped data in import scripts
+MORPH_API_KEY = os.environ.get('MORPH_API_KEY', "")
 
 MANAGE_ADDRESSBASE_MODEL = os.environ.get('MANAGE_ADDRESSBASE_MODEL', True)
 if type(MANAGE_ADDRESSBASE_MODEL) == str \


### PR DESCRIPTION
# What is this for?

As discussed in issue #356, I've found a bunch of APIs/open data portals serving up data on polling stations and districts. To try and find out how up-to-date/stale this data is, I've written a bunch of [scrapers](https://morph.io/wdiv-scrapers) that run every day, poll the apis to detect changes and also pull the data into morph because:
* It allows us to do a bit of pre-processing/getting the data into a more consistent format
* Yay - open data for everyone!

This PR adds an base class for importing this scraped data from morph.

# API Key

In order to download data from morph, you need an API key. If you sign in to morph with GitHub it will give you a key for your github account and any orgs your are a part of. You can use your own, or the DC org's key, but I don't think it really makes any difference.

In order to run the import scripts can either set an env var `MORPH_API_KEY` or add `MORPH_API_KEY = 'foobarbaz'` to `local.py`

# Import scripts

I've started adding a few import scripts mainly just to test/provide examples. A few notes:
* I realise some of the import scripts I've done are for areas that aren't having elections in 2017, but doing import scripts for City of London and Ealing allowed me to A/B test the result of the new morph-based importers against the result of running the importers that fetch data directly from the API. Guildford and Salford are relevant for May 2017
* I currently have no idea how up-to-date this data is/will be. Some of these scripts may be importing stale data, but part of the purpose of this is to answer that question and allow us to retire importers which are fetching data from stale APIs/prod the relevant councils
* I'm aware that the next plan is to rip all this out and move it to https://github.com/DemocracyClub/UK-Polling-Station-Data-Processing but this gives us a base to get @hishivshah working on something fairly accessible as a contributor in the meantime
* For now I have tagged the scripts with whatever election/s they are next relevant to or were last relevant to. e.g: `['local.surrey.2017-05-04']`, ['gla.c.2016-05-05', 'gla.a.2016-05-05', 'mayor.london.2016-05-05', 'ref.2016-06-23'] but obviously the aim is that these scripts should apply to any election that is relevant to this area (assuming we find that the APIs are maintained). It would be nice if we didn't have to re-tag them every election, but lets deal with that as another issue.

Refs issue #356
