### PR TITLE
Sort addresses in API outputs

### DIFF
--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from councils.models import Council
 from data_finder.views import LogLookUpMixin
 from data_finder.helpers import (
+    AddressSorter,
     geocode,
     PostcodeError,
     RateLimitError,
@@ -34,7 +35,8 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
 
     def generate_addresses(self, routing_helper):
         if routing_helper.route_type == "multiple_addresses":
-            return [address for address in routing_helper.addresses]
+            sorter = AddressSorter(routing_helper.addresses)
+            return sorter.natural_sort()
         return []
 
     def generate_polling_station(self, routing_helper, council, location):

--- a/polling_stations/apps/data_finder/tests/test_address_sorter.py
+++ b/polling_stations/apps/data_finder/tests/test_address_sorter.py
@@ -1,74 +1,76 @@
-from operator import itemgetter
+from collections import namedtuple
 from django.test import TestCase
 from data_finder.helpers import AddressSorter
+from pollingstations.models import ResidentialAddress
+
+Address = namedtuple('Address', ['id', 'address'])
 
 class AddressSorterTest(TestCase):
-
-    def setUp(self):
-        self.sorter = AddressSorter()
-        self.key = itemgetter(1)
 
     def test_numeric_order(self):
         # Addresses should sort in numeric order, not string order
         in_list = [
-            (1, "10, THE SQUARE, BOGNOR REGIS"),
-            (2, "1, THE SQUARE, BOGNOR REGIS"),
-            (3, "2, THE SQUARE, BOGNOR REGIS"),
+            Address(id=1, address="10, THE SQUARE, BOGNOR REGIS"),
+            Address(id=2, address="1, THE SQUARE, BOGNOR REGIS"),
+            Address(id=3, address="2, THE SQUARE, BOGNOR REGIS"),
         ]
 
         expected = [
-            (2, "1, THE SQUARE, BOGNOR REGIS"),
-            (3, "2, THE SQUARE, BOGNOR REGIS"),
-            (1, "10, THE SQUARE, BOGNOR REGIS"),
+            Address(id=2, address="1, THE SQUARE, BOGNOR REGIS"),
+            Address(id=3, address="2, THE SQUARE, BOGNOR REGIS"),
+            Address(id=1, address="10, THE SQUARE, BOGNOR REGIS"),
         ]
 
-        result = self.sorter.natural_sort(in_list, self.key)
+        sorter = AddressSorter(in_list)
+        result = sorter.natural_sort()
 
         self.assertEqual(expected, result)
 
     def test_group_by_street(self):
         # Numbered addresses should group by street/building
         in_list = [
-            (1, "1  Haynes House Mount Pleasant"),
-            (2, "1  Partridge House Mount Pleasant"),
-            (3, "3  Haynes House Mount Pleasant"),
-            (4, "2  Partridge House Mount Pleasant"),
-            (5, "2  Haynes House Mount Pleasant"),
+            Address(id=1, address="1  Haynes House Mount Pleasant"),
+            Address(id=2, address="1  Partridge House Mount Pleasant"),
+            Address(id=3, address="3  Haynes House Mount Pleasant"),
+            Address(id=4, address="2  Partridge House Mount Pleasant"),
+            Address(id=5, address="2  Haynes House Mount Pleasant"),
         ]
 
         expected = [
-            (1, "1  Haynes House Mount Pleasant"),
-            (5, "2  Haynes House Mount Pleasant"),
-            (3, "3  Haynes House Mount Pleasant"),
-            (2, "1  Partridge House Mount Pleasant"),
-            (4, "2  Partridge House Mount Pleasant"),
+            Address(id=1, address="1  Haynes House Mount Pleasant"),
+            Address(id=5, address="2  Haynes House Mount Pleasant"),
+            Address(id=3, address="3  Haynes House Mount Pleasant"),
+            Address(id=2, address="1  Partridge House Mount Pleasant"),
+            Address(id=4, address="2  Partridge House Mount Pleasant"),
         ]
 
-        result = self.sorter.natural_sort(in_list, self.key)
+        sorter = AddressSorter(in_list)
+        result = sorter.natural_sort()
 
         self.assertEqual(expected, result)
 
     def test_group_in_numbered_buildings(self):
         # Numbered addresses should group inside numbered buildings
         in_list = [
-            (1, "1  Southlands Court Birchfield Road"),
-            (2, "1 233 The Beeches Birchfield Road"),
-            (3, "207 Birchfield Road"),
-            (4, "203 Birchfield Road"),
-            (5, "2 233 The Beeches Birchfield Road"),
-            (6, "2  Southlands Court Birchfield Road"),
+            Address(id=1, address="1  Southlands Court Birchfield Road"),
+            Address(id=2, address="1 233 The Beeches Birchfield Road"),
+            Address(id=3, address="207 Birchfield Road"),
+            Address(id=4, address="203 Birchfield Road"),
+            Address(id=5, address="2 233 The Beeches Birchfield Road"),
+            Address(id=6, address="2  Southlands Court Birchfield Road"),
         ]
 
         expected = [
-            (2, "1 233 The Beeches Birchfield Road"),
-            (5, "2 233 The Beeches Birchfield Road"),
-            (1, "1  Southlands Court Birchfield Road"),
-            (6, "2  Southlands Court Birchfield Road"),
-            (4, "203 Birchfield Road"),
-            (3, "207 Birchfield Road"),
+            Address(id=2, address="1 233 The Beeches Birchfield Road"),
+            Address(id=5, address="2 233 The Beeches Birchfield Road"),
+            Address(id=1, address="1  Southlands Court Birchfield Road"),
+            Address(id=6, address="2  Southlands Court Birchfield Road"),
+            Address(id=4, address="203 Birchfield Road"),
+            Address(id=3, address="207 Birchfield Road"),
         ]
 
-        result = self.sorter.natural_sort(in_list, self.key)
+        sorter = AddressSorter(in_list)
+        result = sorter.natural_sort()
 
         self.assertEqual(expected, result)
 
@@ -76,45 +78,47 @@ class AddressSorterTest(TestCase):
         # Numbered addresses with number suffix should sort in
         # numeric order and then alphabetically by suffix
         in_list = [
-            (1, "200A Evesham Road"),
-            (2, "190A Evesham Road"),
-            (3, "The Forge Mill Evesham Road"),
-            (4, "202A Evesham Road"),
-            (5, "190C Evesham Road"),
-            (6, "190B Evesham Road"),
+            Address(id=1, address="200A Evesham Road"),
+            Address(id=2, address="190A Evesham Road"),
+            Address(id=3, address="The Forge Mill Evesham Road"),
+            Address(id=4, address="202A Evesham Road"),
+            Address(id=5, address="190C Evesham Road"),
+            Address(id=6, address="190B Evesham Road"),
         ]
 
         expected = [
-            (2, "190A Evesham Road"),
-            (6, "190B Evesham Road"),
-            (5, "190C Evesham Road"),
-            (1, "200A Evesham Road"),
-            (4, "202A Evesham Road"),
-            (3, "The Forge Mill Evesham Road"),
+            Address(id=2, address="190A Evesham Road"),
+            Address(id=6, address="190B Evesham Road"),
+            Address(id=5, address="190C Evesham Road"),
+            Address(id=1, address="200A Evesham Road"),
+            Address(id=4, address="202A Evesham Road"),
+            Address(id=3, address="The Forge Mill Evesham Road"),
         ]
 
-        result = self.sorter.natural_sort(in_list, self.key)
+        sorter = AddressSorter(in_list)
+        result = sorter.natural_sort()
 
         self.assertEqual(expected, result)
 
     def test_prefixed_numbers(self):
         # Prefixed numbers (e.g: flats) should sort by number
         in_list = [
-            (1, "Flat 10  Knapton House North Walsham Road"),
-            (2, "Gardeners Cottage   Knapton House North Walsham Road"),
-            (3, "Old Coach House North Walsham Road"),
-            (4, "Flat 1  Knapton House North Walsham Road"),
-            (5, "Flat 2  Knapton House North Walsham Road"),
+            Address(id=1, address="Flat 10  Knapton House North Walsham Road"),
+            Address(id=2, address="Gardeners Cottage   Knapton House North Walsham Road"),
+            Address(id=3, address="Old Coach House North Walsham Road"),
+            Address(id=4, address="Flat 1  Knapton House North Walsham Road"),
+            Address(id=5, address="Flat 2  Knapton House North Walsham Road"),
         ]
 
         expected = [
-            (4, "Flat 1  Knapton House North Walsham Road"),
-            (5, "Flat 2  Knapton House North Walsham Road"),
-            (1, "Flat 10  Knapton House North Walsham Road"),
-            (2, "Gardeners Cottage   Knapton House North Walsham Road"),
-            (3, "Old Coach House North Walsham Road"),
+            Address(id=4, address="Flat 1  Knapton House North Walsham Road"),
+            Address(id=5, address="Flat 2  Knapton House North Walsham Road"),
+            Address(id=1, address="Flat 10  Knapton House North Walsham Road"),
+            Address(id=2, address="Gardeners Cottage   Knapton House North Walsham Road"),
+            Address(id=3, address="Old Coach House North Walsham Road"),
         ]
 
-        result = self.sorter.natural_sort(in_list, self.key)
+        sorter = AddressSorter(in_list)
+        result = sorter.natural_sort()
 
         self.assertEqual(expected, result)

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -3,8 +3,6 @@ import json
 import re
 import requests
 
-from operator import itemgetter
-
 from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.urlresolvers import reverse
@@ -377,9 +375,9 @@ class AddressFormView(FormView):
             postcode=self.kwargs['postcode']
         )
 
+        sorter = AddressSorter(addresses)
+        addresses = sorter.natural_sort()
         select_addresses = [(element.slug, element.address) for element in addresses]
-        sorter = AddressSorter()
-        select_addresses = sorter.natural_sort(select_addresses, itemgetter(1))
 
         if not addresses:
             raise Http404

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -375,14 +375,13 @@ class AddressFormView(FormView):
             postcode=self.kwargs['postcode']
         )
 
+        if not addresses:
+            raise Http404
+
         sorter = AddressSorter(addresses)
         addresses = sorter.natural_sort()
         select_addresses = [(element.slug, element.address) for element in addresses]
-
-        if not addresses:
-            raise Http404
-        else:
-            return form_class(select_addresses, self.kwargs['postcode'], **self.get_form_kwargs())
+        return form_class(select_addresses, self.kwargs['postcode'], **self.get_form_kwargs())
 
     def form_valid(self, form):
         self.success_url = reverse(


### PR DESCRIPTION
Deploying this will sort out the address picker on the EC's YourVoteMatters site and also help us out when we come to implement the address picker on WCIVF as we don't really want to have to implement this same logic across multiple sites.

Closes #744