### PR TITLE
use election titles from EE

### DIFF
--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -326,7 +326,10 @@ class EveryElectionWrapper:
         if len(self.elections) > 0:
             for election in self.elections:
                 if 'explanation' in election and election['explanation']:
-                    explanations.append(election['explanation'])
+                    explanations.append({
+                        'title': election['election_title'],
+                        'explanation': election['explanation'],
+                    })
         return explanations
 
 

--- a/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
+++ b/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
@@ -12,9 +12,9 @@ def get_data_no_elections(self, postcode):
 
 def get_data_with_elections(self, postcode):
     return [
-        {},  # no explanation key
-        {'explanation': None},  # null explanation key
-        {'explanation': 'some text'},  # explanation key contains text
+        {'election_title': 'some election'},  # no explanation key
+        {'election_title': 'some election', 'explanation': None},  # null explanation key
+        {'election_title': 'some election', 'explanation': 'some text'},  # explanation key contains text
     ]
 
 class EveryElectionWrapperTest(TestCase):
@@ -38,4 +38,6 @@ class EveryElectionWrapperTest(TestCase):
         ee = EveryElectionWrapper('AA11AA')
         self.assertTrue(ee.request_success)
         self.assertTrue(ee.has_election())
-        self.assertEqual(['some text'], ee.get_explanations())
+        self.assertEqual([
+            {'title': 'some election', 'explanation': 'some text'}
+        ], ee.get_explanations())

--- a/polling_stations/templates/election_explainers.html
+++ b/polling_stations/templates/election_explainers.html
@@ -6,10 +6,11 @@
   <h2>Elections in your area</h2>
   {% endblocktrans %}
 
-  {% for explanation in election_explainers %}
+  {% for election in election_explainers %}
     <div>
+        <h3>{{ election.title }}</h3>
     {% filter markdown %}
-{{explanation}}
+{{ election.explanation }}
     {% endfilter %}
     </div>
   {% endfor %}


### PR DESCRIPTION
Use the actual election title from EE for the explainer title instead of embedding a generic title in the markdown.

This needs a bit of faffing to co-ordinate deploying changes across EE, WhereDIV and WhoCIVF. Synchronise watches :watch: 