### PR TITLE
WIP: Crowdsourcing (3rd time lucky)

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -181,12 +181,24 @@ class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
             apps.get_app_config('pollingstations')
         ])
 
+        """
+        Shove args and kwargs into some object properties. This means if
+        another class which extends BaseImporter defines additional custom
+        args, we don't have to override handle() to access them.
+        """
+        self.args = args
+        self.kwargs = kwargs
+
         verbosity = kwargs.get('verbosity')
         self.logger = LogHelper(verbosity)
         self.batch_size = kwargs.get('batch_size')
 
         if self.council_id is None:
-            self.council_id = args[0]
+            if 'council_id' in kwargs:
+                self.council_id = kwargs['council_id']
+            else:
+                self.council_id = args[0]
+            # if args is empty, give up and let it throw an IndexError
 
         self.council = self.get_council(self.council_id)
 

--- a/polling_stations/apps/data_collection/management/commands/generate_csvs.py
+++ b/polling_stations/apps/data_collection/management/commands/generate_csvs.py
@@ -1,0 +1,74 @@
+"""
+Generate CSV templates for collecting
+crowd sourced polling station data
+"""
+
+import csv, glob, os
+from django.core.management.base import BaseCommand
+from pollingstations.models import ElectoralRoll
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'output_path',
+            help="""Path to export CSVs to e.g:
+            '/home/user/data/elections.2017-05-04/'
+            (must be an empty dir)
+            """
+        )
+
+    def generate_files(self):
+        # grab councils we want to build a csv for
+        councils = ElectoralRoll.objects\
+            .distinct("council")\
+            .order_by("council")
+
+        for council in councils:
+            self.generate_file(council.council_id)
+
+        self.stdout.write("wrote %s files" % (councils.count()))
+
+    def generate_file(self, council_id):
+        districts = ElectoralRoll.objects\
+            .filter(council=council_id)\
+            .distinct("polling_district_id")\
+            .order_by("polling_district_id")
+
+        self.stdout.write('writing: ' + "%s.csv" % (council_id))
+
+        filename = os.path.abspath("%s/%s.csv" % (self.output_path, council_id))
+        with open(filename, 'w') as csvfile:
+            fieldnames = [
+                'council_name', 'council_code', 'polling_district_id',
+                'address', 'postcode', 'source'
+            ]
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+            for district in districts:
+                writer.writerow({
+                    'council_name': district.council,
+                    'council_code': district.council_id,
+                    'polling_district_id': district.polling_district_id,
+                    'address': '',
+                    'postcode': '',
+                    'source': ''
+                })
+
+    def handle(self, *args, **kwargs):
+        self.output_path = kwargs['output_path']
+
+        existing_files = glob.glob(
+            os.path.abspath("%s/" % (self.output_path)) + '/*'
+        )
+        if existing_files:
+            # dir exists but is not empty
+            raise OSError('Export dir must be empty!')
+
+        # if the dir doesn't already exist, create it
+        os.makedirs(os.path.dirname(self.output_path), exist_ok=True)
+
+        self.stdout.write(
+            "writing files to: " + os.path.abspath("%s/" % (self.output_path)))
+        self.generate_files()

--- a/polling_stations/apps/data_collection/management/commands/import.py
+++ b/polling_stations/apps/data_collection/management/commands/import.py
@@ -18,6 +18,9 @@ class Command(BaseCommand):
     requires_system_checks = False
 
     summary = []
+    exclude = [
+        'import_crowdsourced_csv.py'
+    ]
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -70,6 +73,10 @@ class Command(BaseCommand):
         # loop over all the import scripts
         for f in files:
             head, tail = os.path.split(f)
+
+            if tail in self.exclude:
+                continue
+
             try:
                 command = SourceFileLoader("module.name", f).load_module()
             except:

--- a/polling_stations/apps/data_collection/management/commands/import_crowdsourced_csv.py
+++ b/polling_stations/apps/data_collection/management/commands/import_crowdsourced_csv.py
@@ -1,0 +1,161 @@
+"""
+Import crowd sourced polling
+station data from CSV file or URL
+
+example usage:
+./manage.py import_crowdsourced_csv X01000001 -f data/crowdsourcing/ref.2016-06-23/X01000001.csv
+./manage.py import_crowdsourced_csv X01000001 -f data/crowdsourcing/pilot/X01000001.csv -c 'latin-1'
+./manage.py import_crowdsourced_csv X01000001 -u 'https://docs.google.com/spreadsheet/ccc?key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&output=csv'
+"""
+
+import logging
+import os
+import tempfile
+import urllib.request
+from django.contrib.gis.geos import Point
+from data_collection.management.commands import BaseCsvStationsCsvAddressesImporter
+from data_finder.helpers import geocode_point_only, PostcodeError
+from pollingstations.models import ElectoralRoll
+
+
+class Command(BaseCsvStationsCsvAddressesImporter):
+
+    addresses_name = None
+    stations_name = None
+    local_files = False
+    csv_encoding = 'utf-8'
+    csv_delimiter = ','
+    elections = []
+    split_districts = set()
+
+    # Additional command line args applicable to import_crowdsourced_csv
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'council_id',
+            help='Council ID to import in the format X01000001'
+        )
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            '-f',
+            '--file',
+            nargs=1,
+            help="""Path to CSV file to import e.g:
+            '/home/user/data/elections.2017-05-04/X01000001.csv'
+            """
+        )
+        group.add_argument(
+            '-u',
+            '--url',
+            nargs=1,
+            help="""URL to CSV file to import e.g:
+            'https://docs.google.com/spreadsheet/ccc?key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&output=csv'
+            """
+        )
+        parser.add_argument(
+            '-c',
+            '--character-encoding',
+            help='<Optional> Character encoding of the CSV',
+            required=False
+        )
+
+    def get_addresses(self):
+        """
+        Instead of fetching addresses to import from a CSV file,
+        fetch them from the ElectoralRoll table instead
+        """
+        return ElectoralRoll.objects.filter(council=self.council_id)
+
+    def address_record_to_dict(self, record):
+        return {
+            'address': record.address,
+            'postcode': record.postcode,
+            'polling_station_id': record.polling_district_id,
+        }
+
+    def get_data_from_file(self, filename):
+        if not os.path.exists(os.path.abspath(filename)):
+            raise OSError('Input file does not exist')
+        return self.get_data(self.stations_filetype, os.path.abspath(filename))
+
+    def get_data_from_url(self, url):
+        with tempfile.NamedTemporaryFile() as tmp:
+            urllib.request.urlretrieve(url, tmp.name)
+            return self.get_data(self.stations_filetype, tmp.name)
+
+    def get_stations(self):
+        # stations may be imported from either a local file
+        # or straight from a URL (e.g: google docs)
+
+        if 'file' in self.kwargs and self.kwargs['file'] is not None:
+            # import from local file system
+            return self.get_data_from_file(self.kwargs['file'][0])
+
+        if 'url' in self.kwargs and self.kwargs['url'] is not None:
+            # import straight from a url
+            return self.get_data_from_url(self.kwargs['url'][0])
+
+    def station_record_to_dict(self, record):
+
+        postcode = record.postcode.strip()
+        address = record.address.strip()
+        id = record.polling_district_id.strip()
+
+        if id in self.split_districts:
+            self.logger.log_message(
+                logging.WARNING,
+                "found split district - discarding polling station: %s" %\
+                (str(id)),
+            )
+            return None
+
+        if not address and not postcode:
+            self.logger.log_message(
+                logging.WARNING,
+                "found blank row - discarding polling station: %s" % (str(id)),
+            )
+            return None
+
+        # if we have a postcode, attempt to attach a grid ref
+        # so we can show the user a map and provide directions
+        if postcode:
+            try:
+                gridref = geocode_point_only(postcode)
+                location = Point(
+                    gridref['wgs84_lon'], gridref['wgs84_lat'], srid=4326)
+            except PostcodeError:
+                location = None
+        else:
+            location = None
+
+        return {
+            'internal_council_id': id,
+            'postcode': postcode,
+            'address': address,
+            'location': location
+        }
+
+    # setup tasks for this import script
+    def pre_import(self):
+        # set character_encoding from command line arg
+        if self.kwargs['character_encoding']:
+            self.csv_encoding = self.kwargs['character_encoding']
+
+        self.find_split_districts()
+
+    def find_split_districts(self):
+        """
+        Identify any district codes which appear more than once
+        with 2 different polling station addresses.
+        We do not want to import these.
+
+        This will make @symroe and @andylolz happy because
+        the CSVs can be faithful transcriptions of the CSVs
+        and the import script will deal with it gracefully :D
+        """
+        stations = self.get_stations()
+        seen = set()
+        for station in stations:
+            id = station.polling_district_id.strip()
+            if id in seen:
+                self.split_districts.add(id)
+            seen.add(id)

--- a/polling_stations/apps/pollingstations/migrations/0012_auto_20161224_2259.py
+++ b/polling_stations/apps/pollingstations/migrations/0012_auto_20161224_2259.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('councils', '0002_auto_20160121_1522'),
+        ('pollingstations', '0011_auto_20160501_2017'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ElectoralRoll',
+            fields=[
+                ('id', models.AutoField(primary_key=True, serialize=False, auto_created=True, verbose_name='ID')),
+                ('address', models.TextField(null=True, blank=True)),
+                ('postcode', models.CharField(null=True, max_length=100, db_index=True, blank=True)),
+                ('polling_district_id', models.CharField(max_length=100, blank=True)),
+                ('council', models.ForeignKey(null=True, to='councils.Council')),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='customfinder',
+            name='area_code',
+            field=models.CharField(primary_key=True, max_length=9, serialize=False, help_text='The GSS code for this area'),
+        ),
+        migrations.AlterField(
+            model_name='customfinder',
+            name='base_url',
+            field=models.CharField(max_length=255, help_text='The landing page for the polling station finder', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='customfinder',
+            name='can_pass_postcode',
+            field=models.BooleanField(help_text="Does the URL have '?postcode=' in it?", default=False),
+        ),
+        migrations.AlterField(
+            model_name='customfinder',
+            name='message',
+            field=models.TextField(default='This council has its own polling station finder:', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='pollingstation',
+            name='internal_council_id',
+            field=models.CharField(max_length=100, db_index=True, blank=True),
+        ),
+    ]

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -121,6 +121,13 @@ class PollingStation(models.Model):
         return "\n".join([x[0] for x in groupby(self.address.split(','))])
 
 
+class ElectoralRoll(models.Model):
+    address             = models.TextField(blank=True, null=True)
+    postcode            = models.CharField(blank=True, null=True, max_length=100, db_index=True)
+    council             = models.ForeignKey(Council, null=True)
+    polling_district_id = models.CharField(blank=True, max_length=100)
+
+
 class ResidentialAddress(models.Model):
     address            = models.TextField(blank=True, null=True)
     postcode           = models.CharField(blank=True, null=True, max_length=100, db_index=True)


### PR DESCRIPTION
We're getting the band back together.. again.... again! Lets see if we can make it work this time.

This all kind of roughly builds on stuff previously done or discussed in
https://github.com/DemocracyClub/UK-Polling-Stations/issues/267#issuecomment-218831211
https://github.com/DemocracyClub/UK-Polling-Stations/pull/268
but some of it has changed because the data has changed, or because the codebase has changed or just because I came up with a better (or at least differently terrible?) idea..

# Progress:
- [ ] Scripts to clean up and import electoral roll
- [x] Script to generate CSV templates
- [x] Script to import crowdsourced data

# Notes:

## Importing Electoral Roll

I've deliberately not done anything about importing Electoral Roll data (yet). Based on the 3 example files we've got, it is clear that we're going to get a bunch of different files in different formats and there's going to be a variety of edge cases to deal with (pretty much everything we see in ResidentialAddress import scripts is going to occur somewhere.. and the rest). I think I'm going to wait until we've got the full data in and then write the cleanup/import scripts rather than trying to write them predictively.

What I **have** done is decided that we shouldn't import it straight into the ResidentialAddress table. What I actually propose is that we stage the Electoral Roll data in its' own table and then bring it over to the ResidentialAddess table as part of the import process. The web app itself never directly accesses the ResidentialAddess table. This is kind of 'wasteful'(?), but I think it simplifies things because:
* CSV templates can be generated with the database in any state - nothing needs to be done in a particular order and we don't need to know which councils will/won't provide data yet, or manually maintain that list
* Whatever mix of open data/data from councils/crowdsourced data we get is easy to accommodate at the end of the process when it is close to election day
* Once we've run all our import scripts, the ResidentialAddress table only contains addresses relevant to areas where we have some polling station coverage


## Generating CSVs

* Once we've dealt with importing electoral roll addresses, we can generate CSV templates for collecting crowdsourced data using the script provided: `python manage.py generate_csvs /path/for/export`
* Then we can:
  * Whack them on google docs
  * Mobilise wombles
  * Assemble data 

..then we can move on to...

## Importing data

* CSVs can be imported directly from a URL (probably google docs) or from local storage. Usage examples:
  * `python manage.py import_crowdsourced_csv X01000001 -f /path/to/data/X01000001.csv`
  * `python manage.py import_crowdsourced_csv X01000001 -f /path/to/data/X01000001.csv -c 'latin-1'`
  * `python manage.py import_crowdsourced_csv X01000001 -u 'https://docs.google.com/spreadsheet/ccc?key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&output=csv'`

* Split districts and blank rows are handled by excluding them. `WARNING` level notification is thrown in these cases.
* Grid refs are attached using postcode centroid if possible - I've assumed we won't have gridrefs for crowdsourced data. Maybe there should be optional gridref/srid columns? I think it is unlikely that PDFs will include these, but there may be some special cases..


## ...and finally

* We probably need a bit of discussion around process, but most of https://github.com/DemocracyClub/UK-Polling-Stations/issues/267#issuecomment-218831211 probably still holds.
* I had a mince pie, I promise!

