### PR TITLE
Add ability to import data from amazon S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ polling_stations/settings/local.py
 
 # editor cruft
 *~
+
+# cached local files from amazon s3
+s3cache/*

--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -152,18 +152,15 @@ class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
     @property
     def data_path(self):
         data_private = getattr(self, 'private', False)
-        data_on_s3 = getattr(self, 'data_on_s3', False)
-        if data_on_s3:
-            s3 = S3Wrapper()
-            s3.fetch_data(self.council_id)
-            path = s3.data_path
-        elif data_private:
+        if data_private:
             path = getattr(
                 settings,
                 'PRIVATE_DATA_PATH',
                 '../polling_station_data/')
         else:
-            path = "./data"
+            s3 = S3Wrapper()
+            s3.fetch_data(self.council_id)
+            path = s3.data_path
         return os.path.abspath(path)
 
     def handle(self, *args, **kwargs):

--- a/polling_stations/apps/data_collection/s3wrapper.py
+++ b/polling_stations/apps/data_collection/s3wrapper.py
@@ -1,0 +1,60 @@
+import glob
+import os
+import shutil
+from boto.s3.connection import S3Connection
+from django.conf import settings
+
+
+class S3Wrapper:
+
+    def __init__(self):
+        if settings.S3_ACCESS_KEY == '':
+            raise NotImplementedError('S3_ACCESS_KEY must be set')
+        if settings.S3_SECRET_KEY == '':
+            raise NotImplementedError('S3_SECRET_KEY must be set')
+        if settings.S3_DATA_BUCKET == '':
+            raise NotImplementedError('S3_DATA_BUCKET must be set')
+
+        # connect to S3 + get ref to our data bucket
+        conn = S3Connection(settings.S3_ACCESS_KEY, settings.S3_SECRET_KEY)
+        self.bucket = conn.get_bucket(settings.S3_DATA_BUCKET)
+
+        # this is where our local data will live
+        self.base_path = os.path.abspath('./s3cache/')
+
+    @property
+    def data_path(self):
+        return os.path.abspath(os.path.join(
+            self.base_path, settings.S3_BASE_DIR))
+
+    def fetch_data(self, council_id):
+        prefix = "%s%s-" % (settings.S3_BASE_DIR, council_id)
+        local_pattern = os.path.abspath("%s/%s*" % (self.base_path, prefix))
+        local_paths = glob.glob(local_pattern)
+
+        if len(local_paths) == 1:
+            # if local dir already exists, delete it to
+            # remove any existing (potentially stale) data
+            shutil.rmtree(local_paths[0])
+        elif len(local_paths) > 1:
+            raise ValueError(
+                "Pattern '%s' matched more than one directory" % local_pattern)
+        else:
+            # if local dir does not exist, no worries. We will create
+            # any necessary directories when we pull data down from s3
+            pass
+
+        # fetch data for this council
+        keys = self.bucket.list(prefix=prefix)
+        count = 0
+        for key in keys:
+            local_file = os.path.join(self.base_path, key.key)
+            os.makedirs(os.path.dirname(local_file), exist_ok=True)
+            key.get_contents_to_filename(local_file)
+            # We have to manually build a count of the number of items:
+            # A BucketListResultSet does not have a len() because it is
+            # a generator expression, not a list
+            count = count + 1
+
+        if count == 0:
+            raise ValueError("Couldn't find any data to import")

--- a/polling_stations/apps/data_collection/s3wrapper.py
+++ b/polling_stations/apps/data_collection/s3wrapper.py
@@ -48,6 +48,8 @@ class S3Wrapper:
         keys = self.bucket.list(prefix=prefix)
         count = 0
         for key in keys:
+            if key.key[-8:] == '$folder$':
+                continue
             local_file = os.path.join(self.base_path, key.key)
             os.makedirs(os.path.dirname(local_file), exist_ok=True)
             key.get_contents_to_filename(local_file)

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -273,8 +273,17 @@ SITE_TITLE = "Where Do I Vote?"
 # Google maps API key used by directions helper
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', "")
 
+
 # Morph API key used for downloading scraped data in import scripts
 MORPH_API_KEY = os.environ.get('MORPH_API_KEY', "")
+
+
+# Config options for Amazon S3
+S3_ACCESS_KEY = os.environ.get('S3_ACCESS_KEY', '')
+S3_SECRET_KEY = os.environ.get('S3_SECRET_KEY', '')
+S3_DATA_BUCKET = os.environ.get('S3_DATA_BUCKET', '')
+S3_BASE_DIR = 'data/raw/ref.2016-06-23/' # <-- TODO: sort out how we're going to organise it!!
+
 
 MANAGE_ADDRESSBASE_MODEL = os.environ.get('MANAGE_ADDRESSBASE_MODEL', True)
 if type(MANAGE_ADDRESSBASE_MODEL) == str \

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -278,11 +278,21 @@ GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', "")
 MORPH_API_KEY = os.environ.get('MORPH_API_KEY', "")
 
 
-# Config options for Amazon S3
-S3_ACCESS_KEY = os.environ.get('S3_ACCESS_KEY', '')
-S3_SECRET_KEY = os.environ.get('S3_SECRET_KEY', '')
-S3_DATA_BUCKET = os.environ.get('S3_DATA_BUCKET', '')
-S3_BASE_DIR = ''
+"""
+Amazon S3 config:
+By default, we will look for a section
+
+[wheredoivote]
+aws_access_key_id = xxxx
+aws_secret_access_key = xxxx
+
+in a /etc/boto.cfg or ~/.boto file, etc
+See: http://boto.cloudhackers.com/en/latest/boto_config_tut.html
+
+We can change the section name using the BOTO_SECTION setting
+"""
+BOTO_SECTION = 'wheredoivote'
+S3_DATA_BUCKET = 'pollingstations-data'
 
 
 MANAGE_ADDRESSBASE_MODEL = os.environ.get('MANAGE_ADDRESSBASE_MODEL', True)

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -282,7 +282,7 @@ MORPH_API_KEY = os.environ.get('MORPH_API_KEY', "")
 S3_ACCESS_KEY = os.environ.get('S3_ACCESS_KEY', '')
 S3_SECRET_KEY = os.environ.get('S3_SECRET_KEY', '')
 S3_DATA_BUCKET = os.environ.get('S3_DATA_BUCKET', '')
-S3_BASE_DIR = 'data/raw/ref.2016-06-23/' # <-- TODO: sort out how we're going to organise it!!
+S3_BASE_DIR = ''
 
 
 MANAGE_ADDRESSBASE_MODEL = os.environ.get('MANAGE_ADDRESSBASE_MODEL', True)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ pygeoif==0.6
 pyshp==1.2.3
 python-dateutil==2.4.2
 requests==2.7.0
+boto==2.42.0
 
 
 git+https://github.com/DemocracyClub/django-static-precompiler


### PR DESCRIPTION
Putting this here so you can see where I've got to with it but not ready to merge yet.

For the moment, I've added the ability to grab data from S3 alongside the existing options for importing from data in the repo or a local private dir without 'disturbing' that logic too much. However this is still WIP - there's a few things I'd like to dicuss before finalising/tidying up so not ready to merge yet.

Rough topics are:
- Should we take this opportunity to re-organise the structure of the data, or just replicate the existing structure?
- How do we enable people other than use (i.e: who don't have an account on the DC S3 bucket) to write import scripts?
- Do we want to retain the ability to import data held locally?
- How much do we need to retain backwards compatibility for old import scripts?
- Also having started splitting stuff out into website/importers I've hit a couple of things I hadn't anticipated - hence targeting this at the main website repo for now.

..since we've got a hangout scheduled next week, lets review and chuck some ideas about and then I'll be able to finish it off..

Refs #303
