### PR TITLE
Correctly handle NI councils not being in councils table

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ python manage.py migrate
 python manage.py import_councils
 ```
 
+#### Load CustomFinder for Northern Ireland
+
+The Electoral Office for Northern Ireland run their own finder. We redirect our users to that.
+
+```
+python manage.py loaddata polling_stations/apps/data_finder/fixtures/northern_ireland.json
+```
+
 #### Import some Polling District/Station data
 
 To populate your database, pass `manage.py import -e` a list of [Election IDs](https://democracyclub.org.uk/projects/election-ids/) to run all of the import scripts relating to a particular election or elections. For example:

--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -30,7 +30,7 @@ class ResidentialAddressSerializer(serializers.HyperlinkedModelSerializer):
 class PostcodeResponseSerializer(serializers.Serializer):
     polling_station_known = serializers.BooleanField(read_only=True)
     postcode_location = PointField(read_only=True)
-    custom_finder = serializers.DictField(read_only=True)
+    custom_finder = serializers.CharField(read_only=True)
     council = CouncilDataSerializer(read_only=True)
     polling_station = PollingStationGeoSerializer(read_only=True)
     addresses = ResidentialAddressSerializer(read_only=True, many=True)

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -86,6 +86,7 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
                 ret['council'] = None
                 ret['polling_station'] = None
                 ret['custom_finder'] = self.generate_custom_finder(l['gss_codes'], postcode)
+                ret['addresses'] = []
                 serializer = PostcodeResponseSerializer(
                     ret, read_only=True, context={'request': request}
                 )

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -52,11 +52,10 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
     def generate_custom_finder(self, gss_codes, postcode):
         finder = CustomFinder.objects.get_custom_finder(gss_codes, postcode)
         if finder and finder.base_url:
-            return {
-                'base_url': finder.base_url,
-                'can_pass_postcode': finder.can_pass_postcode,
-                'encoded_postcode': finder.encoded_postcode,
-            }
+            if finder.can_pass_postcode:
+                return finder.base_url + finder.encoded_postcode
+            else:
+                return finder.base_url
         else:
             return None
 

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -49,6 +49,17 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
         else:
             return None
 
+    def generate_custom_finder(self, gss_codes, postcode):
+        finder = CustomFinder.objects.get_custom_finder(gss_codes, postcode)
+        if finder and finder.base_url:
+            return {
+                'base_url': finder.base_url,
+                'can_pass_postcode': finder.can_pass_postcode,
+                'encoded_postcode': finder.encoded_postcode,
+            }
+        else:
+            return None
+
     def retrieve(self, request, postcode=None, format=None, geocoder=geocode, log=True):
         postcode = postcode.replace(' ', '')
         ret = {}
@@ -70,7 +81,18 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
         try:
             council = Council.objects.get(area__covers=location)
         except ObjectDoesNotExist:
-            return Response({'detail': 'Internal server error'}, 500)
+            if postcode[:2] == 'BT' or 'N07000001' in l['gss_codes']:
+                # this postcode is in Northern Ireland
+                ret['polling_station_known'] = False
+                ret['council'] = None
+                ret['polling_station'] = None
+                ret['custom_finder'] = self.generate_custom_finder(l['gss_codes'], postcode)
+                serializer = PostcodeResponseSerializer(
+                    ret, read_only=True, context={'request': request}
+                )
+                return Response(serializer.data)
+            else:
+                return Response({'detail': 'Internal server error'}, 500)
         ret['council'] = council
 
         rh = RoutingHelper(postcode)
@@ -86,12 +108,7 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
         # get custom finder (if no polling station)
         ret['custom_finder'] = None
         if not ret['polling_station_known']:
-            finder = CustomFinder.objects.get_custom_finder(l['gss_codes'], postcode)
-            if finder and finder.base_url:
-                ret['custom_finder'] = {}
-                ret['custom_finder']['base_url'] = finder.base_url
-                ret['custom_finder']['can_pass_postcode'] = finder.can_pass_postcode
-                ret['custom_finder']['encoded_postcode'] = finder.encoded_postcode
+            ret['custom_finder'] = self.generate_custom_finder(l['gss_codes'], postcode)
 
         # create log entry
         log_data = {}

--- a/polling_stations/apps/data_finder/features/index.feature
+++ b/polling_stations/apps/data_finder/features/index.feature
@@ -47,6 +47,14 @@ Feature: Check Postcodes
     Then I should see "Choose Your Address / Street"
     Then I click "My address is not in the list"
     Then I should see "Contact Foo Council"
-    And I should see "We don't have data for your area."
-    And I should see "We think everyone should be able to find their polling station online. If you agree, please sign up below."
+    Then I should see "We don't have data for your area."
+    Then I should see "We think everyone should be able to find their polling station online. If you agree, please sign up below."
+    Then No errors were thrown
+
+    Scenario: Check Northern Ireland postcode
+    When I visit site page "/"
+    Then I should see "Find your polling station"
+    Then I fill in "postcode" with "BT1 1AA"
+    Then I submit the only form
+    Then I should see "The Electoral Office of Northern Ireland has its own polling station finder: Find your polling station"
     And No errors were thrown

--- a/polling_stations/apps/data_finder/features/index.py
+++ b/polling_stations/apps/data_finder/features/index.py
@@ -31,6 +31,7 @@ def setup(scenario, outline, steps):
     with open(os.devnull, "w") as f:
         call_command('loaddata', 'test_routing.json', stdout=f)
         call_command('loaddata', 'newport_council.json', stdout=f)
+        call_command('loaddata', 'polling_stations/apps/data_finder/fixtures/northern_ireland.json', stdout=f)
 
 @step('No errors were thrown')
 def no_errors(step):

--- a/polling_stations/apps/data_finder/fixtures/northern_ireland.json
+++ b/polling_stations/apps/data_finder/fixtures/northern_ireland.json
@@ -1,0 +1,11 @@
+[
+  {
+    "model": "pollingstations.customfinder",
+    "fields": {
+      "can_pass_postcode": true,
+      "message": "The Electoral Office of Northern Ireland has its own polling station finder:",
+      "base_url": "http://www.eoni.org.uk/Offices/Postcode-Search-Results?postcode="
+    },
+    "pk": "N07000001"
+  }
+]

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -158,6 +158,8 @@ class BasePollingStationView(
             # this postcode is in Northern Ireland
             context['custom'] = CustomFinder.objects.get_custom_finder(
                 l['gss_codes'], self.postcode)
+            if context['custom'] is None:
+                raise Http404
             return self.get_context_data_northern_ireland(**context)
 
         self.council = self.get_council()

--- a/polling_stations/templates/api_docs/blueprints/finder.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder.apibp
@@ -9,8 +9,9 @@ A `200 OK` response from `/postcode` or `/address` is an object containing the f
   containing a [Point object](http://geojson.org/geojson-spec.html#point) describing the centroid of the input postcode.
 * `polling_station`: (object, nullable) - A GeoJSON [polling station feature](#polling-stations-polling-stations-geojson-get)
 * `addresses`: (array) - An array of address objects listing the addresses applicable to this request (if necessary).
-* `council`: (object) - A [Council](#councils-councils-json-get) object describing the local authority which covers this postcode.
+* `council`: (object, nullable) - A [Council](#councils-councils-json-get) object describing the local authority which covers this postcode.
   If we do not know the user's polling station, this can be used to provide contact info for their local council.
+  Council may be `null` if we are not able to determine the user's council or the postcode given is in Northern Ireland.
 * `custom_finder`: (string, nullable) - If we don't know a user's polling station,
   sometimes we can provide the URL of a polling station finder provided by their local council.
 

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/schema.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/schema.apibp
@@ -96,7 +96,10 @@
                   "description": "An array of address objects listing the addresses applicable to this request (if necessary)."
                 },
                 "council": {
-                  "type": "object",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
                   "properties": {
                     "url": {
                       "type": "string",

--- a/polling_stations/templates/api_docs/html/docs.html
+++ b/polling_stations/templates/api_docs/html/docs.html
@@ -25,8 +25,9 @@ containing a <a href="http://geojson.org/geojson-spec.html#point">Point object</
 <p><code>addresses</code>: (array) - An array of address objects listing the addresses applicable to this request (if necessary).</p>
 </li>
 <li>
-<p><code>council</code>: (object) - A <a href="#councils-councils-json-get">Council</a> object describing the local authority which covers this postcode.
-If we do not know the user’s polling station, this can be used to provide contact info for their local council.</p>
+<p><code>council</code>: (object, nullable) - A <a href="#councils-councils-json-get">Council</a> object describing the local authority which covers this postcode.
+If we do not know the user’s polling station, this can be used to provide contact info for their local council.
+Council may be <code>null</code> if we are not able to determine the user’s council or the postcode given is in Northern Ireland.</p>
 </li>
 <li>
 <p><code>custom_finder</code>: (string, nullable) - If we don’t know a user’s polling station,
@@ -207,7 +208,10 @@ the following conditions can be observed in the response body:</p>
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"An array of address objects listing the addresses applicable to this request (if necessary)."</span>
     </span>}</span>,
     "<span class="hljs-attribute">council</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value">[
+        <span class="hljs-string">"object"</span>,
+        <span class="hljs-string">"null"</span>
+      ]</span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
         "<span class="hljs-attribute">url</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
@@ -440,7 +444,10 @@ This can be used to request the user’s address and make a second API call to t
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"An array of address objects listing the addresses applicable to this request (if necessary)."</span>
     </span>}</span>,
     "<span class="hljs-attribute">council</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value">[
+        <span class="hljs-string">"object"</span>,
+        <span class="hljs-string">"null"</span>
+      ]</span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
         "<span class="hljs-attribute">url</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
@@ -636,7 +643,10 @@ the following conditions can be observed in the response body:</p>
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"An array of address objects listing the addresses applicable to this request (if necessary)."</span>
     </span>}</span>,
     "<span class="hljs-attribute">council</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value">[
+        <span class="hljs-string">"object"</span>,
+        <span class="hljs-string">"null"</span>
+      ]</span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
         "<span class="hljs-attribute">url</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
@@ -867,7 +877,10 @@ the following conditions can be observed in the response body:</p>
       "<span class="hljs-attribute">description</span>": <span class="hljs-value"><span class="hljs-string">"An array of address objects listing the addresses applicable to this request (if necessary)."</span>
     </span>}</span>,
     "<span class="hljs-attribute">council</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
+      "<span class="hljs-attribute">type</span>": <span class="hljs-value">[
+        <span class="hljs-string">"object"</span>,
+        <span class="hljs-string">"null"</span>
+      ]</span>,
       "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
         "<span class="hljs-attribute">url</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span></span>,
@@ -1576,7 +1589,7 @@ containing a GIS boundary and meta-data about a polling district.</p>
   </span>}
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>404</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">detail</span>": <span class="hljs-value"><span class="hljs-string">"Not found."</span>
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 09 Feb 2017</p><script>/* eslint-env browser */
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 12 Mar 2017</p><script>/* eslint-env browser */
 /* eslint quotes: [2, "single"] */
 'use strict';
 

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-northern-ireland-postcode/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-northern-ireland-postcode/then-i-submit-the-only-form.yaml
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.7.0 CPython/3.4.3 Linux/3.13.0-105-generic]
+    method: GET
+    uri: http://mapit.democracyclub.org.uk//postcode/BT11AA
+  response:
+    body: {string: '
+        {
+          "wgs84_lat": 54.550429095775804,
+          "wgs84_lon": -6.206229421006293,
+          "postcode": "BT1 1AA",
+          "easting": 316117,
+          "northing": 368380,
+          "areas": {
+            "1": {
+              "parent_area": null,
+              "codes": {
+                "gss": "N07000001"
+              },
+              "name": "Northern Ireland",
+              "type": "EUR"
+            }
+          }
+        }'
+    }
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=2419200]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sun, 12 Mar 2017 20:46:58 GMT']
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=631138519]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [DENY]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1


### PR DESCRIPTION
This PR goes hand-in-hand with the changes in #441 (it probably doesn't make much sense without that). It adds a variety of special cases so that we can direct NI users to the EONI site without having to have the NI councils in the councils table (and not throw 500 errors). Note that we are now relying on a `CustomFinder` record for the EONI finder being present (although we fail slightly more cleanly without it). I've added a fixture and a note in the `README.md`. I did also want to add a system check for it, but Django doesn't seem to like you trying to load a model in the system checks (I think it hasn't fully bootstrapped the app yet at the point it runs the checks) so I don't think that is an option. Dunno if you've got any other ideas on that?

Additionally, this probably creates a merge conflict with the acceptance tests in PR #501 so one or other will probably need rebasing in order to merge both.

Refs #441
Also closes #531 as it became relevant here too.

Btw, cheers for sorting coverage reports out today. Having it has already provided incentive for me to add tests that I probably wouldn't have bothered to write if I had done this yesterday :D