### PR TITLE
Upgrade django to 1.8.17

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-extensions
 django-filter==0.11.0
 django-localflavor==1.1
 django-model-utils==2.3.1
-django==1.8.4
+django==1.8.17
 djangorestframework==3.2.3
 fastkml==0.11
 git+git://github.com/geomet/geomet.git


### PR DESCRIPTION
In general we aren't very good about keeping dependencies up-to-date, but we should try and be better at it. Django seems like a good place to start.

This is the most recent 1.8.x (LTS) release of django and contains various bugfixes and patches for security vulns. All the tests pass and I've been running this version of django on my dev copy for a few days while working on stuff and I've not noticed any issues.