### PR TITLE
strip non-alphanumeric chars from spaces in more places

### DIFF
--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -458,7 +458,7 @@ class DirectionsHelper():
 class RoutingHelper():
 
     def __init__(self, postcode):
-        self.postcode = postcode.replace(' ', '').upper()
+        self.postcode = re.sub('[^A-Z0-9]', '', postcode.upper())
         self.Endpoint = namedtuple('Endpoint', ['view', 'kwargs'])
         self.get_addresses()
         self.get_councils_from_blacklist()

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -85,7 +85,7 @@ class HomeView(WhiteLabelTemplateOverrideMixin, FormView):
 
     def form_valid(self, form):
 
-        postcode = form.cleaned_data['postcode'].replace(' ', '')
+        postcode = re.sub('[^A-Z0-9]', '', form.cleaned_data['postcode'])
 
         rh = RoutingHelper(postcode)
         endpoint = rh.get_endpoint()
@@ -191,7 +191,7 @@ class PostcodeView(BasePollingStationView):
             self.kwargs['postcode'] = kwargs['postcode'] = request.GET['postcode']
         if 'postcode' not in kwargs or kwargs['postcode'] == '':
             return HttpResponseRedirect(reverse('home'))
-        self.kwargs['postcode'] = kwargs['postcode'] = kwargs['postcode'].upper().replace(' ', '')
+        self.kwargs['postcode'] = kwargs['postcode'] = re.sub('[^A-Z0-9]', '', kwargs['postcode'].upper())
 
         rh = RoutingHelper(self.kwargs['postcode'])
         endpoint = rh.get_endpoint()


### PR DESCRIPTION
In a lot of the facebook traffic hitting WhoCIVF from facebook the postcode is in the form `AA1+1AA` (i.e: with the space encoded as a `+`). At the moment this will just fail on WhereDIV because the plus character is not stripped.
This commit qucikly papers over that crack.
Refs #678 but does not fix