### PR TITLE
ID info for Northern Ireland - important!

### DIFF
--- a/polling_stations/templates/sidebar/you_dont_need_poll_card.html
+++ b/polling_stations/templates/sidebar/you_dont_need_poll_card.html
@@ -4,7 +4,7 @@
         <h3>You don't need your poll card to vote</h3>
         <p>If you don't have your poll card, you can go to the polling
             station and give them your name and address.</p>
-        <p>You don't need any other form of ID.</p>
+        <p>You don't need any other form of ID, unless you are voting in Northern Ireland where you will need </a>photographic identification</a>.</p>
         <p>If you haven’t received a polling card but think you should have done, contact your council</p>
         <p><strong>Polling stations are open from 7am to 10pm on Thursday 8 June.</strong></p>
         <p><a href="https://www.gov.uk/voting-in-the-uk/polling-stations" target="_top">

--- a/polling_stations/templates/sidebar/you_dont_need_poll_card.html
+++ b/polling_stations/templates/sidebar/you_dont_need_poll_card.html
@@ -8,7 +8,10 @@
         <p>If you haven’t received a polling card but think you should have done, contact your council</p>
         <p><strong>Polling stations are open from 7am to 10pm on Thursday 8 June.</strong></p>
         <p><a href="https://www.gov.uk/voting-in-the-uk/polling-stations" target="_top">
-          Read more about voting in the UK
+          Read more about voting in England, Wales and Scotland
+        </a></p>
+        <p><a href="https://www.yourvotematters.co.uk/how-do-i-vote" target="_top">
+          Read more about voting in Northern Ireland
         </a></p>
         {% endblocktrans %}
     </div>


### PR DESCRIPTION
In Northern Ireland, registered voters *do* need photographic identification to vote.

Therefore, I've added a message to alert NI voters to this, with a link to the Electoral Office guidance on acceptable forms of ID http://www.eoni.org.uk/Vote/Voting-at-a-polling-place

A better way to handle this might be to identify an NI voter through postcode (simple as all NI postcodes start with 'BT') but this is a quick and necessary fix.