### PR TITLE
ignore files called tests.py in coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     */tests/*
+    */tests.py
     */apps.py
     */migrations/*
     polling_stations/wsgi.py


### PR DESCRIPTION
ronseal