### PR TITLE
allow local.py to define further installed apps

### DIFF
--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -279,7 +279,14 @@ from .constants.tiles import *  # noqa
 
 # Import .local.py last - settings in local.py override everything else
 try:
+
     from .local import *  # noqa
+
+    try:
+        INSTALLED_APPS += PROD_APPS
+    except NameError:
+        pass
+
 except ImportError:
     pass
 


### PR DESCRIPTION
In some cases we might want to define `INSTALLED_APPS` which are only relevant in a production setting. Specifically I'm thinking about `raven` right now so we can fix https://github.com/DemocracyClub/polling_deploy/issues/26 but in principle there might be others..