### PR TITLE
Import script for Hart

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_hart.py
+++ b/polling_stations/apps/data_collection/management/commands/import_hart.py
@@ -1,0 +1,33 @@
+from django.contrib.gis.geos import Point
+from data_collection.management.commands import BaseCsvStationsJsonDistrictsImporter
+
+class Command(BaseCsvStationsJsonDistrictsImporter):
+    srid = 27700
+    districts_srid = 27700
+    council_id = 'E07000089'
+    districts_name = 'Hart Polling Districts-fixed.geojson'
+    stations_name = 'Hart Polling Stations 2017.csv'
+    elections = ['local.hampshire.2017-05-04']
+
+    def district_record_to_dict(self, record):
+        name = str(record['properties']['Name']).strip()
+        code = name.split(' ')[1]
+        return {
+            'internal_council_id': code,
+            'name': name,
+        }
+
+    def station_record_to_dict(self, record):
+        location = Point(float(record.easting), float(record.northing), srid=self.srid)
+        stations = []
+        district_ids = record.districts.split(',')
+        district_ids = [d.strip() for d in district_ids]
+        for district_id in district_ids:
+            stations.append({
+                'internal_council_id': district_id,
+                'address' : record.polling_place,
+                'postcode': record.postcode,
+                'polling_district_id': district_id,
+                'location': location,
+            })
+        return stations


### PR DESCRIPTION
I don't think there is anything actionable to do based on this, but I want to explain what I've done just so that someone else is aware of it.

* Districts shapefile supplied by Hart was corrupt in 2 ways:
  * It was misreporting its CRS as WGS84, but the co-ordinates were actually in UK National Grid.
  * There was a feature with a null geometry (with a district code that doesn't appear in the stations file).
* I was able to import the file into QGIS (if I manually set the CRS correctly), but GDAL was only able to parse up to the null geometry. It wouldn't import anything else in the file after that.
* I tried fixing the shapefile by re-exporting the layer from QGIS - same problem
* I tried fixing the shapefile by running `ogr2ogr -skipfailures fixed_shapefile.shp corrupted_shapefile.shp` - same problem.
* I managed to fix it by exporting as GeoJSON, opening in a text editor, removing the feature with no geometry and slapping that on S3.
* Note that the GeoJson file uses CRS `urn:ogc:def:crs:EPSG::27700`. This is totally legal GeoJson, but non-WGS84 CRS is not a widely supported feature of the spec.

Resulting file now imports cleanly. As far as I can see, the resulting data checks out, but obviously I've meesed about with their data a bit, so want to make it clear that I have done that.

Closes #471