### PR TITLE
pin libsass to >=0.12.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,5 +24,5 @@ boto==2.42.0
 
 
 git+https://github.com/DemocracyClub/django-static-precompiler
-libsass==0.12.1
+libsass>=0.12.3
 git+git://github.com/DemocracyClub/dc_base_theme.git@04efca5047b31d705e63d516b3b5dc5d0f0694a7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,5 +24,5 @@ boto==2.42.0
 
 
 git+https://github.com/DemocracyClub/django-static-precompiler
-libsass
+libsass==0.12.1
 git+git://github.com/DemocracyClub/dc_base_theme.git@04efca5047b31d705e63d516b3b5dc5d0f0694a7


### PR DESCRIPTION
I've been seeing build errors in Travis on my fork, but the tests were passing locally and the Travis build on this repo for the same commits are passing. See:

https://travis-ci.org/chris48s/UK-Polling-Stations/builds/189648477
https://travis-ci.org/DemocracyClub/UK-Polling-Stations/builds/189650389
(same commit)

https://travis-ci.org/chris48s/UK-Polling-Stations/builds/189815624
https://travis-ci.org/DemocracyClub/UK-Polling-Stations/builds/189817109
(same commit)

After some hours of pulling my hair out, I tracked down the issue:
* A new version of `libsass-python` (0.12.2) was released on Jan 5th
* The travis build on my fork is fetching this latest version (0.12.2), whereas the travis build on the DC upstream is still using a cached copy of 0.12.1, which is why the build errors aren't happening here.
* `python-libsass` 0.12.2 wraps a version of `libsass` which contains a bug causing the segfault. See:
  * https://github.com/dahlia/libsass-python/issues/177
  * https://github.com/sass/libsass/issues/2289
* Reproducing this locally, this issue causes the django app to segfault trying to render a page - it isn't just a test/build issue. We definitely don't want to upgrade to this version.
* A fix for the issue has now been merged in `libsass` but there's no release which includes the fix yet

so, propose pinning to 0.12.1 for the moment but we can keep an eye out for an 0.12.3 release as hopefully this will solve the issue. While this is not merged we might start seeing failing builds on new PRs to `master` once Travis invalidates the pip cache and fetches a new version.
