### PR TITLE
Correctly handle mapit 404

### DIFF
--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -58,35 +58,44 @@ def geocode(postcode):
 
     res = requests.get("%s/postcode/%s" % (settings.MAPIT_URL, postcode), headers=headers)
 
-    if res.status_code == 403:
-        # we hit MapIt's rate limit
-        raise RateLimitError("Mapit error 403: Rate limit exceeded")
+    if res.status_code != 200:
+        if res.status_code == 403:
+            # we hit MapIt's rate limit
+            raise RateLimitError("Mapit error 403: Rate limit exceeded")
 
-    if res.status_code == 404:
-        # if mapit returns 404, it returns HTML even if we requested json
-        # this will cause an unhandled exception if we try to parse it
-        raise PostcodeError("Mapit error {}: {}".format(res.status_code, 'Not Found'))
+        if res.status_code == 404:
+            # if mapit returns 404, it returns HTML even if we requested json
+            # this will cause an unhandled exception if we try to parse it
+            raise PostcodeError("Mapit error 404: Not Found")
+
+        try:
+            # attempt to parse error from json
+            res_json = res.json()
+            if 'error' in res_json:
+                raise PostcodeError("Mapit error {}: {}".format(res_json['code'], res_json['error']))
+            else:
+                raise PostcodeError("Mapit error {}: unknown".format(res.status_code))
+        except ValueError:
+            # if we fail to parse json, raise a less specific exception
+            raise PostcodeError("Mapit error {}: unknown".format(res.status_code))
 
     res_json = res.json()
 
-    if 'error' in res_json:
-        raise PostcodeError("Mapit error {}: {}".format(res_json['code'], res_json['error']))
-    else:
-        gss_codes = []
-        council_gss = None
-        for area in res_json['areas']:
-            if 'gss' in res_json['areas'][area]['codes']:
-                gss = res_json['areas'][area]['codes']['gss']
-                gss_codes.append(gss)
-                if res_json['areas'][area]['type'] in COUNCIL_TYPES:
-                    council_gss = gss
+    gss_codes = []
+    council_gss = None
+    for area in res_json['areas']:
+        if 'gss' in res_json['areas'][area]['codes']:
+            gss = res_json['areas'][area]['codes']['gss']
+            gss_codes.append(gss)
+            if res_json['areas'][area]['type'] in COUNCIL_TYPES:
+                council_gss = gss
 
-        return {
-            'wgs84_lon': res_json['wgs84_lon'],
-            'wgs84_lat': res_json['wgs84_lat'],
-            'gss_codes': gss_codes,
-            'council_gss': council_gss,
-        }
+    return {
+        'wgs84_lon': res_json['wgs84_lon'],
+        'wgs84_lat': res_json['wgs84_lat'],
+        'gss_codes': gss_codes,
+        'council_gss': council_gss,
+    }
 
 
 # sort a list of tuples by key in natural/human order

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -62,6 +62,11 @@ def geocode(postcode):
         # we hit MapIt's rate limit
         raise RateLimitError("Mapit error 403: Rate limit exceeded")
 
+    if res.status_code == 404:
+        # if mapit returns 404, it returns HTML even if we requested json
+        # this will cause an unhandled exception if we try to parse it
+        raise PostcodeError("Mapit error {}: {}".format(res.status_code, 'Not Found'))
+
     res_json = res.json()
 
     if 'error' in res_json:


### PR DESCRIPTION
If we try to feed something into mapit that doesn't match a route, the 404 mapit response is html not json (because it is Django's router throwing the 404 - none of the view code is ever invoked in this situation). Trying to parse it as json throws `ValueError`. This patch fixes that by re-throwing it as `PostcodeError`.

This also sort of addresses issue #372, in that if this happens as a result of requesting something like `/postcode/tel:029`, the user now sees

```
Sorry, we can't find tel:029

This doesn't appear to be a valid postcode.
```

instead of throwing an unhandled exception.

Looking at the info in Sentry ( https://sentry.io/democracy-club-gp/pollingstationsprod/issues/168417308/ ), 93% of these errors are from IE6 on Windows XP (I guess because IE6 just doesn't understand what to to with `tel:`) and I'm personally not *particularly* bothered about optimising for a 15 year old browser. Dunno if you want to say this also fixes issue #372 or not..? I'll leave it up to you