### PR TITLE
Import script for Daventry + some tidying

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -464,7 +464,17 @@ class BaseAddressesImporter(BaseImporter, metaclass=abc.ABCMeta):
 class BaseStationsDistrictsImporter(BaseStationsImporter,
                                     BaseDistrictsImporter):
 
+    def pre_import(self):
+        raise NotImplementedError
+
     def import_data(self):
+
+        # Optional step for pre import tasks
+        try:
+            self.pre_import()
+        except NotImplementedError:
+            pass
+
         self.stations = StationSet()
         self.districts = DistrictSet()
         self.import_polling_districts()
@@ -476,7 +486,17 @@ class BaseStationsDistrictsImporter(BaseStationsImporter,
 class BaseStationsAddressesImporter(BaseStationsImporter,
                                     BaseAddressesImporter):
 
+    def pre_import(self):
+        raise NotImplementedError
+
     def import_data(self):
+
+        # Optional step for pre import tasks
+        try:
+            self.pre_import()
+        except NotImplementedError:
+            pass
+
         self.stations = StationSet()
         self.addresses = AddressSet(self.logger)
         self.import_residential_addresses()
@@ -576,6 +596,13 @@ class BaseGenericApiImporter(BaseStationsDistrictsImporter):
     local_files = False
 
     def import_data(self):
+
+        # Optional step for pre import tasks
+        try:
+            self.pre_import()
+        except NotImplementedError:
+            pass
+
         self.districts = DistrictSet()
         self.stations = StationSet()
 

--- a/polling_stations/apps/data_collection/geo_utils.py
+++ b/polling_stations/apps/data_collection/geo_utils.py
@@ -1,0 +1,14 @@
+from django.contrib.gis.geos import MultiPolygon, Polygon, LinearRing
+
+def convert_linestring_to_multiploygon(linestring):
+    points = linestring.coords
+
+    # close the LineString so we can transform to LinearRing
+    points = list(points)
+    points.append(points[0])
+    ring = LinearRing(points)
+
+    # now we have a LinearRing we can make a Polygon.. and the rest is simple
+    poly = Polygon(ring)
+    multipoly = MultiPolygon(poly)
+    return multipoly

--- a/polling_stations/apps/data_collection/management/commands/import_daventry.py
+++ b/polling_stations/apps/data_collection/management/commands/import_daventry.py
@@ -1,0 +1,101 @@
+from django.contrib.gis.geos import (
+    GEOSGeometry,
+    MultiPolygon,
+    Point,
+    Polygon,
+    LinearRing
+)
+from data_collection.data_types import (DistrictSet, StationSet)
+from data_collection.management.commands import BaseApiKmlStationsKmlDistrictsImporter
+
+class Command(BaseApiKmlStationsKmlDistrictsImporter):
+    srid             = 4326
+    districts_srid   = 4326
+    council_id       = 'E07000151'
+    districts_url    = 'http://feeds.getmapping.com/47732.wmsx?login=61dfb362-893b-464d-8a96-fb3edb7565f8&password=yd5v5y03&LAYERS=daventry_parliamentary_polling_districts_region&TRANSPARENT=TRUE&HOVER=false&FORMAT=kml&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS=EPSG%3A27700&BBOX=447025,247876,489247,288998&WIDTH=867&HEIGHT=426'
+    stations_url     = 'http://feeds.getmapping.com/47733.wmsx?login=70a1b086-b9cc-4b22-9b90-7d88bd589d4b&password=sjy2869b&LAYERS=daventry_parliamentary_polling_stations&TRANSPARENT=TRUE&HOVER=false&FORMAT=kml&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS=EPSG%3A27700&BBOX=449708,250805,486927,287603&WIDTH=867&HEIGHT=426'
+    elections        = [
+        'local.northamptonshire.2017-05-04'
+    ]
+    duplicate_districts = set()
+
+    def find_duplicate_districts(self):
+        # identify any district codes which appear
+        # more than once (with 2 different polygons)
+        # We do not want to import these.
+        seen = set()
+        districts = self.get_districts()
+        for district in districts:
+            if str(district['pollingdis']) in seen:
+                self.duplicate_districts.add(str(district['pollingdis']))
+            seen.add(str(district['pollingdis']))
+
+    def convert_linestring_to_multiploygon(self, linestring):
+        points = linestring.coords
+
+        # close the LineString so we can transform to LinearRing
+        points = list(points)
+        points.append(points[0])
+        ring = LinearRing(points)
+
+        # now we have a LinearRing we can make a Polygon.. and the rest is simple
+        poly = Polygon(ring)
+        multipoly = MultiPolygon(poly)
+        return multipoly
+
+    def district_record_to_dict(self, record):
+        # polygon
+        geojson = record.geom.geojson
+        geometry_collection = self.clean_poly(GEOSGeometry(geojson, srid=self.get_srid('districts')))
+        poly = self.convert_linestring_to_multiploygon(geometry_collection)
+
+        district_id = str(record['pollingdis']).strip()
+        if district_id in self.duplicate_districts:
+            return None
+        else :
+            return {
+                'internal_council_id': district_id,
+                'name'               : "%s - %s" % (record['pollingdis'], record['name']),
+                'area'               : poly
+            }
+
+    def format_address(self, address_parts):
+        address = "\n".join(address_parts)
+        while "\n\n" in address:
+            address = address.replace("\n\n", "\n")
+        return address
+
+    def station_record_to_dict(self, record):
+        # point
+        geojson = record.geom.geojson
+        location = GEOSGeometry(geojson, srid=self.get_srid())
+
+        # address
+        address = self.format_address([
+            str(record['polling_st']),
+            ("%s %s" % (str(record['address1']), str(record['address2']))).strip(),
+            str(record['locality']),
+            str(record['town_villa']),
+        ])
+
+        district_ids = str(record['pollingdis']).strip().split(', ')
+        for district_id in district_ids:
+            return {
+                'internal_council_id': district_id,
+                'postcode':            record['postcode'],
+                'address':             address,
+                'location':            location,
+                'polling_district_id': district_id
+            }
+
+    def import_data(self):
+        # override import_data so we can populate
+        # self.duplicate_districts as a pre-process
+        self.find_duplicate_districts()
+
+        self.stations = StationSet()
+        self.districts = DistrictSet()
+        self.import_polling_districts()
+        self.import_polling_stations()
+        self.districts.save()
+        self.stations.save()

--- a/polling_stations/apps/data_collection/management/commands/import_daventry.py
+++ b/polling_stations/apps/data_collection/management/commands/import_daventry.py
@@ -1,5 +1,4 @@
 from django.contrib.gis.geos import GEOSGeometry, Point
-from data_collection.data_types import DistrictSet, StationSet
 from data_collection.geo_utils import convert_linestring_to_multiploygon
 from data_collection.management.commands import BaseApiKmlStationsKmlDistrictsImporter
 
@@ -13,6 +12,9 @@ class Command(BaseApiKmlStationsKmlDistrictsImporter):
         'local.northamptonshire.2017-05-04'
     ]
     duplicate_districts = set()
+
+    def pre_import(self):
+        self.find_duplicate_districts()
 
     def find_duplicate_districts(self):
         # identify any district codes which appear
@@ -69,15 +71,3 @@ class Command(BaseApiKmlStationsKmlDistrictsImporter):
                 'location':            location,
                 'polling_district_id': district_id
             }
-
-    def import_data(self):
-        # override import_data so we can populate
-        # self.duplicate_districts as a pre-process
-        self.find_duplicate_districts()
-
-        self.stations = StationSet()
-        self.districts = DistrictSet()
-        self.import_polling_districts()
-        self.import_polling_stations()
-        self.districts.save()
-        self.stations.save()

--- a/polling_stations/apps/data_collection/management/commands/import_mid_sussex.py
+++ b/polling_stations/apps/data_collection/management/commands/import_mid_sussex.py
@@ -1,4 +1,3 @@
-from data_collection.data_types import (DistrictSet, StationSet)
 from data_collection.management.commands import BaseMorphApiImporter
 
 class Command(BaseMorphApiImporter):
@@ -10,6 +9,9 @@ class Command(BaseMorphApiImporter):
     scraper_name = 'wdiv-scrapers/DC-PollingStations-Mid-Sussex'
     geom_type = 'geojson'
     split_districts = set()
+
+    def pre_import(self):
+        self.find_split_districts()
 
     def get_station_hash(self, record):
         # handle exact dupes on code/address
@@ -51,15 +53,3 @@ class Command(BaseMorphApiImporter):
             'address':             record['address'],
             'location':            location,
         }
-
-    def import_data(self):
-        # override import_data so we can populate
-        # self.split_districts as a pre-process
-        self.find_split_districts()
-
-        self.stations = StationSet()
-        self.districts = DistrictSet()
-        self.import_polling_districts()
-        self.import_polling_stations()
-        self.districts.save()
-        self.stations.save()

--- a/polling_stations/apps/data_collection/management/commands/import_york.py
+++ b/polling_stations/apps/data_collection/management/commands/import_york.py
@@ -1,4 +1,3 @@
-from data_collection.data_types import DistrictSet, StationSet
 from data_collection.management.commands import BaseMorphApiImporter
 
 class Command(BaseMorphApiImporter):
@@ -10,6 +9,9 @@ class Command(BaseMorphApiImporter):
     scraper_name = 'wdiv-scrapers/DC-PollingStations-York'
     geom_type = 'geojson'
     split_districts = set()
+
+    def pre_import(self):
+        self.find_split_districts()
 
     def find_split_districts(self):
         'Identify districts mapped to more than one polling station.'
@@ -56,15 +58,3 @@ class Command(BaseMorphApiImporter):
                     'polling_district_id': id
                 })
             return stations
-
-    def import_data(self):
-        # override import_data so we can populate
-        # self.split_districts as a pre-process
-        self.find_split_districts()
-
-        self.stations = StationSet()
-        self.districts = DistrictSet()
-        self.import_polling_districts()
-        self.import_polling_stations()
-        self.districts.save()
-        self.stations.save()


### PR DESCRIPTION
* Factor out `convert_linestring_to_multiploygon()` to a common library where it can be shared by multiple import scripts (there may be some other things we need to factor out into `geo_utils.py` at some point).
* Add `pre_import()` hook method so we can perform setup tasks without overriding `import_data()` in import scripts
* Add import script for Daventry