### PR TITLE
warn if station point is outside target local auth

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -104,6 +104,14 @@ class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
             default=3000
         )
 
+        parser.add_argument(
+            '--nochecks',
+            help='<Optional> Do not perform validation checks',
+            action='store_true',
+            required=False,
+            default=False
+        )
+
     def teardown(self, council):
         PollingStation.objects.filter(council=council).delete()
         PollingDistrict.objects.filter(council=council).delete()
@@ -194,6 +202,7 @@ class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
         verbosity = kwargs.get('verbosity')
         self.logger = LogHelper(verbosity)
         self.batch_size = kwargs.get('batch_size')
+        self.validation_checks = not(kwargs.get('nochecks'))
 
         if self.council_id is None:
             self.council_id = args[0]
@@ -347,7 +356,8 @@ class BaseStationsImporter(BaseImporter, metaclass=abc.ABCMeta):
                         *station.shape.points[0],
                         srid=self.get_srid())
 
-                self.check_station_point(station_record)
+                if self.validation_checks:
+                    self.check_station_point(station_record)
                 self.add_polling_station(station_record)
 
     def add_polling_station(self, station_info):

--- a/polling_stations/apps/data_collection/management/commands/import.py
+++ b/polling_stations/apps/data_collection/management/commands/import.py
@@ -132,9 +132,9 @@ class Command(BaseCommand):
 
         commands_series = []
         commands_parallel = []
-        opts = {'noclean': False, 'verbosity': 1}
+        opts = {'noclean': False, 'nochecks': True, 'verbosity': 1}
         if kwargs['multiprocessing']:
-            opts = {'noclean': False, 'verbosity': 0}
+            opts = {'noclean': False, 'nochecks': True, 'verbosity': 0}
 
         # loop over all the import scripts
         # and build up a list of management commands to run


### PR DESCRIPTION
One of the things we have talked about is adding additional automated checks to the import process to reduce the overhead of manually checking data and detect certain avoidable errors more easily.

There are more of these to add, but the first one I've picked is logging a `WARNING` if a polling station is located outside the target council area. This is not always an error - sometimes this is valid, but it is worth flagging for follow up if it happens.

As I add more of these checks, each one is going to add additional overhead to the execution of an import script and cumulatively this will slow down image builds. To counteract this, I've set it up so the checks are on by default if we're running a single script but off by default if we're running scripts in bulk using `import.py`. See the commit message 95fdd74 for more detail. Further checks can be wrapped in a `if self.validation_checks` block. I think that is reasonable default behaviour.

Refs #668, #588
