### PR TITLE
Don't assume that pollingstationumber is unique in Halarose base class

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_hounslow.py
+++ b/polling_stations/apps/data_collection/management/commands/import_hounslow.py
@@ -10,6 +10,11 @@ class Command(BaseHalaroseCsvImporter):
     elections       = ['parl.2017-06-08']
     csv_encoding    = 'windows-1252'
 
+    def get_station_hash(self, record):
+        return "-".join([
+            record.pollingstationnumber.strip(),
+        ])
+
     # Hounslow have supplied an additional file with
     # better grid references for the polling stations
     def post_import(self):
@@ -23,7 +28,7 @@ class Command(BaseHalaroseCsvImporter):
         for record in gridrefs:
             stations = PollingStation.objects.filter(
                 council_id=self.council_id,
-                internal_council_id=record.pollingstationnumber
+                internal_council_id=self.get_station_hash(record)
             )
             if len(stations) == 1:
                 station = stations[0]
@@ -34,5 +39,5 @@ class Command(BaseHalaroseCsvImporter):
                 )
                 station.save()
             else:
-                print("Could not find station id " + record.pollingstationnumber)
+                print("Could not find station id " + self.get_station_hash(record))
         print("...done")

--- a/polling_stations/apps/data_collection/management/commands/import_south_ribble.py
+++ b/polling_stations/apps/data_collection/management/commands/import_south_ribble.py
@@ -23,7 +23,7 @@ class Command(BaseHalaroseCsvImporter):
     ]
 
     def get_station_hash(self, record):
-        raise NotImplementedError
+        return record.pollingstationnumber.strip()
 
     def get_station_point(self, record):
         return Point(

--- a/polling_stations/apps/data_collection/management/commands/import_sutton.py
+++ b/polling_stations/apps/data_collection/management/commands/import_sutton.py
@@ -23,7 +23,7 @@ class Command(BaseHalaroseCsvImporter):
         for record in gridrefs:
             stations = PollingStation.objects.filter(
                 council_id=self.council_id,
-                internal_council_id=record.pollingstationnumber
+                internal_council_id=self.get_station_hash(record)
             )
             if len(stations) == 1:
                 station = stations[0]
@@ -34,5 +34,5 @@ class Command(BaseHalaroseCsvImporter):
                 )
                 station.save()
             else:
-                print("Could not find station id " + record.pollingstationnumber)
+                print("Could not find station id " + record.get_station_hash(record))
         print("...done")


### PR DESCRIPTION
Worryingly, after recieving a report from a council we discovered that in their data the same `pollingstationnumber` could describe more than one place.

station number 53 was both
Victoria Park Comm Centre and
Highbridge Community Hall

and station number 56 was both
Axbridge Town Hall and
Woolavington Village Hall

This commit switches Halarose importers so that the default behaviour is to use `pollingstationnumber` and a slug of the station name as the id

Also some updates to special-case Halarose importers to account for the change