### PR TITLE
Fix council import

### DIFF
--- a/polling_stations/apps/councils/management/commands/import_councils.py
+++ b/polling_stations/apps/councils/management/commands/import_councils.py
@@ -79,9 +79,8 @@ class Command(BaseCommand):
             defaults = {
                 'name': council['name'],
             }
-            if defaults != "LGD":
-                defaults.update(
-                    self.get_contact_info_from_gov_uk(council_id))
+            defaults.update(
+                self.get_contact_info_from_gov_uk(council_id))
 
             defaults['council_type'] = council_type
             defaults['mapit_id']= mapit_id

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -6,7 +6,6 @@ COUNCIL_TYPES = [
     "LBO",
     "DIS",
     "MTD",
-    "LGD",
     "UTA",
     "COI",
 ]


### PR DESCRIPTION
Refs #386 

The importer is currently breaking on council id `95G` (Ballymena Borough Council). Digging about it seems that this is a NI council, that's being imported because "LGD" was in the COUNCIL_TYPES. See the comment on 2b1ff67.

Whilst I was there, I saw that we're doing some logic that just would never have worked, so I removed that, see 	ae80a17.