### PR TITLE
make flaky tests less flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: python
 python:
   - '3.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - postgresql-9.5-postgis-2.3
 before_script:
   - psql -U postgres -c "create extension postgis"
+  - export BOTO_CONFIG=/dev/null
 cache:
   pip: true
   directories:

--- a/polling_stations/apps/data_finder/features/index.py
+++ b/polling_stations/apps/data_finder/features/index.py
@@ -24,7 +24,7 @@ temp_dir = tempfile.mkdtemp()
 def before_all():
     # build static assets into a temporary location
     settings.STATIC_ROOT=temp_dir
-    call_command('collectstatic', interactive=False)
+    call_command('collectstatic', interactive=False, verbosity=0)
 
 @after.all
 def after_all():
@@ -56,6 +56,10 @@ def take_down(scenario, outline, steps):
     except OSError:
         # ..or we can do this the hard way
         world.browser.service.process.send_signal(signal.SIGTERM)
+
+@before.each_step
+def each_step(step):
+    print(str(step))
 
 @around.each_step
 @contextmanager

--- a/polling_stations/apps/data_finder/features/index.py
+++ b/polling_stations/apps/data_finder/features/index.py
@@ -36,6 +36,7 @@ def setup(scenario, outline, steps):
     # TODO Set browser in django.conf.settings
     # world.browser = webdriver.Chrome()
     world.browser = webdriver.PhantomJS()
+    world.browser.set_page_load_timeout(10)
 
     with open(os.devnull, "w") as f:
         call_command('loaddata', 'test_routing.json', stdout=f)

--- a/polling_stations/apps/data_finder/features/index.py
+++ b/polling_stations/apps/data_finder/features/index.py
@@ -37,6 +37,7 @@ def setup(scenario, outline, steps):
     # world.browser = webdriver.Chrome()
     world.browser = webdriver.PhantomJS()
     world.browser.set_page_load_timeout(10)
+    world.browser.set_script_timeout(10)
 
     with open(os.devnull, "w") as f:
         call_command('loaddata', 'test_routing.json', stdout=f)

--- a/polling_stations/settings/testing.py
+++ b/polling_stations/settings/testing.py
@@ -4,8 +4,9 @@ INSTALLED_APPS = list(INSTALLED_APPS)
 INSTALLED_APPS.append('aloe_django',)
 
 NOSE_ARGS = [
-    '--verbosity=0',
+    '--verbosity=2',
     '--nologcapture',
+    '--nocapture',
 ]
 
 MIGRATION_MODULES = {


### PR DESCRIPTION
After lots of testing and debugging, I've worked out we are hitting this: https://github.com/travis-ci/travis-ci/issues/3251
Not sure exactly why we're hitting it more frequently now - maybe something we've changed, maybe something in the travis environment (e.g: recent upgrade to trusty builds). Either way, it has become frequent and annoying.

I've tried various things to try and fix this - older version of `phantomjs`, newer version of `phantomjs` (some people seem to have had better/worse luck with different versions, various bits of discussion buried in https://github.com/travis-ci/travis-ci/issues/3225), tweaks to the webdriver config and so on. None of it works..

I've seen some people who have managed to work around the problem using some variation of "if it throws a `selenium.common.exceptions.TimeoutException`, try it a couple more times, just to be sure" e.g:
https://github.com/spacetelescope/asv/pull/290/files
https://github.com/gator-life/gator.life/commit/0e1794f850ec7082461332eceeb0394f64f9255a
I have played about with that, but I would much rather avoid that workaround - it is a hack, not a fix.

The one thing I've found which appears to get the tests to work consistently (or at least fail much less frequently, touch wood :deciduous_tree:) is to run them in a VM instead of a container. PR #1048 requires us to move to using a VM-based build anyway because we need `sudo` to install drafter, so I lets just do that to start with.. It avoids the need for nasty workarounds.

Commits e4c1579 and ff963d2 implement that fix.

Commits e38d8c1, 1feb625 and 69a5664 are refined versions of some of the debugging code I added. They're concerned with getting the tests to run (or fail) in a more deterministic way and providing more information about what is happeneing in the test run so that problems with the integration tests are easier to track down.