### PR TITLE
Make address_select view clearer on Android

### DIFF
--- a/polling_stations/templates/address_select.html
+++ b/polling_stations/templates/address_select.html
@@ -29,5 +29,17 @@
   </div>
 </div>
 
-
 {% endblock content %}
+
+{% block in_page_javascript %}
+<script type="text/javascript">
+fallback.ready(['jQuery'], function() {
+    $(document).ready(function() {
+        var isAndroid = /(android)/i.test(navigator.userAgent);
+        if (isAndroid) {
+            $('.select_multirow').css('-webkit-appearance', 'menulist');
+        }
+    });
+});
+</script>
+{% endblock in_page_javascript %}


### PR DESCRIPTION
This fixes issue #189 for Chrome on Android.

I used http://www.browsershots.net/ to generate some screenshots on various versions of Safari on iOS and it appears that this isn't an issue for iPhones because Safari on iOS displays this element in the same way as a desktop browser. It would be useful if someone with an actual iJobbie of some description could confirm that.

The reason I've added the css conditionally using javascript like this is you don't want to set `'-webkit-appearance:menulist;'` because this makes it look odd when webkit-based desktop browsers display the full-height version.

