### PR TITLE
Optimise ResidentialAddress queries

### DIFF
--- a/polling_stations/apps/data_collection/tests/fixtures/address_importer/addresses.csv
+++ b/polling_stations/apps/data_collection/tests/fixtures/address_importer/addresses.csv
@@ -4,7 +4,10 @@ address,postcode,polling_station
 "36 Abbots Park, London","SW2 3QD",3
 "36 Abbots Park, London","SW2 3QD",3
 "3 Factory Rd, Poole","BH16 5HT",1
+"4 Factory Rd, Poole","BH16 5HT",1
+"5 Factory Rd, Poole","BH16 5HT",1
 "5-6 Mickleton Dr, Southport",PR82QX,1
 "5/6, Mickleton Dr.  Southport",PR82QX,2
 "5-6 mickleton dr southport",PR82QX,1
 "80 Pine Vale Cres, Bournemouth","BH10 6BJ",2
+"81 Pine Vale Cres, Bournemouth","BH10 6BJ",1

--- a/polling_stations/apps/data_collection/tests/test_importers.py
+++ b/polling_stations/apps/data_collection/tests/test_importers.py
@@ -162,9 +162,20 @@ class ImporterTest(TestCase):
 
         addresses = ResidentialAddress.objects\
                                       .filter(council_id='X01000000')\
-                                      .order_by('address')
+                                      .order_by('postcode', 'address')
 
-        self.assertEqual(3, len(addresses))
-        self.assertEqual('36 Abbots Park, London', addresses[0].address)
-        self.assertEqual('3 Factory Rd, Poole', addresses[1].address)
-        self.assertEqual('80 Pine Vale Cres, Bournemouth', addresses[2].address)
+        self.assertEqual(4, len(addresses))
+
+        # this postcode contains addresses mapping to more than one
+        # station so we import the individual addresses
+        self.assertEqual('BH106BJ', addresses[0].postcode)
+        self.assertEqual('80 Pine Vale Cres, Bournemouth', addresses[0].address)
+        self.assertEqual('BH106BJ', addresses[1].postcode)
+        self.assertEqual('81 Pine Vale Cres, Bournemouth', addresses[1].address)
+
+        # all addresses in these postcodes map to the same station
+        # so we collapse to a single postcode record
+        self.assertEqual('BH165HT', addresses[2].postcode)
+        self.assertEqual('', addresses[2].address)
+        self.assertEqual('SW23QD', addresses[3].postcode)
+        self.assertEqual('', addresses[3].address)


### PR DESCRIPTION
This is an optimisation that I actually thought of doing some time ago, but kind of mentally parked it because the changes in PR #359 were needed first. I've been thinking about performance if we import the electoral roll for most of the country and that has resurfaced the thought.

Here's the lowdown:
When we import a `ResidentialAddress` dataset, we currently import every address. However, in the majority of cases every address with a particular postcode is mapped to the same polling station. In these situations, we can collapse all of those addresses into a single record for that postcode and only store the individual addresses where the addresses described by a given postcode are split between >1 stations. By only storing the addresses we need, we massively reduce the search space for `ResidentialAddress` queries and improve performance.

This does add a bit more processing to the import process, but it doesn't slow it down by much.

As a happy side effect, this also means that where we have `ResidentialAddress` data, the page the user is directed to has a more meaningful slug because we are creating a postcode-level slug rather than just picking a random address with the same postcode the user entered (which is what we currently do).

As far as I can see, this doesn't create any additional problems that don't already exist but if you can think of any edge cases I haven't considered, let me know.

The only down side I can think of is it would prevent us from doing issue #234, but it isn't something we're doing at the moment so it doesn't break any existing functionality and we can always review the performance tradeoff if we decide we do want to add that.