### PR TITLE
Improve validation on postcode endpoint

### DIFF
--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -188,8 +188,9 @@ class PostcodeView(BasePollingStationView):
 
         if 'postcode' in request.GET:
             self.kwargs['postcode'] = kwargs['postcode'] = request.GET['postcode']
-        if 'postcode' not in kwargs:
+        if 'postcode' not in kwargs or kwargs['postcode'] == '':
             return HttpResponseRedirect(reverse('home'))
+        self.kwargs['postcode'] = kwargs['postcode'] = kwargs['postcode'].upper().replace(' ', '')
 
         rh = RoutingHelper(self.kwargs['postcode'])
         endpoint = rh.get_endpoint()


### PR DESCRIPTION
See comments in issue #608 for more detail. The following calls all do something sensible:

`/postcode/?postcode=CV3%202DF`
`/postcode/?postcode=CV3+2DF`
`/postcode/?postcode=cv32df`
`/postcode/?postcode=CV6%207JF`
`/postcode/?postcode=CV6+7JF`
`/postcode/?postcode=cv67jf`
`/postcode/?postcode=blablabla`
`/postcode/?postcode=`
`/postcode/CV3%202DF`
`/postcode/cv32df`
`/postcode/CV6%207JF`
`/postcode/cv67jf`
`/postcode/blablabla`
`/postcode/`

Coventry have actually added some javascript to their form which converts everything to uppercase and strips the whitespace, but we should have this in place on our side in case people don't have JS enabled or other councils would like to do something similar.

closes #608