### PR TITLE
remove custom point for Manchester Central Library

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/misc_fixes.py
+++ b/polling_stations/apps/data_collection/management/commands/misc_fixes.py
@@ -29,11 +29,6 @@ class Command(BaseCommand):
         print("..updated")
 
 
-        print("updating point for: Manchester Central Library...")
-        update_station_point('E08000003', '3019',
-            Point(-2.24415, 53.47784, srid=4326))
-
-
         print("updating point for: CLASSROOM HS210, WALSALL COLLEGE...")
         update_station_point('E08000030', '15',
             Point(-1.984424, 52.590524, srid=4326))


### PR DESCRIPTION
Central Library is not a station for `parl.2017-06-08`