### PR TITLE
Never fall back to station in district lookup

### DIFF
--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -70,15 +70,8 @@ class PollingStationManager(models.GeoManager):
             # do not fall back and attempt point within polygon lookup
             return station
         else:
-            # only try a point within polygon lookup
-            # if polling_station_id is not set
-            station = self.filter(
-                location__within=polling_district.area, council_id=council_id)
-            if len(station) == 1:
-                return station[0]
-            else:
-                # make this explicit rather than implied
-                return None
+            # make this explicit rather than implied
+            return None
 
     def get_polling_station_by_id(self, internal_council_id, council_id):
         station = self.filter(

--- a/polling_stations/apps/pollingstations/tests/test_polling_station_manager.py
+++ b/polling_stations/apps/pollingstations/tests/test_polling_station_manager.py
@@ -50,3 +50,11 @@ class PollingStationsDistrictIdTest(TestCase, PollingStationsTestBase):
 # test lookup when we match based on point in polygon
 class PollingStationsPointInPolygonTest(TestCase, PollingStationsTestBase):
     fixtures = ['test_polling_stations_polygon.json']
+
+    def test_good(self):
+        # this point will be in district AA
+        point = Point(-2.1588134765625, 52.8193630015979)
+        station = PollingStation.objects.get_polling_station(
+            'X01000001', location=point)
+        # district AA has a blank station refernce
+        self.assertIsNone(station)


### PR DESCRIPTION
Was looking at something else and realised this is still here. I think we left this case here to deal with City of London lat year, but it may now be returning an incorrect result in situtations where we have an orphan district, which does occasionally happen. If we can't attach a station to a district using `polling_station.polling_district_id` or `polling_district.polling_station_id`, this function should return `None`. We hold no data this year that should be matching this case.