### PR TITLE
Scraper report

### DIFF
--- a/polling_stations/apps/data_collection/urls.py
+++ b/polling_stations/apps/data_collection/urls.py
@@ -2,11 +2,12 @@ from django.conf.urls import patterns, include, url
 from django.conf import settings
 from django.views.decorators.cache import cache_page
 
-from .views import LeagueTable
+from .views import LeagueTable, MorphReport
 
 urlpatterns = patterns(
     '',
     url(r'^/$', LeagueTable.as_view(), name='league_table'),
+    url(r'/scraper_report/$', MorphReport.as_view(), name='scraper_report'),
     url(r'/data_quality/(?P<council_id>.+)/$', 'data_collection.views.data_quality', name='data_quality'),
 )
 

--- a/polling_stations/apps/data_collection/views.py
+++ b/polling_stations/apps/data_collection/views.py
@@ -35,11 +35,17 @@ class MorphReport(TemplateView):
         return message % (date_formatted, date_human)
 
     def query(self):
-        url = "https://api.morph.io/wdiv-scrapers/dc-meta-scraper/data.json"
-        url += "?key=%s&query=select%%20*%%20from%%20%%27report%%27%%3B"
-        url = url % (settings.MORPH_API_KEY)
 
-        res = requests.get(url)
+        url = "https://api.morph.io/wdiv-scrapers/dc-meta-scraper/data.json"
+        query = "SELECT * FROM 'report' ORDER BY "
+        query += "(CASE WHEN changes>0 THEN 1 ELSE 0 END) DESC, "
+        query += "last_changed DESC, council_id, entity;"
+        payload = {
+            'key': settings.MORPH_API_KEY,
+            'query': query
+        }
+
+        res = requests.get(url, payload)
         if res.status_code != 200:
             res.raise_for_status()
         return res.json()

--- a/polling_stations/apps/data_collection/views.py
+++ b/polling_stations/apps/data_collection/views.py
@@ -1,6 +1,9 @@
+import requests
+from datetime import datetime
+from django.conf import settings
 from django.db.models import Case, IntegerField, Q, Value, When
 from django.shortcuts import get_object_or_404, render
-from django.views.generic import ListView
+from django.views.generic import ListView, TemplateView
 from .models import DataQuality
 
 
@@ -18,6 +21,46 @@ class LeagueTable(ListView):
         )\
         .order_by('-has_report', 'council__name')
 
+
+class MorphReport(TemplateView):
+    template_name = 'data_collection/morph_report.html'
+
+    def get_timestamp_message(self, message, timestamp):
+        """
+        Used for printing a messages like
+        'bla bla bla [date] (N days ago)'
+        """
+        date_formatted = datetime.strftime(timestamp, '%Y-%m-%d')
+        date_human = TimeHelper.days_ago(timestamp)
+        return message % (date_formatted, date_human)
+
+    def query(self):
+        url = "https://api.morph.io/wdiv-scrapers/dc-meta-scraper/data.json"
+        url += "?key=%s&query=select%%20*%%20from%%20%%27report%%27%%3B"
+        url = url % (settings.MORPH_API_KEY)
+
+        res = requests.get(url)
+        if res.status_code != 200:
+            res.raise_for_status()
+        return res.json()
+
+    def get_context_data(self, **context):
+        data = self.query()
+        context = { 'data': [] }
+        for council in data:
+            started_polling = TimeHelper.parse_timestamp(council['started_polling'])
+            council['started_polling'] = self.get_timestamp_message(
+                '%s<br />(%s days ago)', started_polling)
+
+            last_changed = TimeHelper.parse_timestamp(council['last_changed'])
+            council['last_changed'] = self.get_timestamp_message(
+                '%s<br />(%s days ago)', last_changed)
+
+            context['data'].append(council)
+
+        return context
+
+
 def data_quality(request, council_id):
     data = get_object_or_404(DataQuality.objects.select_related('council'),
         pk=council_id)
@@ -25,3 +68,17 @@ def data_quality(request, council_id):
         'summary': data
     }
     return render(request, 'data_collection/dataquality_detail.html', context)
+
+
+class TimeHelper:
+
+    @staticmethod
+    def parse_timestamp(timestamp, tz=True):
+        if tz:
+            return datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f+00:00')
+        else:
+            return datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f')
+
+    @staticmethod
+    def days_ago(timestamp):
+        return abs(datetime.utcnow() - timestamp).days

--- a/polling_stations/templates/data_collection/morph_report.html
+++ b/polling_stations/templates/data_collection/morph_report.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="columns large-centered columns large-9 card">
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Scraper</th>
+            <th>Entity</th>
+            <th>Started Polling</th>
+            <th>Times Changed</th>
+            <th>Last Changed</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for council in data %}
+            <tr>
+                <td>{{ council.council_id }}</td>
+                <td>
+                    <a href="https://morph.io/wdiv-scrapers/{{ council.scraper }}/">
+                    {{ council.scraper }}
+                    </a>
+                </td>
+                <td>{{ council.entity }}</td>
+                <td>{{ council.started_polling|safe }}</td>
+                <td>{{ council.changes }}</td>
+                <td>{{ council.last_changed|safe }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Had this knocking about for a while now. There may be one or 2 kinks still to work out with scrapers that occasionally generate a false positive (i.e: reporting the data has changed when the content isn't fundamentally different) but I think at this stage it is probably useful to get it in the repo. It will provide useful info about which import scripts we need to re-run as we get closer to the elections in May.