### PR TITLE
Revert "Remove calls to EveryElection"

### DIFF
--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -155,13 +155,11 @@ class BasePollingStationView(
         self.station = self.get_station()
         self.directions = self.get_directions()
 
-        #ee = EveryElectionWrapper(self.postcode)
-        #context['has_election'] = ee.has_election()
-        context['has_election'] = True
+        ee = EveryElectionWrapper(self.postcode)
+        context['has_election'] = ee.has_election()
         if not context['has_election']:
             context['error'] = 'There are no upcoming elections in your area'
-        #context['election_explainers'] = ee.get_explanations()
-        context['election_explainers'] = []
+        context['election_explainers'] = ee.get_explanations()
 
         context['postcode'] = self.postcode
         context['location'] = self.location


### PR DESCRIPTION
I removed the API call to EE for fear of it becoming a performance bottleneck.

Now that there aren't elections happening, this probably does serve a useful function so lets put it back..

More generally we probably want to work out how to scale this properly