### PR TITLE
[WIP] improve directions

### DIFF
--- a/polling_stations/apps/data_finder/directions_clients.py
+++ b/polling_stations/apps/data_finder/directions_clients.py
@@ -7,7 +7,8 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 
 
-Directions = namedtuple('Directions', ['walk_time', 'walk_dist', 'route', 'precision'])
+Directions = namedtuple('Directions', [
+    'walk_time', 'walk_dist', 'route', 'precision', 'source'])
 
 
 class DirectionsException(Exception):
@@ -62,7 +63,8 @@ class GoogleDirectionsClient(DirectionsClient):
             directions['routes'][0]['legs'][0]['distance']['text']
         ).replace('mi', _('miles'))
 
-        return Directions(walk_time, walk_dist, json.dumps(route), self.precision)
+        return Directions(
+            walk_time, walk_dist, json.dumps(route), self.precision, 'Google')
 
 
 class MapzenDirectionsClient(DirectionsClient):
@@ -120,4 +122,5 @@ class MapzenDirectionsClient(DirectionsClient):
             round(directions['trip']['summary']['length'],1)
         ) + _(" miles")
 
-        return Directions(walk_time, walk_dist, json.dumps(route), self.precision)
+        return Directions(
+            walk_time, walk_dist, json.dumps(route), self.precision, 'MapZen')

--- a/polling_stations/apps/data_finder/directions_clients.py
+++ b/polling_stations/apps/data_finder/directions_clients.py
@@ -1,0 +1,117 @@
+import abc
+import json
+import requests
+import urllib
+from collections import namedtuple
+from django.conf import settings
+from django.utils.translation import ugettext as _
+
+
+Directions = namedtuple('Directions', ['walk_time', 'walk_dist', 'route', 'precision'])
+
+
+class DirectionsException(Exception):
+    pass
+
+
+class DirectionsClient(metaclass=abc.ABCMeta):
+
+    def __init__(self):
+        pass
+
+    @abc.abstractmethod
+    def get_route(self, start, end):
+        pass
+
+
+class GoogleDirectionsClient(DirectionsClient):
+
+    precision = 5
+
+    def get_base_url(self):
+        return "{base}&key={key}".format(
+            base=settings.BASE_GOOGLE_URL,
+            key=settings.GOOGLE_API_KEY
+        )
+
+    def get_route(self, start, end):
+        url = "{base_url}&origin={origin}&destination={destination}".format(
+                base_url=self.get_base_url(),
+                origin="{0},{1}".format(start.y, start.x),
+                destination="{0},{1}".format(end.y, end.x),
+            )
+
+        resp = requests.get(url)
+        if resp.status_code != 200:
+            raise DirectionsException("Google Directions API error: HTTP status code %i" % resp.status_code)
+        directions = resp.json()
+
+        if directions['status'] != 'OK':
+            raise DirectionsException("Google Directions API error: {}".format(directions['status']))
+
+        route = directions['routes'][0]['overview_polyline']['points']
+
+        walk_time = str(
+            directions['routes'][0]['legs'][0]['duration']['text']
+        ).replace('mins', _('minute'))
+
+        walk_dist = str(
+            directions['routes'][0]['legs'][0]['distance']['text']
+        ).replace('mi', _('miles'))
+
+        return Directions(walk_time, walk_dist, json.dumps(route), self.precision)
+
+
+class MapzenDirectionsClient(DirectionsClient):
+
+    precision = 6
+
+    def get_base_url(self):
+        return "{base}?api_key={key}".format(
+            base=settings.BASE_MAPZEN_URL,
+            key=settings.MAPZEN_API_KEY
+        )
+
+    def get_route(self, start, end):
+        if settings.MAPZEN_API_KEY == '':
+            raise DirectionsException("No Mapzen Directions API key set")
+
+        query = {
+            'locations': [
+                {
+                    'lat': start.y,
+                    'lon': start.x,
+                },
+                {
+                    'lat': end.y,
+                    'lon': end.x,
+                },
+            ],
+            'costing': 'pedestrian',
+            'directions_options': { 'units': 'miles' },
+            'id': 'polling_station_route',
+        }
+        url = "{base_url}&json={json}".format(
+            base_url=self.get_base_url(),
+            json=urllib.parse.quote_plus(json.dumps(query))
+        )
+
+        resp = requests.get(url)
+        if resp.status_code != 200:
+            raise DirectionsException("Mapzen Directions API error: HTTP status code %i" % resp.status_code)
+        directions = resp.json()
+
+        if directions['trip']['status'] != 0:
+            raise DirectionsException("Mapzen Directions API error: {}".format(directions['trip']['status']))
+
+        route = directions['trip']['legs'][0]['shape']
+
+        walk_time = str(
+            int(round(directions['trip']['summary']['time']/60, 0))
+        ) + " minute"
+
+        walk_dist = str(
+            round(directions['trip']['summary']['length'],1)
+        ) + " miles"
+
+        return Directions(walk_time, walk_dist, json.dumps(route), self.precision)

--- a/polling_stations/apps/data_finder/directions_clients.py
+++ b/polling_stations/apps/data_finder/directions_clients.py
@@ -83,8 +83,11 @@ class MapzenDirectionsClient(DirectionsClient):
             raise DirectionsException("Mapzen Directions API error: HTTP status code %i" % resp.status_code)
         return resp.json()
 
+    def get_api_key(self):
+        return settings.MAPZEN_API_KEY
+
     def get_route(self, start, end):
-        if settings.MAPZEN_API_KEY == '':
+        if self.get_api_key() == '':
             raise DirectionsException("No Mapzen Directions API key set")
 
         query = {
@@ -123,4 +126,4 @@ class MapzenDirectionsClient(DirectionsClient):
         ) + _(" miles")
 
         return Directions(
-            walk_time, walk_dist, json.dumps(route), self.precision, 'MapZen')
+            walk_time, walk_dist, json.dumps(route), self.precision, 'Mapzen')

--- a/polling_stations/apps/data_finder/directions_clients.py
+++ b/polling_stations/apps/data_finder/directions_clients.py
@@ -108,10 +108,10 @@ class MapzenDirectionsClient(DirectionsClient):
 
         walk_time = str(
             int(round(directions['trip']['summary']['time']/60, 0))
-        ) + " minute"
+        ) + _(" minute")
 
         walk_dist = str(
             round(directions['trip']['summary']['length'],1)
-        ) + " miles"
+        ) + _(" miles")
 
         return Directions(walk_time, walk_dist, json.dumps(route), self.precision)

--- a/polling_stations/apps/data_finder/directions_clients.py
+++ b/polling_stations/apps/data_finder/directions_clients.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 
 
 Directions = namedtuple('Directions', [
-    'walk_time', 'walk_dist', 'route', 'precision', 'source'])
+    'time', 'dist', 'mode', 'route', 'precision', 'source'])
 
 
 class DirectionsException(Exception):
@@ -39,7 +39,7 @@ class GoogleDirectionsClient(DirectionsClient):
         return resp.json()
 
     def get_route(self, start, end):
-        url = "{base_url}&origin={origin}&destination={destination}".format(
+        url = "{base_url}&mode=walking&origin={origin}&destination={destination}".format(
                 base_url=self.get_base_url(),
                 origin="{0},{1}".format(start.y, start.x),
                 destination="{0},{1}".format(end.y, end.x),
@@ -52,16 +52,16 @@ class GoogleDirectionsClient(DirectionsClient):
 
         route = directions['routes'][0]['overview_polyline']['points']
 
-        walk_time = str(
+        time = str(
             directions['routes'][0]['legs'][0]['duration']['text']
         ).replace('mins', _('minute'))
 
-        walk_dist = str(
+        dist = str(
             directions['routes'][0]['legs'][0]['distance']['text']
         ).replace('mi', _('miles'))
 
         return Directions(
-            walk_time, walk_dist, json.dumps(route), self.precision, 'Google')
+            time, dist, 'walk', json.dumps(route), self.precision, 'Google')
 
 
 class MapzenDirectionsClient(DirectionsClient):
@@ -114,13 +114,13 @@ class MapzenDirectionsClient(DirectionsClient):
 
         route = directions['trip']['legs'][0]['shape']
 
-        walk_time = str(
+        time = str(
             int(round(directions['trip']['summary']['time']/60, 0))
         ) + _(" minute")
 
-        walk_dist = str(
+        dist = str(
             round(directions['trip']['summary']['length'],1)
         ) + _(" miles")
 
         return Directions(
-            walk_time, walk_dist, json.dumps(route), self.precision, 'Mapzen')
+            time, dist, 'walk', json.dumps(route), self.precision, 'Mapzen')

--- a/polling_stations/apps/data_finder/directions_clients.py
+++ b/polling_stations/apps/data_finder/directions_clients.py
@@ -34,6 +34,12 @@ class GoogleDirectionsClient(DirectionsClient):
             key=settings.GOOGLE_API_KEY
         )
 
+    def get_data(self, url):
+        resp = requests.get(url)
+        if resp.status_code != 200:
+            raise DirectionsException("Google Directions API error: HTTP status code %i" % resp.status_code)
+        return resp.json()
+
     def get_route(self, start, end):
         url = "{base_url}&origin={origin}&destination={destination}".format(
                 base_url=self.get_base_url(),
@@ -41,10 +47,7 @@ class GoogleDirectionsClient(DirectionsClient):
                 destination="{0},{1}".format(end.y, end.x),
             )
 
-        resp = requests.get(url)
-        if resp.status_code != 200:
-            raise DirectionsException("Google Directions API error: HTTP status code %i" % resp.status_code)
-        directions = resp.json()
+        directions = self.get_data(url)
 
         if directions['status'] != 'OK':
             raise DirectionsException("Google Directions API error: {}".format(directions['status']))
@@ -72,6 +75,12 @@ class MapzenDirectionsClient(DirectionsClient):
             key=settings.MAPZEN_API_KEY
         )
 
+    def get_data(self, url):
+        resp = requests.get(url)
+        if resp.status_code != 200:
+            raise DirectionsException("Mapzen Directions API error: HTTP status code %i" % resp.status_code)
+        return resp.json()
+
     def get_route(self, start, end):
         if settings.MAPZEN_API_KEY == '':
             raise DirectionsException("No Mapzen Directions API key set")
@@ -96,10 +105,7 @@ class MapzenDirectionsClient(DirectionsClient):
             json=urllib.parse.quote_plus(json.dumps(query))
         )
 
-        resp = requests.get(url)
-        if resp.status_code != 200:
-            raise DirectionsException("Mapzen Directions API error: HTTP status code %i" % resp.status_code)
-        directions = resp.json()
+        directions = self.get_data(url)
 
         if directions['trip']['status'] != 0:
             raise DirectionsException("Mapzen Directions API error: {}".format(directions['trip']['status']))

--- a/polling_stations/apps/data_finder/directions_clients.py
+++ b/polling_stations/apps/data_finder/directions_clients.py
@@ -17,9 +17,6 @@ class DirectionsException(Exception):
 
 class DirectionsClient(metaclass=abc.ABCMeta):
 
-    def __init__(self):
-        pass
-
     @abc.abstractmethod
     def get_route(self, start, end):
         pass

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -401,7 +401,7 @@ class GoogleDirectionsClient(DirectionsClient):
             directions['routes'][0]['legs'][0]['distance']['text']
         ).replace('mi', _('miles'))
 
-        return Directions(walk_time, walk_dist, route, self.precision)
+        return Directions(walk_time, walk_dist, json.dumps(route), self.precision)
 
 
 class MapzenDirectionsClient(DirectionsClient):
@@ -456,7 +456,7 @@ class MapzenDirectionsClient(DirectionsClient):
             round(directions['trip']['summary']['length'],1)
         ) + " miles"
 
-        return Directions(walk_time, walk_dist, route, self.precision)
+        return Directions(walk_time, walk_dist, json.dumps(route), self.precision)
 
 
 class DirectionsHelper():

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -1,11 +1,9 @@
 import abc
-import json
 import logging
 import lxml.etree
 import re
 import requests
 import time
-import urllib
 from collections import namedtuple
 from operator import itemgetter
 
@@ -13,13 +11,14 @@ from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
 
 from addressbase.helpers import centre_from_points_qs
 from addressbase.models import Address, Blacklist, Onsad
 
 from pollingstations.models import ResidentialAddress
 from pollingstations.helpers import format_postcode_no_space, format_postcode_with_space
+from data_finder.directions_clients import (
+    DirectionsException, GoogleDirectionsClient, MapzenDirectionsClient)
 
 
 class PostcodeError(Exception):
@@ -348,116 +347,6 @@ class EveryElectionWrapper:
                         'explanation': election['explanation'],
                     })
         return explanations
-
-
-Directions = namedtuple('Directions', ['walk_time', 'walk_dist', 'route', 'precision'])
-
-
-class DirectionsException(Exception):
-    pass
-
-
-class DirectionsClient(metaclass=abc.ABCMeta):
-
-    def __init__(self):
-        pass
-
-    @abc.abstractmethod
-    def get_route(self, start, end):
-        pass
-
-
-class GoogleDirectionsClient(DirectionsClient):
-
-    precision = 5
-
-    def get_base_url(self):
-        return "{base}&key={key}".format(
-            base=settings.BASE_GOOGLE_URL,
-            key=settings.GOOGLE_API_KEY
-        )
-
-    def get_route(self, start, end):
-        url = "{base_url}&origin={origin}&destination={destination}".format(
-                base_url=self.get_base_url(),
-                origin="{0},{1}".format(start.y, start.x),
-                destination="{0},{1}".format(end.y, end.x),
-            )
-
-        resp = requests.get(url)
-        if resp.status_code != 200:
-            raise DirectionsException("Google Directions API error: HTTP status code %i" % resp.status_code)
-        directions = resp.json()
-
-        if directions['status'] != 'OK':
-            raise DirectionsException("Google Directions API error: {}".format(directions['status']))
-
-        route = directions['routes'][0]['overview_polyline']['points']
-
-        walk_time = str(
-            directions['routes'][0]['legs'][0]['duration']['text']
-        ).replace('mins', _('minute'))
-
-        walk_dist = str(
-            directions['routes'][0]['legs'][0]['distance']['text']
-        ).replace('mi', _('miles'))
-
-        return Directions(walk_time, walk_dist, json.dumps(route), self.precision)
-
-
-class MapzenDirectionsClient(DirectionsClient):
-
-    precision = 6
-
-    def get_base_url(self):
-        return "{base}?api_key={key}".format(
-            base=settings.BASE_MAPZEN_URL,
-            key=settings.MAPZEN_API_KEY
-        )
-
-    def get_route(self, start, end):
-        if settings.MAPZEN_API_KEY == '':
-            raise DirectionsException("No Mapzen Directions API key set")
-
-        query = {
-            'locations': [
-                {
-                    'lat': start.y,
-                    'lon': start.x,
-                },
-                {
-                    'lat': end.y,
-                    'lon': end.x,
-                },
-            ],
-            'costing': 'pedestrian',
-            'directions_options': { 'units': 'miles' },
-            'id': 'polling_station_route',
-        }
-        url = "{base_url}&json={json}".format(
-            base_url=self.get_base_url(),
-            json=urllib.parse.quote_plus(json.dumps(query))
-        )
-
-        resp = requests.get(url)
-        if resp.status_code != 200:
-            raise DirectionsException("Mapzen Directions API error: HTTP status code %i" % resp.status_code)
-        directions = resp.json()
-
-        if directions['trip']['status'] != 0:
-            raise DirectionsException("Mapzen Directions API error: {}".format(directions['trip']['status']))
-
-        route = directions['trip']['legs'][0]['shape']
-
-        walk_time = str(
-            int(round(directions['trip']['summary']['time']/60, 0))
-        ) + " minute"
-
-        walk_dist = str(
-            round(directions['trip']['summary']['length'],1)
-        ) + " miles"
-
-        return Directions(walk_time, walk_dist, json.dumps(route), self.precision)
 
 
 class DirectionsHelper():

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -357,7 +357,7 @@ class DirectionsHelper():
             for client in clients:
                 try:
                     return client.get_route(kwargs['start_location'], kwargs['end_location'])
-                except DirectionsException as e:
+                except DirectionsException:
                     pass
             return None
         else:

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -383,15 +383,7 @@ class DirectionsHelper():
         if directions['status'] != 'OK':
             raise GoogleDirectionsApiError("Google Directions API error: {}".format(directions['status']))
 
-        start_points = [
-            Point(x['start_location']['lng'], x['start_location']['lat'])
-            for x in directions['routes'][0]['legs'][0]['steps']
-        ]
-
-        end_points = [
-            Point(x['end_location']['lng'], x['end_location']['lat'])
-            for x in directions['routes'][0]['legs'][0]['steps']
-        ]
+        route = directions['routes'][0]['overview_polyline']['points']
 
         walk_time = str(
             directions['routes'][0]['legs'][0]['duration']['text']
@@ -401,7 +393,7 @@ class DirectionsHelper():
             directions['routes'][0]['legs'][0]['distance']['text']
         ).replace('mi', _('miles'))
 
-        return self.Directions(walk_time, walk_dist, start_points[:] + end_points[-1:])
+        return self.Directions(walk_time, walk_dist, route)
 
     def get_directions(self, **kwargs):
         if kwargs['start_location'] and kwargs['end_location']:

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -5,6 +5,7 @@ import lxml.etree
 import re
 import requests
 import time
+import urllib
 from collections import namedtuple
 from operator import itemgetter
 
@@ -435,7 +436,7 @@ class MapzenDirectionsClient(DirectionsClient):
         }
         url = "{base_url}&json={json}".format(
             base_url=self.get_base_url(),
-            json=json.dumps(query)
+            json=urllib.parse.quote_plus(json.dumps(query))
         )
 
         resp = requests.get(url)

--- a/polling_stations/apps/data_finder/tests/test_directions_helper.py
+++ b/polling_stations/apps/data_finder/tests/test_directions_helper.py
@@ -20,11 +20,11 @@ def mock_route_exception(self, start, end):
 
 def mock_route_google(self, start, end):
     return Directions(
-        '1', '1', 'foo', 5, 'Google')
+        '1', '1', 'walk', 'foo', 5, 'Google')
 
 def mock_route_mapzen(self, start, end):
     return Directions(
-        '1', '1', 'foo', 6, 'Mapzen')
+        '1', '1', 'walk', 'foo', 6, 'Mapzen')
 
 
 class DirectionsTest(TestCase):

--- a/polling_stations/apps/data_finder/tests/test_directions_helper.py
+++ b/polling_stations/apps/data_finder/tests/test_directions_helper.py
@@ -1,0 +1,67 @@
+import mock
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+from data_finder.directions_clients import (
+    Directions,
+    DirectionsException,
+    GoogleDirectionsClient,
+    MapzenDirectionsClient
+)
+from data_finder.helpers import DirectionsHelper
+
+
+"""
+mock get_route() functions for monkey-patching
+In these tests we don't care about the outputs
+We only care about the source of the result
+"""
+def mock_route_exception(self, start, end):
+    raise DirectionsException('oh noes!! terrible things happened :(')
+
+def mock_route_google(self, start, end):
+    return Directions(
+        '1', '1', 'foo', 5, 'Google')
+
+def mock_route_mapzen(self, start, end):
+    return Directions(
+        '1', '1', 'foo', 6, 'Mapzen')
+
+
+class DirectionsTest(TestCase):
+
+    def setUp(self):
+        self.a = Point(-0.14158760012261312, 51.50100893647978, srid=4326)
+        self.b = Point(-0.14168760012297544, 51.60100773643453, srid=4326)
+        # because we want to get from A to B :)
+
+    def test_bad_params(self):
+        # params passed are invalid
+        d = DirectionsHelper()
+        result = d.get_directions(start_location=False, end_location=False)
+        self.assertIsNone(result)
+
+    @mock.patch("data_finder.directions_clients.MapzenDirectionsClient.get_route", mock_route_exception)
+    @mock.patch("data_finder.directions_clients.GoogleDirectionsClient.get_route", mock_route_exception)
+    def test_all_bad(self):
+        # all directions providers throw a DirectionsException
+        # get_directions() should return None
+        d = DirectionsHelper()
+        result = d.get_directions(start_location=self.a, end_location=self.b)
+        self.assertIsNone(result)
+
+    @mock.patch("data_finder.directions_clients.MapzenDirectionsClient.get_route", mock_route_exception)
+    @mock.patch("data_finder.directions_clients.GoogleDirectionsClient.get_route", mock_route_google)
+    def test_google(self):
+        # Mapzen throws an exception
+        # Fall back to google
+        d = DirectionsHelper()
+        result = d.get_directions(start_location=self.a, end_location=self.b)
+        self.assertEqual('Google', result.source)
+
+    @mock.patch("data_finder.directions_clients.MapzenDirectionsClient.get_route", mock_route_mapzen)
+    @mock.patch("data_finder.directions_clients.GoogleDirectionsClient.get_route", mock_route_google)
+    def test_mapzen(self):
+        # Mapzen returns a valid result
+        d = DirectionsHelper()
+        result = d.get_directions(start_location=self.a, end_location=self.b)
+        self.assertEqual('Mapzen', result.source)

--- a/polling_stations/apps/data_finder/tests/test_google_directions.py
+++ b/polling_stations/apps/data_finder/tests/test_google_directions.py
@@ -1,0 +1,61 @@
+import json
+from django.conf import settings
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+from data_finder.directions_clients import (
+    DirectionsException, GoogleDirectionsClient)
+
+
+class GoogleDirectionsClientInvalidMock(GoogleDirectionsClient):
+
+    def get_data(self, url):
+        return {
+            'status': 'oh noes!! terrible things happened :('
+        }
+
+
+class GoogleDirectionsClientValidMock(GoogleDirectionsClient):
+
+    def get_data(self, url):
+        return {
+            'status': 'OK',
+            'routes': [
+                {
+                    'legs': [
+                        {
+                            'duration': {
+                                'text': '4 mins'
+                            },
+                            'distance': {
+                                'text': '0.2 mi'
+                            }
+                        }
+                    ],
+                    'overview_polyline': {
+                        'points': 'foo\bar'
+                    }
+                }
+            ]
+        }
+
+
+class GoogleDirectionsClientTest(TestCase):
+
+    def setUp(self):
+        self.a = Point(-0.14158760012261312, 51.50100893647978, srid=4326)
+        self.b = Point(-0.14168760012297544, 51.60100773643453, srid=4326)
+        # because we want to get from A to B :)
+
+    def test_invalid(self):
+        g = GoogleDirectionsClientInvalidMock()
+        with self.assertRaises(DirectionsException):
+            g.get_route(self.a, self.b)
+
+    def test_valid(self):
+        g = GoogleDirectionsClientValidMock()
+        result = g.get_route(self.a, self.b)
+        self.assertEqual('4 minute', result.walk_time)
+        self.assertEqual('0.2 miles', result.walk_dist)
+        self.assertEqual(json.dumps('foo\bar'), result.route)
+        self.assertEqual(5, result.precision)
+        self.assertEqual('Google', result.source)

--- a/polling_stations/apps/data_finder/tests/test_google_directions.py
+++ b/polling_stations/apps/data_finder/tests/test_google_directions.py
@@ -54,8 +54,8 @@ class GoogleDirectionsClientTest(TestCase):
     def test_valid(self):
         g = GoogleDirectionsClientValidMock()
         result = g.get_route(self.a, self.b)
-        self.assertEqual('4 minute', result.walk_time)
-        self.assertEqual('0.2 miles', result.walk_dist)
+        self.assertEqual('4 minute', result.time)
+        self.assertEqual('0.2 miles', result.dist)
         self.assertEqual(json.dumps('foo\bar'), result.route)
         self.assertEqual(5, result.precision)
         self.assertEqual('Google', result.source)

--- a/polling_stations/apps/data_finder/tests/test_mapzen_directions.py
+++ b/polling_stations/apps/data_finder/tests/test_mapzen_directions.py
@@ -62,8 +62,8 @@ class MapzenDirectionsClientTest(TestCase):
     def test_valid(self):
         m = MapzenDirectionsClientValidMock()
         result = m.get_route(self.a, self.b)
-        self.assertEqual('10 minute', result.walk_time)
-        self.assertEqual('0.5 miles', result.walk_dist)
+        self.assertEqual('10 minute', result.time)
+        self.assertEqual('0.5 miles', result.dist)
         self.assertEqual(json.dumps('foo\bar'), result.route)
         self.assertEqual(6, result.precision)
         self.assertEqual('Mapzen', result.source)

--- a/polling_stations/apps/data_finder/tests/test_mapzen_directions.py
+++ b/polling_stations/apps/data_finder/tests/test_mapzen_directions.py
@@ -1,0 +1,69 @@
+import json
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+from data_finder.directions_clients import (
+    DirectionsException, MapzenDirectionsClient)
+
+
+class MapzenDirectionsClientInvalidMock(MapzenDirectionsClient):
+
+    def get_data(self, url):
+        return {
+            'trip': {
+                'status': 'oh noes!! terrible things happened :('
+            }
+        }
+
+
+class MapzenDirectionsClientNoApiKeyMock(MapzenDirectionsClient):
+
+    def get_api_key(self):
+        return ''
+
+
+class MapzenDirectionsClientValidMock(MapzenDirectionsClient):
+
+    def get_api_key(self):
+        return 'foobarbaz'
+
+    def get_data(self, url):
+        return {
+            'trip': {
+                'status': 0,
+                'summary': {
+                    'time': 600,
+                    'length': 0.457,
+                },
+                'legs': [
+                    {
+                        'shape': 'foo\bar'
+                    }
+                ]
+            },
+        }
+
+class MapzenDirectionsClientTest(TestCase):
+
+    def setUp(self):
+        self.a = Point(-0.14158760012261312, 51.50100893647978, srid=4326)
+        self.b = Point(-0.14168760012297544, 51.60100773643453, srid=4326)
+        # because we want to get from A to B :)
+
+    def test_invalid(self):
+        m = MapzenDirectionsClientInvalidMock()
+        with self.assertRaises(DirectionsException):
+            m.get_route(self.a, self.b)
+
+    def test_no_api_key(self):
+        m = MapzenDirectionsClientNoApiKeyMock()
+        with self.assertRaises(DirectionsException):
+            m.get_route(self.a, self.b)
+
+    def test_valid(self):
+        m = MapzenDirectionsClientValidMock()
+        result = m.get_route(self.a, self.b)
+        self.assertEqual('10 minute', result.walk_time)
+        self.assertEqual('0.5 miles', result.walk_dist)
+        self.assertEqual(json.dumps('foo\bar'), result.route)
+        self.assertEqual(6, result.precision)
+        self.assertEqual('Mapzen', result.source)

--- a/polling_stations/assets/js/polyline/.eslintrc
+++ b/polling_stations/assets/js/polyline/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "rules": {
+    "no-shadow": [0],
+    "camelcase": [0],
+    "quotes": [2, "single"]
+  }
+}

--- a/polling_stations/assets/js/polyline/.gitignore
+++ b/polling_stations/assets/js/polyline/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.nyc_output/

--- a/polling_stations/assets/js/polyline/.travis.yml
+++ b/polling_stations/assets/js/polyline/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - "4"
+before_install:
+  - npm install -g npm@~1.4.6

--- a/polling_stations/assets/js/polyline/API.md
+++ b/polling_stations/assets/js/polyline/API.md
@@ -1,0 +1,18 @@
+### polyline.decode(string[, precision])
+
+Takes a string representation of 1+ coordinate pairs
+and returns an array of lat, lon arrays. If not specified,
+precision defaults to 5.
+
+### polyline.encode(array[, precision])
+
+Takes an array of lat, lon arrays and returns an encoded
+string. If not specified, precision defaults to 5.
+
+### polyline.fromGeoJSON(geojson[, precision])
+
+Takes a GeoJSON LineString feature and returns an encoded string. If not specified, precision defaults to 5.
+
+### polyline.toGeoJSON(string[, precision])
+
+Takes an encoded string and returns a GeoJSON LineString geometry. If not specified, precision defaults to 5.

--- a/polling_stations/assets/js/polyline/CHANGELOG.md
+++ b/polling_stations/assets/js/polyline/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.2.0
+
+* Add `.toGeoJSON` method to convert an encoded polyline to GeoJSON
+  LineString.
+
+## 0.1.0
+
+* Add `.fromGeoJSON` method to encode GeoJSON geometries as polylines
+  without needing to manually flip coordinates.

--- a/polling_stations/assets/js/polyline/LICENSE
+++ b/polling_stations/assets/js/polyline/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c), Development Seed  
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+- Neither the name "Development Seed" nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/polling_stations/assets/js/polyline/Makefile
+++ b/polling_stations/assets/js/polyline/Makefile
@@ -1,0 +1,4 @@
+test:
+	mocha -R spec
+
+.PHONY: test

--- a/polling_stations/assets/js/polyline/README.md
+++ b/polling_stations/assets/js/polyline/README.md
@@ -1,0 +1,53 @@
+[![Build Status](https://secure.travis-ci.org/mapbox/polyline.png?branch=master)](http://travis-ci.org/mapbox/polyline) [![Coverage Status](https://coveralls.io/repos/mapbox/polyline/badge.svg)](https://coveralls.io/r/mapbox/polyline)
+
+# polyline
+
+A simple [google-esque polyline](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
+implementation in Javascript. Compatible with nodejs (`npm install polyline` and the browser (copy `src/polyline.js`)).
+
+Encodes/decodes into lat/lng coordinate pairs. Use `fromGeoJSON()` to encode from GeoJSON objects.
+
+## Installation
+
+    npm install @mapbox/polyline
+
+## Example
+
+```js
+var polyline = require('@mapbox/polyline');
+
+// returns an array of lat, lon pairs
+polyline.decode('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+
+// returns a string-encoded polyline
+polyline.encode([[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]);
+
+// returns a string-encoded polyline from a GeoJSON LineString
+polyline.fromGeoJSON({ "type": "Feature",
+  "geometry": {
+    "type": "LineString",
+    "coordinates": [[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]]
+  },
+  "properties": {}
+});
+```
+
+## Command line
+
+Install globally or run `./node_modules/.bin/polyline`.
+
+Send input via stdin and use `--decode`, `--encode`, or `--fromGeoJSON` flags. If omitted will default to `--decode`.
+
+Example :
+
+```
+cat file.json | ./bin/polyline.bin.js --fromGeoJSON > result.txt
+```
+
+# [Documentation](https://github.com/mapbox/polyline/blob/master/API.md)
+
+## See Also
+
+* [polyline algorithm](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
+* [Mark McClure's Google Maps Project](http://facstaff.unca.edu/mcmcclur/GoogleMaps.html)
+* [Routing geometry decoder in project-osrm](https://github.com/Project-OSRM/osrm-frontend/blob/master/WebContent/routing/OSRM.RoutingGeometry.js)

--- a/polling_stations/assets/js/polyline/bin/polyline.bin.js
+++ b/polling_stations/assets/js/polyline/bin/polyline.bin.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+var polyline = require('../');
+
+var HELP = 'Provide data from stdin and use with --decode (default), --encode, or --fromGeoJSON\n';
+
+var mode = process.argv[2] || '--decode';
+var rawInput = '';
+
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('readable', function() {
+  var chunk = process.stdin.read();
+  if (chunk !== null) {
+    rawInput += chunk;
+  }
+});
+
+process.stdin.on('end', function() {
+  if (mode === '--help' || mode === '-h') {
+    exit();
+  } else {
+    var converted = convert(rawInput, mode);
+    if (!converted) {
+      exit();
+    }
+    process.stdout.write(JSON.stringify(converted));
+  }
+});
+
+function convert(rawString, mode) {
+  switch(mode) {
+    case '--decode' :
+      return polyline.decode(rawString);
+    case '--encode' :
+      return polyline.encode(rawString);
+    case '--fromGeoJSON' :
+      return polyline.fromGeoJSON(JSON.parse(rawString));
+  }
+}
+
+function exit() {
+  process.stdout.write(HELP);
+  process.exit();
+}

--- a/polling_stations/assets/js/polyline/index.js
+++ b/polling_stations/assets/js/polyline/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/polyline.js');

--- a/polling_stations/assets/js/polyline/package.json
+++ b/polling_stations/assets/js/polyline/package.json
@@ -1,0 +1,26 @@
+{
+  "author": "Tom MacWright <tom@macwright.org> (http://macwright.org/)",
+  "name": "@mapbox/polyline",
+  "description": "Polyline encoding and decoding",
+  "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mapbox/polyline.git"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "^0.23.0",
+    "tap": "^1.2.1"
+  },
+  "optionalDependencies": {},
+  "scripts": {
+    "test": "eslint --no-eslintrc -c .eslintrc src && tap --coverage test/polyline.test.js"
+  },
+  "main": "src/polyline.js",
+  "engines": {
+    "node": "*"
+  },
+  "bin": {
+    "polyline": "bin/polyline.bin.js"
+  }
+}

--- a/polling_stations/assets/js/polyline/src/polyline.js
+++ b/polling_stations/assets/js/polyline/src/polyline.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * Based off of [the offical Google document](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
+ *
+ * Some parts from [this implementation](http://facstaff.unca.edu/mcmcclur/GoogleMaps/EncodePolyline/PolylineEncoder.js)
+ * by [Mark McClure](http://facstaff.unca.edu/mcmcclur/)
+ *
+ * @module polyline
+ */
+
+var polyline = {};
+
+function py2_round(value) {
+    // Google's polyline algorithm uses the same rounding strategy as Python 2, which is different from JS for negative values
+    return Math.floor(Math.abs(value) + 0.5) * Math.sign(value);
+}
+
+function encode(current, previous, factor) {
+    current = py2_round(current * factor);
+    previous = py2_round(previous * factor);
+    var coordinate = current - previous;
+    coordinate <<= 1;
+    if (current - previous < 0) {
+        coordinate = ~coordinate;
+    }
+    var output = '';
+    while (coordinate >= 0x20) {
+        output += String.fromCharCode((0x20 | (coordinate & 0x1f)) + 63);
+        coordinate >>= 5;
+    }
+    output += String.fromCharCode(coordinate + 63);
+    return output;
+}
+
+/**
+ * Decodes to a [latitude, longitude] coordinates array.
+ *
+ * This is adapted from the implementation in Project-OSRM.
+ *
+ * @param {String} str
+ * @param {Number} precision
+ * @returns {Array}
+ *
+ * @see https://github.com/Project-OSRM/osrm-frontend/blob/master/WebContent/routing/OSRM.RoutingGeometry.js
+ */
+polyline.decode = function(str, precision) {
+    var index = 0,
+        lat = 0,
+        lng = 0,
+        coordinates = [],
+        shift = 0,
+        result = 0,
+        byte = null,
+        latitude_change,
+        longitude_change,
+        factor = Math.pow(10, precision || 5);
+
+    // Coordinates have variable length when encoded, so just keep
+    // track of whether we've hit the end of the string. In each
+    // loop iteration, a single coordinate is decoded.
+    while (index < str.length) {
+
+        // Reset shift, result, and byte
+        byte = null;
+        shift = 0;
+        result = 0;
+
+        do {
+            byte = str.charCodeAt(index++) - 63;
+            result |= (byte & 0x1f) << shift;
+            shift += 5;
+        } while (byte >= 0x20);
+
+        latitude_change = ((result & 1) ? ~(result >> 1) : (result >> 1));
+
+        shift = result = 0;
+
+        do {
+            byte = str.charCodeAt(index++) - 63;
+            result |= (byte & 0x1f) << shift;
+            shift += 5;
+        } while (byte >= 0x20);
+
+        longitude_change = ((result & 1) ? ~(result >> 1) : (result >> 1));
+
+        lat += latitude_change;
+        lng += longitude_change;
+
+        coordinates.push([lat / factor, lng / factor]);
+    }
+
+    return coordinates;
+};
+
+/**
+ * Encodes the given [latitude, longitude] coordinates array.
+ *
+ * @param {Array.<Array.<Number>>} coordinates
+ * @param {Number} precision
+ * @returns {String}
+ */
+polyline.encode = function(coordinates, precision) {
+    if (!coordinates.length) { return ''; }
+
+    var factor = Math.pow(10, precision || 5),
+        output = encode(coordinates[0][0], 0, factor) + encode(coordinates[0][1], 0, factor);
+
+    for (var i = 1; i < coordinates.length; i++) {
+        var a = coordinates[i], b = coordinates[i - 1];
+        output += encode(a[0], b[0], factor);
+        output += encode(a[1], b[1], factor);
+    }
+
+    return output;
+};
+
+function flipped(coords) {
+    var flipped = [];
+    for (var i = 0; i < coords.length; i++) {
+        flipped.push(coords[i].slice().reverse());
+    }
+    return flipped;
+}
+
+/**
+ * Encodes a GeoJSON LineString feature/geometry.
+ *
+ * @param {Object} geojson
+ * @param {Number} precision
+ * @returns {String}
+ */
+polyline.fromGeoJSON = function(geojson, precision) {
+    if (geojson && geojson.type === 'Feature') {
+        geojson = geojson.geometry;
+    }
+    if (!geojson || geojson.type !== 'LineString') {
+        throw new Error('Input must be a GeoJSON LineString');
+    }
+    return polyline.encode(flipped(geojson.coordinates), precision);
+};
+
+/**
+ * Decodes to a GeoJSON LineString geometry.
+ *
+ * @param {String} str
+ * @param {Number} precision
+ * @returns {Object}
+ */
+polyline.toGeoJSON = function(str, precision) {
+    var coords = polyline.decode(str, precision);
+    return {
+        type: 'LineString',
+        coordinates: flipped(coords)
+    };
+};
+
+if (typeof module === 'object' && module.exports) {
+    module.exports = polyline;
+}

--- a/polling_stations/assets/js/polyline/test/polyline.test.js
+++ b/polling_stations/assets/js/polyline/test/polyline.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+var test = require('tap').test,
+    polyline = require('../');
+
+test('polyline', function(t) {
+    var example = [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
+        // encoded value will enclude slashes -> tests escaping
+        example_slashes = [[35.6, -82.55], [35.59985, -82.55015], [35.6, -82.55]],
+        example_flipped = [[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]],
+        example_rounding = [[0, 0.000006], [0, 0.000002]],
+        example_rounding_negative = [[36.05322, -112.084004], [36.053573, -112.083914], [36.053845, -112.083965]];
+
+    var geojson = { 'type': 'Feature',
+        'geometry': {
+            'type': 'LineString',
+            'coordinates': example_flipped
+        },
+        'properties': {}
+    };
+
+    t.test('#decode()', function(t) {
+        t.test('decodes an empty Array', function(t) {
+            t.deepEqual(polyline.decode(''), []);
+            t.end();
+        });
+
+        t.test('decodes a String into an Array of lat/lon pairs', function(t) {
+            t.deepEqual(polyline.decode('_p~iF~ps|U_ulLnnqC_mqNvxq`@'), example);
+            t.end();
+        });
+
+        t.test('decodes with a custom precision', function(t) {
+            t.deepEqual(polyline.decode('_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI', 6), example);
+            t.end();
+        });
+
+        t.end();
+    });
+
+    t.test('#identity', function(t) {
+        t.test('feed encode into decode and check if the result is the same as the input', function(t) {
+            t.deepEqual(polyline.decode(polyline.encode(example_slashes)), example_slashes);
+            t.end();
+        });
+
+        t.test('feed decode into encode and check if the result is the same as the input', function(t) {
+            t.equal(polyline.encode(polyline.decode('_chxEn`zvN\\\\]]')), '_chxEn`zvN\\\\]]');
+            t.end();
+        });
+
+        t.end();
+    });
+
+    t.test('#encode()', function(t) {
+        t.test('encodes an empty Array', function(t) {
+            t.equal(polyline.encode([]), '');
+            t.end();
+        });
+
+        t.test('encodes an Array of lat/lon pairs into a String', function(t) {
+            t.equal(polyline.encode(example), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+            t.end();
+        });
+
+        t.test('encodes with proper rounding', function(t) {
+            t.equal(polyline.encode(example_rounding), '?A?@');
+            t.end();
+        });
+
+        t.test('encodes with proper negative rounding', function(t) {
+            t.equal(polyline.encode(example_rounding_negative), 'ss`{E~kbkTeAQw@J');
+            t.end();
+        });
+
+        t.test('encodes with a custom precision', function(t) {
+            t.equal(polyline.encode(example, 6), '_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI');
+            t.end();
+        });
+
+        t.test('encodes negative values correctly', function(t) {
+            t.ok(polyline.decode(polyline.encode([[-107.3741825, 0]], 7), 7)[0][0] < 0);
+            t.end();
+        });
+
+
+        t.end();
+    });
+
+    t.test('#fromGeoJSON()', function(t) {
+        t.test('throws for non linestrings', function(t) {
+            t.throws(function() {
+                polyline.fromGeoJSON({});
+            }, /Input must be a GeoJSON LineString/);
+            t.end();
+        });
+
+        t.test('allows geojson geometries', function(t) {
+            t.equal(polyline.fromGeoJSON(geojson.geometry), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+            t.end();
+        });
+
+        t.test('flips coordinates and encodes', function(t) {
+            t.equal(polyline.fromGeoJSON(geojson), '_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+            t.end();
+        });
+
+        t.end();
+    });
+
+    t.test('#toGeoJSON()', function(t) {
+        t.test('flips coordinates and decodes geometry', function(t) {
+            t.deepEqual(polyline.toGeoJSON('_p~iF~ps|U_ulLnnqC_mqNvxq`@'), geojson.geometry);
+            t.end();
+        });
+
+        t.end();
+    });
+
+    t.end();
+});

--- a/polling_stations/settings/constants/directions.py
+++ b/polling_stations/settings/constants/directions.py
@@ -2,7 +2,7 @@ import os
 
 # Google maps settings used by directions helper
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', "")
-BASE_GOOGLE_URL = "https://maps.googleapis.com/maps/api/directions/json?mode=walking&units=imperial"
+BASE_GOOGLE_URL = "https://maps.googleapis.com/maps/api/directions/json?units=imperial"
 
 MAPZEN_API_KEY = os.environ.get('MAPZEN_API_KEY', "")
 BASE_MAPZEN_URL = "https://valhalla.mapzen.com/route"

--- a/polling_stations/settings/constants/directions.py
+++ b/polling_stations/settings/constants/directions.py
@@ -3,4 +3,3 @@ import os
 # Google maps settings used by directions helper
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', "")
 BASE_GOOGLE_URL = "https://maps.googleapis.com/maps/api/directions/json?mode=walking&units=imperial"
-ORS_ROUTE_URL_TEMPLATE = "http://openls.geog.uni-heidelberg.de/route?start={},{}&end={},{}&via=&lang=en&distunit=MI&routepref=Pedestrian&weighting=Fastest&avoidAreas=&useTMC=false&noMotorways=false&noTollways=false&noUnpavedroads=false&noSteps=false&noFerries=false&instructions=false"

--- a/polling_stations/settings/constants/directions.py
+++ b/polling_stations/settings/constants/directions.py
@@ -3,3 +3,6 @@ import os
 # Google maps settings used by directions helper
 GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', "")
 BASE_GOOGLE_URL = "https://maps.googleapis.com/maps/api/directions/json?mode=walking&units=imperial"
+
+MAPZEN_API_KEY = os.environ.get('MAPZEN_API_KEY', "")
+BASE_MAPZEN_URL = "https://valhalla.mapzen.com/route"

--- a/polling_stations/settings/testing.py
+++ b/polling_stations/settings/testing.py
@@ -13,3 +13,5 @@ MIGRATION_MODULES = {
     for app in INSTALLED_APPS
     if 'django' not in app
 }
+
+MAPZEN_API_KEY = ''

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -311,6 +311,9 @@
           ],
           'L.ExtraMarkers': [
               '{% static "Leaflet.ExtraMarkers/js/leaflet.extra-markers.min.js" %}'
+          ],
+          'polyline': [
+              '{% static 'js/polyline/src/polyline.js' %}'
           ]}, {
             shim: {
               'L': ['jQuery'],

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -115,11 +115,11 @@
                 {% endif %}
             </address>
             </div>
-            {% if directions.walk_time %}
+            {% if directions.time %}
             <div id="directions">
             <p>
-                {% blocktrans with directions.walk_time as walk_time and directions.walk_dist as walk_dist %}
-                It's about {{ walk_dist }} away or a {{ walk_time }} walk from {{ postcode }}.
+                {% blocktrans with directions.time as time and directions.dist as dist and directions.mode as mode %}
+                It's about {{ dist }} away or a {{ time }} {{ mode }} from {{ postcode }}.
                 {% endblocktrans %}</p>
             Get
             <a href="https://www.google.com/maps/dir/{{ location.y }},{{ location.x }}/{{ station.location.y }},{{ station.location.x }}" target="_top">

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -255,7 +255,7 @@
       }).addTo(map);
 
       {% if directions.route %}
-      decoded = polyline.decode('{{ directions.route }}');
+      decoded = polyline.decode('{{ directions.route }}', {{ directions.precision }});
       try {
         firstpolyline = new L.Polyline(decoded, {
             color: 'red',

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -218,6 +218,7 @@
           prefix: 'fa'
       });
       var polling_station_location = point;
+      var firstpolyline = false;
 
       var map = L.map('area_map', {zoomControl:true, dragging: !L.Browser.mobile});
       {% if request.brand == 'embed' %}
@@ -254,36 +255,38 @@
       }).addTo(map);
 
       {% if directions.route %}
-      var pointList = [
-      {% for p in directions.route %}
-          new L.LatLng({{p.1}}, {{p.0}}){% if not forloop.last %},{% endif %}
-      {% endfor %}
-      ];
+      decoded = polyline.decode('{{ directions.route }}');
+      try {
+        firstpolyline = new L.Polyline(decoded, {
+            color: 'red',
+            weight: 3,
+            opacity: 1.0,
+            smoothFactor: 1,
+            dashArray: "5, 5"
+        });
 
-      // home
-      L.marker(pointList[0], {
-        'clickable': true,
-        'icon': homeMarker
-      }).addTo(map);
+        // home
+        L.marker(firstpolyline._latlngs[0], {
+            'clickable': true,
+            'icon': homeMarker
+        }).addTo(map);
 
-      var firstpolyline = new L.Polyline(pointList, {
-        color: 'red',
-        weight: 3,
-        opacity: 1.0,
-        smoothFactor: 1,
-        dashArray: "5, 5"
-      });
-      firstpolyline.addTo(map);
+        firstpolyline.addTo(map);
+      } catch (e) {
+        // do nothing
+        // if something goes wrong trying to plot the route
+        // we only want to show the station point
+      }
       {% endif %}
 
       window.map = map;
       window.polling_station_location = polling_station_location;
 
-      {% if directions.route %}
-      map.fitBounds(firstpolyline.getBounds(), {maxZoom: 16});
-      {% else %}
-      map.setView([{{ station.location.1 }}, {{ station.location.0 }}],15);
-      {% endif %}
+      if (firstpolyline) {
+        map.fitBounds(firstpolyline.getBounds(), {maxZoom: 16});
+      } else {
+        map.setView([{{ station.location.1 }}, {{ station.location.0 }}],15);
+      }
     };
 
     var point = [{{ location.1 }}, {{ location.0 }}];

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -255,7 +255,7 @@
       }).addTo(map);
 
       {% if directions.route %}
-      decoded = polyline.decode('{{ directions.route }}', {{ directions.precision }});
+      decoded = polyline.decode({{ directions.route|safe }}, {{ directions.precision }});
       try {
         firstpolyline = new L.Polyline(decoded, {
             color: 'red',


### PR DESCRIPTION
It feels like quite a long time since I've written one of my pull request novels :) So what's goin on here then...

We have several directions-related problems that need solving:

* Our approach to directions just draws lines connecting points - we want curvy lines
* Google maps won't let us buy more than 100,000 requests per day
* The Open Route Service fallback code was broken so we had no fallback provider

To that end I have:

* Removed the broken Open Route Service code
* Modified the google maps code to use the `overview_polyline` (so we get smoothed shapes if we're using google maps)
* Added a directions client for [mapzen](https://mapzen.com/) (according to [mapzen's pricing](https://mapzen.com/pricing/#turn-by-turn) we should be able to buy as many requests as we need but it is worth checking)
* Made mapzen the default with fallback to google directions (if no mapzen key is set it will go straight to google maps without making a http request to mapzen) - this gives us a high-volume fallback and cuts down on the number of API keys you need to be able to start contributing because you can use GMaps with no key
* Refactored the `DirectionsHelper` class so it is easier to add or switch directions providers (using the same model as we've used for geocoding services)
* Added a whole bunch of unit tests (previously the `DirectionsHelper` was kind of covered by proxy in the integration tests but this is a lot more rigorous)

so whereas before, we were showing routes like this:

![before](https://user-images.githubusercontent.com/6025893/28214195-36234096-68a1-11e7-8189-7e0637f63226.png)

now we can show lovely curvy ones like this (mapzen):

![mapzen](https://user-images.githubusercontent.com/6025893/28214202-38ee2142-68a1-11e7-9718-55c5d50b89ac.png)

..and this (google):

![google](https://user-images.githubusercontent.com/6025893/28214207-3d25bdec-68a1-11e7-9fd4-5051bd706679.png)

woo :)

In order to test the mapzen stuff locally, add `MAPZEN_API_KEY = 'our-api-key'` to `local.py`. @symroe - I've sent you the login details on slack.

There are several additional things we need to do alongside merging this:

* Update [deploy repo](https://github.com/DemocracyClub/polling_deploy) to add a `MAPZEN_API_KEY` to the config file
* Add DC credit card details to mapzen account
* Contact mapzen about usage - are we definitely 100% ok to smash through >100,000 requests in a single day as long as we are giving them cashmonies?
* The other thing I would also like to address in this PR before merging (and with an accompanything PR to https://github.com/DemocracyClub/WhereDoIVote-Widget ) is that we've now got a bit of a random mashup of direction links going on. On the main site we link out to google maps for directions, but in the widget we're linking to OSM for directions and also a google maps link.. I'd like to standardise all that to either use google maps or OSM consistently (I'm happy for CycleStreets to be the odd one out given you're of the opinion that it is superior to GMaps or OSM for that particular purpose). I'm leaning towards changing all the links to OSM instead of google maps because "yay - open data!!" but google maps is probably more familiar to people. Thoughts on this??


Additionally, there are several issues arising from this PR which are out of scope and should be addressed elsewhere but are worth acknowledging here:

* As noted in e8ad46a our approach to JS dependency management in this project is a bit rubbish and there's a mix of stuff we've just commited to the repo and some NPM dependencies (PhantomJS, Aglio) which aren't properly managed. Its worth looking at whether we can make a better job of this (probably with `yarn` but needs a bit of thought)
* All [this](https://github.com/chris48s/UK-Polling-Stations/commit/caa748f7b9161d65ccdfb01164fca753f2eeb1d7#diff-2163c5f843c83763dbbb8f664d402cd2) is a bit of a mess but should be addressed under #540
* Both of the above points tie into looking at our javascript pipeline for this project, but I think that fits under https://github.com/DemocracyClub/polling_deploy/issues/6 or maybe with upgrading the theme?
* Both of the directions APIs we're using do return the info we would need to actually embed directions on the page. If you look at https://maps.googleapis.com/maps/api/directions/json?mode=walking&units=imperial&key=&origin=53.52608322352942,-2.288074417647058&destination=53.521097882352954,-2.292880429411764 for example, there are instructions like `Head <b>south</b> on <b>Lowther Rd</b> toward <b>Lowther Cl</b>` in the JSON and Mapzen does the same. I think for the improvements in this PR are enough for now, but maybe we should look at using these to provide inline directions in future?

