### PR TITLE
make councils import script harvest Isles of Scilly

### DIFF
--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -8,4 +8,5 @@ COUNCIL_TYPES = [
     "MTD",
     "LGD",
     "UTA",
+    "COI",
 ]


### PR DESCRIPTION
Re-importing councils on prod with this change will close #386 but bear in mind caveat about issues with Northern Ireland councils on the DC mapit.