### PR TITLE
Fix race conditions running Scotland import scripts

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -598,6 +598,7 @@ class BaseScotlandSpatialHubImporter(BaseShpStationsShpDistrictsImporter,
     districts_name = 'polling_districts_20170406/polling_districts_20170406.shp'
     stations_name = 'polling_places_20170407/polling_places_20170407.shp'
     data_prefix = 'Scotland May 2017'
+    run_in_series = True
 
     @property
     @abc.abstractmethod


### PR DESCRIPTION
This isn't the most sophisticated approach to this, but I've added a flag which allows us to set particular import scripts not to run in parallel (even when we run with the `--multiprocessing` argument). I've then used that to set all the Scotland scripts to run in series.

Closes #720