### PR TITLE
RFC: make choices in address select form more obvious (1)

### DIFF
--- a/polling_stations/templates/address_select.html
+++ b/polling_stations/templates/address_select.html
@@ -15,11 +15,22 @@
         {% csrf_token %}
         <div class="form-group">
             {{ form.as_p }}
-            <button type="submit" class="button" id="submit-address">
-              {% trans "I've selected my address. Find my Polling Station" %}
+
+            <p class="text-right">&nbsp;
+              <span id="clear-span" style="display:none;">
+                <a href="#" id="clear-button">
+                  <i class="fa fa-times" aria-hidden="true"></i> clear selection
+                </a>
+              </span>
+            </p>
+
+            <button type="submit" class="button" id="submit-button">
+              <i class="fa fa-check" aria-hidden="true"></i>
+              {% trans "Find my Polling Station" %}
             </button>
-            <a class="button" href="{% url "we_dont_know" postcode=form.postcode %}">
-                {% trans "My address is not in the list" %}
+
+            <a class="button" href="{% url "we_dont_know" postcode=form.postcode %}" id="wdk-button">
+              {% trans "My address is not in the list" %}
             </a>
         </div>
       </form>
@@ -39,6 +50,26 @@ fallback.ready(['jQuery'], function() {
         if (isAndroid) {
             $('.select_multirow').css('-webkit-appearance', 'menulist');
         }
+
+        var address_change_handler = function() {
+          if ($("#id_address").val() == null) {
+            $("#submit-button").addClass('disabled');
+            $("#wdk-button").removeClass('disabled');
+            $("#clear-span").hide();
+          } else {
+            $("#submit-button").removeClass('disabled');
+            $("#wdk-button").addClass('disabled');
+            $("#clear-span").show();
+          }
+        };
+        $("#id_address").on('change', address_change_handler);
+        address_change_handler();
+
+        $("#clear-button").on('click', function() {
+          $("#id_address").val(null);
+          address_change_handler();
+        });
+
     });
 });
 </script>


### PR DESCRIPTION
So over in issue #367, @mtsk3000 has helpfully given us some feedback on the address select page from a UX perspective. I've had a go at implementing his idea pretty much exactly as suggested.

On balance, I reckon this is an improvement, but the one thing I'm not 100% sure on is:

If you hit the form for the first time and see something like this:

![screenshot at 2017-04-30 20 00 10](https://cloud.githubusercontent.com/assets/6025893/25567171/e7d6d674-2ddf-11e7-9fe5-a7470585e4db.png)

does it make it look too much like 'My address is not in the list' is the default option?

@symroe (and anyone else who is interested) - can you pull it down and see what you think. Is this better or worse than it was before?

As a note, I've done this such that if the user hits the page and doesn't have javascript enabled, both buttons ar active (i.e: it works pretty much exactly how it does now) - so the javascript 'enhances' the functionality but it is not essential to the form's operation. I think the shorter button text also looks better on mobile.