### PR TITLE
Throw PostcodeError on 'No location information' from mapit

### DIFF
--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -86,6 +86,9 @@ def geocode(postcode):
             if res_json['areas'][area]['type'] in COUNCIL_TYPES:
                 council_gss = gss
 
+    if 'wgs84_lon' not in res_json or 'wgs84_lat' not in res_json:
+        raise PostcodeError("No location information")
+
     return {
         'wgs84_lon': res_json['wgs84_lon'],
         'wgs84_lat': res_json['wgs84_lat'],


### PR DESCRIPTION
Turns out Mapit will sometimes return a `200 OK` but no point or areas. e.g:
http://mapit.democracyclub.org.uk/postcode/JE37DW.html
http://mapit.democracyclub.org.uk/postcode/JE37DW.json
(this particular postcode is in Jersey).

These postcodes were causing us to throw an unhandled exception. This patch converts this to a `PostcodeException` which we handle cleanly.

Closes #573