### PR TITLE
Import script for Lichfield

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_lichfield.py
+++ b/polling_stations/apps/data_collection/management/commands/import_lichfield.py
@@ -1,35 +1,43 @@
-"""
-Import Lichfield
-"""
-from django.contrib.gis.geos import Point
+from data_collection.management.commands import BaseShpStationsShpDistrictsImporter
 
-from data_collection.management.commands import (
-    BaseShpStationsShpDistrictsImporter
-)
+"""
+Lichfield publish their data on data.gov.uk as zipped shp files
+
+I've uploaded the data to Amazon S3 for import purposes
+
+Additionally there's a hashes only scraper at
+https://morph.io/wdiv-scrapers/DC-PollingStations-Lichfield
+polling the URLs to look for changes.
+"""
 
 class Command(BaseShpStationsShpDistrictsImporter):
-    """
-    Imports the Polling Station data from Lichfield Council
-    """
-    council_id     = 'E07000194'
-    districts_name = 'Lichfield_District_Council_Polling_Districts'
-    stations_name  = 'Lichfield_District_Council_Polling_Station_Locations.shp'
-    elections      = ['parl.2015-05-07']
+    srid = 27700
+    council_id = 'E07000194'
+    districts_name = 'local.staffordshire.2017-05-04/Lichfield District Council Polling Districts Shapefile/Lichfield District Council Polling Districts'
+    stations_name = 'local.staffordshire.2017-05-04/LDC_Polling_Stations_Shapefile/Lichfield_District_Council_Polling_Station_Locations.shp'
+    elections = ['local.staffordshire.2017-05-04']
 
     def district_record_to_dict(self, record):
         return {
-            'internal_council_id': record[0],
-            'name': record[2],
+            'internal_council_id': str(record[3]).strip(),
+            'name': str(record[3]).strip(),
+            'polling_station_id': str(record[3]).strip(),
         }
 
     def station_record_to_dict(self, record):
-        print(record)
-        print(record[1])
-        print(record[4])
-        print(record[5])
+        address = "\n".join([
+            str(record[1]).strip(),
+            str(record[4]).strip(),
+        ])
+        postcode = str(record[5]).strip()
+        codes = [record[9].strip(), record[10].strip(), record[11].strip()]
 
-        return {
-            'internal_council_id': record[0],
-            'postcode'           : record[5],
-            'address'            : "\n".join([record[1], record[4]]),
-        }
+        stations = []
+        for code in codes:
+            if code != b'':
+                stations.append({
+                    'internal_council_id': str(code),
+                    'postcode'           : postcode,
+                    'address'            : address,
+                })
+        return stations


### PR DESCRIPTION
When running this import, you'll note that there are several stations which aren't attached to any district. I think the reason for this is that for constituency-based elections, Lichfield is covered by 2 constituencies - one of which also covers part of a neighbouring local auth. My guess is that Lichfield electoral services organise the polling stations for that whole constituency and have included all of the stations they administer in their file:

![untitled](https://cloud.githubusercontent.com/assets/6025893/21743324/a281d5e2-d4f7-11e6-8bf9-fec29bacd70f.png)

so I think it is legit that some of the stations in the file just don't have a corresponding district.

Additionally there is one orphan district which I've asked Joe to follow up with them. Will update if we get a response.