### PR TITLE
Improve address sorting

### DIFF
--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -98,11 +98,36 @@ def geocode(postcode):
     }
 
 
-# sort a list of tuples by key in natural/human order
-def natural_sort(l, key):
-    convert = lambda text: int(text) if text.isdigit() else text
-    alphanum_key = lambda item: [ convert(c) for c in re.split('([0-9]+)', key(item)) ]
-    return sorted(l, key = alphanum_key)
+class AddressSorter:
+    # Class for sorting sort a list of tuples
+    # containing addresses (defined by key function)
+    # in a human-readable order.
+
+    def convert(self, text):
+        # if text is numeric, covert to an int
+        # this allows us to sort numbers in int order, not string order
+        return int(text) if text.isdigit() else text
+
+    def alphanum_key(self, tup):
+        # split the desired component of tup (defined by key function)
+        # into a listof numeric and text components
+        return [ self.convert(c) for c in filter(None, re.split('([0-9]+)', self.key(tup))) ]
+
+    def swap_fields(self, item):
+        lst = self.alphanum_key(item)
+        # swap things about so we can sort by street name, house number
+        # instead of house number, street name
+        if len(lst) > 1 and isinstance(lst[0], int) and isinstance(lst[1], str) and (lst[1][0].isspace() or lst[1][0] == ','):
+            lst[0], lst[1] = lst[1], lst[0]
+        if len(lst) > 1 and isinstance(lst[0], int) and isinstance(lst[1], int):
+            lst[0], lst[1] = lst[1], lst[0]
+        if isinstance(lst[0], int):
+            lst[0] = str(lst[0])
+        return lst
+
+    def natural_sort(self, lst, key):
+        self.key = key
+        return sorted(lst, key = self.swap_fields)
 
 
 class OrsDirectionsApiError(Exception):

--- a/polling_stations/apps/data_finder/tests/test_address_sorter.py
+++ b/polling_stations/apps/data_finder/tests/test_address_sorter.py
@@ -1,0 +1,120 @@
+from operator import itemgetter
+from django.test import TestCase
+from data_finder.helpers import AddressSorter
+
+class AddressSorterTest(TestCase):
+
+    def setUp(self):
+        self.sorter = AddressSorter()
+        self.key = itemgetter(1)
+
+    def test_numeric_order(self):
+        # Addresses should sort in numeric order, not string order
+        in_list = [
+            (1, "10, THE SQUARE, BOGNOR REGIS"),
+            (2, "1, THE SQUARE, BOGNOR REGIS"),
+            (3, "2, THE SQUARE, BOGNOR REGIS"),
+        ]
+
+        expected = [
+            (2, "1, THE SQUARE, BOGNOR REGIS"),
+            (3, "2, THE SQUARE, BOGNOR REGIS"),
+            (1, "10, THE SQUARE, BOGNOR REGIS"),
+        ]
+
+        result = self.sorter.natural_sort(in_list, self.key)
+
+        self.assertEqual(expected, result)
+
+    def test_group_by_street(self):
+        # Numbered addresses should group by street/building
+        in_list = [
+            (1, "1  Haynes House Mount Pleasant"),
+            (2, "1  Partridge House Mount Pleasant"),
+            (3, "3  Haynes House Mount Pleasant"),
+            (4, "2  Partridge House Mount Pleasant"),
+            (5, "2  Haynes House Mount Pleasant"),
+        ]
+
+        expected = [
+            (1, "1  Haynes House Mount Pleasant"),
+            (5, "2  Haynes House Mount Pleasant"),
+            (3, "3  Haynes House Mount Pleasant"),
+            (2, "1  Partridge House Mount Pleasant"),
+            (4, "2  Partridge House Mount Pleasant"),
+        ]
+
+        result = self.sorter.natural_sort(in_list, self.key)
+
+        self.assertEqual(expected, result)
+
+    def test_group_in_numbered_buildings(self):
+        # Numbered addresses should group inside numbered buildings
+        in_list = [
+            (1, "1  Southlands Court Birchfield Road"),
+            (2, "1 233 The Beeches Birchfield Road"),
+            (3, "207 Birchfield Road"),
+            (4, "203 Birchfield Road"),
+            (5, "2 233 The Beeches Birchfield Road"),
+            (6, "2  Southlands Court Birchfield Road"),
+        ]
+
+        expected = [
+            (2, "1 233 The Beeches Birchfield Road"),
+            (5, "2 233 The Beeches Birchfield Road"),
+            (1, "1  Southlands Court Birchfield Road"),
+            (6, "2  Southlands Court Birchfield Road"),
+            (4, "203 Birchfield Road"),
+            (3, "207 Birchfield Road"),
+        ]
+
+        result = self.sorter.natural_sort(in_list, self.key)
+
+        self.assertEqual(expected, result)
+
+    def test_number_suffix(self):
+        # Numbered addresses with number suffix should sort in
+        # numeric order and then alphabetically by suffix
+        in_list = [
+            (1, "200A Evesham Road"),
+            (2, "190A Evesham Road"),
+            (3, "The Forge Mill Evesham Road"),
+            (4, "202A Evesham Road"),
+            (5, "190C Evesham Road"),
+            (6, "190B Evesham Road"),
+        ]
+
+        expected = [
+            (2, "190A Evesham Road"),
+            (6, "190B Evesham Road"),
+            (5, "190C Evesham Road"),
+            (1, "200A Evesham Road"),
+            (4, "202A Evesham Road"),
+            (3, "The Forge Mill Evesham Road"),
+        ]
+
+        result = self.sorter.natural_sort(in_list, self.key)
+
+        self.assertEqual(expected, result)
+
+    def test_prefixed_numbers(self):
+        # Prefixed numbers (e.g: flats) should sort by number
+        in_list = [
+            (1, "Flat 10  Knapton House North Walsham Road"),
+            (2, "Gardeners Cottage   Knapton House North Walsham Road"),
+            (3, "Old Coach House North Walsham Road"),
+            (4, "Flat 1  Knapton House North Walsham Road"),
+            (5, "Flat 2  Knapton House North Walsham Road"),
+        ]
+
+        expected = [
+            (4, "Flat 1  Knapton House North Walsham Road"),
+            (5, "Flat 2  Knapton House North Walsham Road"),
+            (1, "Flat 10  Knapton House North Walsham Road"),
+            (2, "Gardeners Cottage   Knapton House North Walsham Road"),
+            (3, "Old Coach House North Walsham Road"),
+        ]
+
+        result = self.sorter.natural_sort(in_list, self.key)
+
+        self.assertEqual(expected, result)

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -28,7 +28,7 @@ from .forms import PostcodeLookupForm, AddressSelectForm
 from .helpers import (
     geocode,
     DirectionsHelper,
-    natural_sort,
+    AddressSorter,
     PostcodeError,
     RateLimitError,
     RoutingHelper
@@ -295,7 +295,8 @@ class AddressFormView(FormView):
         )
 
         select_addresses = [(element.slug, element.address) for element in addresses]
-        select_addresses = natural_sort(select_addresses, itemgetter(1))
+        sorter = AddressSorter()
+        select_addresses = sorter.natural_sort(select_addresses, itemgetter(1))
 
         if not addresses:
             raise Http404


### PR DESCRIPTION
Had a look at whether we should split address into multiple fields in the `ResidentialAddress` table, but I've come to the conclusion we will just end up solving this same problem many times over in import scripts.

This change fixes the problem identified in issue #440 and adds some tests to formalise the behaviour of the new class `AddressSorter`. If we find any more edge cases, we should fix and add additional test cases to `test_address_sorter.py `.

Closes #440