### PR TITLE
Bugfix for import_polling_districts

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -399,7 +399,7 @@ class BaseDistrictsImporter(BaseImporter, metaclass=abc.ABCMeta):
                 geojson = json.dumps(district.shape.__geo_interface__)
             if self.districts_filetype == 'geojson':
                 geojson = json.dumps(district['geometry'])
-            if 'location' not in district_info and\
+            if 'area' not in district_info and\
                     (self.districts_filetype == 'shp' or\
                      self.districts_filetype == 'geojson'):
                 poly = self.clean_poly(


### PR DESCRIPTION
In situations where we have (for some reason) manually returned a district geometry in a shp/geojson importer, the key will be called `'area'` not `'location'`. This is not something we often do (I think this is only here if we need to fix a corrupt polygon or something) so I never spotted it.