### PR TITLE
Add ability to import zipped shapefile/csv from the web, update Lichfield importer

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -271,7 +271,7 @@ class BaseStationsImporter(BaseImporter, metaclass=abc.ABCMeta):
             except NotImplementedError:
                 pass
 
-            if self.stations_filetype == 'shp':
+            if self.stations_filetype in ['shp', 'shp.zip']:
                 record = station.record
             else:
                 record = station
@@ -317,7 +317,7 @@ class BaseStationsImporter(BaseImporter, metaclass=abc.ABCMeta):
                 For other file types, we must return the key
                 'location' from station_record_to_dict()
                 """
-                if self.stations_filetype == 'shp' and 'location' not in station_record:
+                if self.stations_filetype in ['shp', 'shp.zip'] and 'location' not in station_record:
                     station_record['location'] = Point(
                         *station.shape.points[0],
                         srid=self.get_srid())
@@ -369,7 +369,7 @@ class BaseDistrictsImporter(BaseImporter, metaclass=abc.ABCMeta):
     def import_polling_districts(self):
         districts = self.get_districts()
         for district in districts:
-            if self.districts_filetype == 'shp':
+            if self.districts_filetype in ['shp', 'shp.zip']:
                 district_info = self.district_record_to_dict(district.record)
             else:
                 district_info = self.district_record_to_dict(district)
@@ -395,13 +395,12 @@ class BaseDistrictsImporter(BaseImporter, metaclass=abc.ABCMeta):
             For other file types, we must return the key
             'area' from address_record_to_dict()
             """
-            if self.districts_filetype == 'shp':
+            if self.districts_filetype in ['shp', 'shp.zip']:
                 geojson = json.dumps(district.shape.__geo_interface__)
             if self.districts_filetype == 'geojson':
                 geojson = json.dumps(district['geometry'])
             if 'area' not in district_info and\
-                    (self.districts_filetype == 'shp' or\
-                     self.districts_filetype == 'geojson'):
+                    (self.districts_filetype in ['shp', 'shp.zip', 'geojson']):
                 poly = self.clean_poly(
                     GEOSGeometry(geojson, srid=self.get_srid('districts')))
                 district_info['area'] = poly
@@ -858,3 +857,13 @@ class BaseApiKmlStationsKmlDistrictsImporter(BaseGenericApiImporter):
 
     stations_filetype = 'kml'
     districts_filetype = 'kml'
+
+
+class BaseApiShpZipStationsShpZipDistrictsImporter(BaseGenericApiImporter):
+    """
+    Stations in Zipped SHP format
+    Districts in Zipped SHP format
+    """
+
+    stations_filetype = 'shp.zip'
+    districts_filetype = 'shp.zip'

--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -867,3 +867,14 @@ class BaseApiShpZipStationsShpZipDistrictsImporter(BaseGenericApiImporter):
 
     stations_filetype = 'shp.zip'
     districts_filetype = 'shp.zip'
+
+
+class BaseApiCsvStationsShpZipDistrictsImporter(BaseGenericApiImporter,
+                                                CsvMixin):
+    """
+    Stations in CSV format
+    Districts in Zipped SHP format
+    """
+
+    stations_filetype = 'csv'
+    districts_filetype = 'shp.zip'

--- a/polling_stations/apps/data_collection/filehelpers.py
+++ b/polling_stations/apps/data_collection/filehelpers.py
@@ -41,6 +41,8 @@ class CsvHelper:
             '.': '_',
             '(': '',
             ')': '',
+            '/': '_',
+            '\\': '_',
         }
         clean = []
         for s in header:

--- a/polling_stations/apps/data_collection/filehelpers.py
+++ b/polling_stations/apps/data_collection/filehelpers.py
@@ -1,5 +1,7 @@
 import csv
+import fnmatch
 import json
+import os
 import shapefile
 import tempfile
 import zipfile
@@ -8,6 +10,13 @@ from collections import namedtuple
 
 from django.contrib.gis.gdal import DataSource, GDALException
 
+
+def recursive_find(path, pattern):
+    matches = []
+    for root, dirnames, filenames in os.walk(path):
+        for filename in fnmatch.filter(filenames, pattern):
+            matches.append(os.path.join(root, filename))
+    return matches
 
 """
 Helper class for reading data from CSV files
@@ -56,12 +65,28 @@ Helper class for reading geographic data from ESRI SHP files
 """
 class ShpHelper:
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, zip=False):
         self.filepath = filepath
+        self.zip = zip
 
     def get_features(self):
-        sf = shapefile.Reader(self.filepath)
-        return sf.shapeRecords()
+        # If our shapefile is in a zip, extract it
+        # otherwise, we can read it directly
+        if self.zip:
+            zip_file = zipfile.ZipFile(self.filepath, 'r')
+            tmpdir = tempfile.mkdtemp()
+            zip_file.extractall(tmpdir)
+
+            shp_files = recursive_find(tmpdir, "*.shp")
+            if len(shp_files) != 1:
+                raise ValueError('Found %i shapefiles in archive' % len(shp_files))
+            shp_file = shp_files[0]
+
+            sf = shapefile.Reader(shp_file)
+            return sf.shapeRecords()
+        else:
+            sf = shapefile.Reader(self.filepath)
+            return sf.shapeRecords()
 
 
 """
@@ -135,6 +160,8 @@ class FileHelperFactory():
     def create(filetype, filepath, options):
         if (filetype == 'shp'):
             return ShpHelper(filepath)
+        elif (filetype == 'shp.zip'):
+            return ShpHelper(filepath, zip=True)
         elif (filetype == 'kml'):
             return KmlHelper(filepath)
         elif (filetype == 'geojson'):
@@ -143,3 +170,5 @@ class FileHelperFactory():
             return JsonHelper(filepath)
         elif (filetype == 'csv'):
             return CsvHelper(filepath, options['encoding'], options['delimiter'])
+        else:
+            raise ValueError('Unexpected file type: %s' % (filetype))

--- a/polling_stations/apps/data_collection/management/commands/__init__.py
+++ b/polling_stations/apps/data_collection/management/commands/__init__.py
@@ -8,4 +8,5 @@ from data_collection.base_importers import (
     BaseHalaroseCsvImporter,
     BaseShpStationsCsvAddressesImporter,
     BaseApiKmlStationsKmlDistrictsImporter,
+    BaseApiShpZipStationsShpZipDistrictsImporter,
 )

--- a/polling_stations/apps/data_collection/management/commands/__init__.py
+++ b/polling_stations/apps/data_collection/management/commands/__init__.py
@@ -9,4 +9,5 @@ from data_collection.base_importers import (
     BaseShpStationsCsvAddressesImporter,
     BaseApiKmlStationsKmlDistrictsImporter,
     BaseApiShpZipStationsShpZipDistrictsImporter,
+    BaseApiCsvStationsShpZipDistrictsImporter,
 )

--- a/polling_stations/apps/data_collection/management/commands/import_lichfield.py
+++ b/polling_stations/apps/data_collection/management/commands/import_lichfield.py
@@ -1,20 +1,11 @@
-from data_collection.management.commands import BaseShpStationsShpDistrictsImporter
+from data_collection.management.commands import BaseApiShpZipStationsShpZipDistrictsImporter
 
-"""
-Lichfield publish their data on data.gov.uk as zipped shp files
-
-I've uploaded the data to Amazon S3 for import purposes
-
-Additionally there's a hashes only scraper at
-https://morph.io/wdiv-scrapers/DC-PollingStations-Lichfield
-polling the URLs to look for changes.
-"""
-
-class Command(BaseShpStationsShpDistrictsImporter):
+class Command(BaseApiShpZipStationsShpZipDistrictsImporter):
     srid = 27700
+    districts_srid = 27700
     council_id = 'E07000194'
-    districts_name = 'local.staffordshire.2017-05-04/Lichfield District Council Polling Districts Shapefile/Lichfield_District_Council_Polling_Districts'
-    stations_name = 'local.staffordshire.2017-05-04/LDC_Polling_Stations_Shapefile/Lichfield_District_Council_Polling_Station_Locations.shp'
+    districts_url = 'https://www.lichfielddc.gov.uk/Inspire-data-sets/Lichfield%20District%20Council%20Polling%20Districts/Lichfield%20District%20Council%20Polling%20Districts%20Shapefile.zip'
+    stations_url = 'https://www.lichfielddc.gov.uk/Inspire-data-sets/Lichfield%20District%20Council%20Polling%20Stations/LDC_Polling_Stations_Shapefile.zip'
     elections = ['local.staffordshire.2017-05-04']
 
     def district_record_to_dict(self, record):


### PR DESCRIPTION
This PR adds the ability to import zipped files straight from the web (instead of downloading and uploading to S3, which is what we do at the moment). I originally did this work in the context of Uttlesford and wrote the base classes before realising that their data had major problems. I've decided to pull the work on the base classes out and merge it ahead of that as we haven't had any response from them.
At the moment, this just makes it easier to update data from Lichfield if they publish new data. This is a useful improvement in itself, but I've also added `BaseApiCsvStationsShpZipDistrictsImporter`. Right now no importers use this but if we get updated data from Uttlesford, this will be the class to use. These classes may also prove useful for importing data from other councils.