### PR TITLE
Import script for Pembrokeshire

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_pembrokeshire.py
+++ b/polling_stations/apps/data_collection/management/commands/import_pembrokeshire.py
@@ -1,87 +1,31 @@
-"""
-Imports Pembrokeshire
-"""
-from django.contrib.gis.geos import Point
-from data_collection.management.commands import BaseCsvStationsCsvAddressesImporter
-from data_finder.helpers import geocode_point_only, PostcodeError
+from data_collection.management.commands import BaseShpStationsShpDistrictsImporter
 
-class Command(BaseCsvStationsCsvAddressesImporter):
-    """
-    Imports the Polling Station data from Pembrokeshire
-    """
-    council_id      = 'W06000009'
-    addresses_name  = 'GAZETTEER_DATA.CSV'
-    stations_name   = 'ERCOVER.DTA'
-    elections       = [
-        'pcc.2016-05-05',
-        'naw.c.2016-05-05',
-        'naw.r.2016-05-05',
-        'ref.2016-06-23'
-    ]
+class Command(BaseShpStationsShpDistrictsImporter):
+    srid = 27700
+    council_id = 'W06000009'
+    districts_name = 'PollingDistrictWithStation Pembrokeshire for 2017/PollingDistrictWithStation'
+    stations_name = 'PollingDistrictWithStation Pembrokeshire for 2017/PollingDistrictWithStation.shp'
+    elections = ['local.pembrokeshire.2017-05-04']
+
+    def district_record_to_dict(self, record):
+        return {
+            'internal_council_id': str(record[1]).strip(),
+            'name': str(record[2]).strip()
+        }
 
     def station_record_to_dict(self, record):
-
-        # Don't import the Carmarthenshire polling stations
-        # We don't have the address data to go with them :(
-        if record.local_auth == 'W06000010':
-            return None
-
-        # format address
-        address_parts = []
-        if record.bldg_name:
-            address_parts.append(record.bldg_name)
-        if record.bldg_add1:
-            address_parts.append(record.bldg_add1)
-        if record.bldg_add2:
-            address_parts.append(record.bldg_add2)
-        if record.bldg_add3:
-            address_parts.append(record.bldg_add3)
-        if record.bldg_add4:
-            address_parts.append(record.bldg_add4)
-        if record.bldg_add5:
-            address_parts.append(record.bldg_add5)
-        address = "\n".join(address_parts)
-
-        # convert postcode to upper case
-        postcode = record.bldg_pcode.upper()
-
-        if record.kml_lng and record.kml_lat:
-            location = Point(float(record.kml_lng), float(record.kml_lat), srid=4326)
-        else:
-            # there is one station we don't have a point for - geocode it
-            try:
-                gridref = geocode_point_only(postcode)
-                location = Point(gridref['wgs84_lon'], gridref['wgs84_lat'], srid=4326)
-            except PostcodeError:
-                location = None
-
-        return {
-            'internal_council_id': record.district,
-            'postcode'           : postcode,
-            'address'            : address,
-            'location'           : location
+        station = {
+            'internal_council_id': str(record[1]).strip(),
+            'postcode': '',
+            'address': str(record[4]).strip(),
+            'polling_district_id': str(record[1]).strip(),
         }
 
-    def address_record_to_dict(self, record):
+        """
+        This file doesn't actually have points for stations
+        and we want to ensure that we don't try to insert
+        the polygon data into the location field
+        """
+        station ['location'] = None
 
-        # format address
-        address_parts = []
-        if record.address1:
-            address_parts.append(record.address1)
-        if record.address2:
-            address_parts.append(record.address2)
-        if record.address3:
-            address_parts.append(record.address3)
-        if record.address4:
-            address_parts.append(record.address4)
-        if record.address5:
-            address_parts.append(record.address5)
-        if record.address6:
-            address_parts.append(record.address6)
-        address = "\n".join(address_parts[:-1])
-
-        return {
-            'address'           : address,
-            'postcode'          : record.postcode,
-            'polling_station_id': record.district_code
-        }
+        return station

--- a/polling_stations/apps/data_collection/s3wrapper.py
+++ b/polling_stations/apps/data_collection/s3wrapper.py
@@ -45,8 +45,11 @@ class S3Wrapper:
         keys = self.bucket.list(prefix=prefix)
         count = 0
         for key in keys:
-            if key.key[-8:] == '$folder$':
+
+            # ignore directories
+            if key.key[-8:] == '$folder$' or key.key[-1] == '/':
                 continue
+
             local_file = os.path.join(self.base_path, key.key)
             os.makedirs(os.path.dirname(local_file), exist_ok=True)
             key.get_contents_to_filename(local_file)


### PR DESCRIPTION
Based off PR #405
Closes issue #398

The data supplied by Pembrokeshire doesn't include points or postcodes. The districts shapefile just has a 'station address' column. This means we can't show maps/directions - only an address. Sometimes this is reasonably good (e.g: "Albany Church Hall, Hill Street, Haverfordwest"). Sometimes it is a bit vague (e.g: "Pembroke Rugby Club").

When I first started doing this, I was fairly gung-ho about trying to do stuff like attach missing points and postcodes to addresses by geocoding. However more recently, I'm tending towards the approach of just publishing the data we're given as my impression is that it is more advantageous to be telling councils we aren't fiddling about with their data.. so I haven't tried to do anything clever with it.