### PR TITLE
Ensure directory keys are ignored in s3wrapper

### DIFF
--- a/polling_stations/apps/data_collection/s3wrapper.py
+++ b/polling_stations/apps/data_collection/s3wrapper.py
@@ -45,8 +45,11 @@ class S3Wrapper:
         keys = self.bucket.list(prefix=prefix)
         count = 0
         for key in keys:
-            if key.key[-8:] == '$folder$':
+
+            # ignore directories
+            if key.key[-8:] == '$folder$' or key.key[-1] == '/':
                 continue
+
             local_file = os.path.join(self.base_path, key.key)
             os.makedirs(os.path.dirname(local_file), exist_ok=True)
             key.get_contents_to_filename(local_file)


### PR DESCRIPTION
Looks like the s3 client Joe is using denotes a key is a directory by ending with a trailing slash, rather than `$folder$` like s3fox does.