### PR TITLE
uk_geo_utils app part 3

### DIFF
--- a/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
+++ b/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
@@ -1,11 +1,11 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from data_finder.helpers import (
-    AddressBaseGeocoder, CodesNotFoundException, MultipleCouncilsException
+    AddressBaseGeocoderAdapter, CodesNotFoundException, MultipleCouncilsException
 )
 
 
-class AddressBaseGeocoderTest(TestCase):
+class AddressBaseGeocoderAdapterTest(TestCase):
 
     fixtures = ['test_addressbase.json']
 
@@ -15,7 +15,7 @@ class AddressBaseGeocoderTest(TestCase):
 
         Exception of class ObjectDoesNotExist should be thrown
         """
-        addressbase = AddressBaseGeocoder('DD1 1DD')
+        addressbase = AddressBaseGeocoderAdapter('DD1 1DD')
         exception_thrown = False
         try:
             result = addressbase.geocode()
@@ -37,7 +37,7 @@ class AddressBaseGeocoderTest(TestCase):
 
         Exception of class CodesNotFoundException should be thrown
         """
-        addressbase = AddressBaseGeocoder('AA11AA')
+        addressbase = AddressBaseGeocoderAdapter('AA11AA')
         exception_thrown = False
         try:
             result = addressbase.geocode()
@@ -57,7 +57,7 @@ class AddressBaseGeocoderTest(TestCase):
 
         Exception of class MultipleCouncilsException should be thrown
         """
-        addressbase = AddressBaseGeocoder('CC11CC')
+        addressbase = AddressBaseGeocoderAdapter('CC11CC')
         exception_thrown = False
         try:
             result = addressbase.geocode()
@@ -79,7 +79,7 @@ class AddressBaseGeocoderTest(TestCase):
         Note that in this case, the ONSUD table does not contain corresponding
         records for *all* of the UPRNs we found, but we accept the result anyway
         """
-        addressbase = AddressBaseGeocoder('bb 1   1B B')  # intentionally spurious whitespace and case
+        addressbase = AddressBaseGeocoderAdapter('bb 1   1B B')  # intentionally spurious whitespace and case
         result = addressbase.geocode()
         self.assertEqual('addressbase', result['source'])
         self.assertEqual('B01000001', result['council_gss'])

--- a/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
+++ b/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
@@ -16,19 +16,12 @@ class AddressBaseGeocoderAdapterTest(TestCase):
         Exception of class ObjectDoesNotExist should be thrown
         """
         addressbase = AddressBaseGeocoderAdapter('DD1 1DD')
-        exception_thrown = False
-        try:
+        with self.assertRaises(ObjectDoesNotExist):
             result = addressbase.geocode()
-        except ObjectDoesNotExist:
-            exception_thrown = True
-        self.assertTrue(exception_thrown)
 
         # point only geocode should also fail
-        try:
+        with self.assertRaises(ObjectDoesNotExist):
             result = addressbase.geocode_point_only()
-        except ObjectDoesNotExist:
-            exception_thrown = True
-        self.assertTrue(exception_thrown)
 
     def test_no_codes(self):
         """
@@ -38,12 +31,8 @@ class AddressBaseGeocoderAdapterTest(TestCase):
         Exception of class CodesNotFoundException should be thrown
         """
         addressbase = AddressBaseGeocoderAdapter('AA11AA')
-        exception_thrown = False
-        try:
+        with self.assertRaises(CodesNotFoundException):
             result = addressbase.geocode()
-        except CodesNotFoundException:
-            exception_thrown = True
-        self.assertTrue(exception_thrown)
 
         # point only geocode should return a result anyway
         result = addressbase.geocode_point_only()
@@ -58,12 +47,8 @@ class AddressBaseGeocoderAdapterTest(TestCase):
         Exception of class MultipleCouncilsException should be thrown
         """
         addressbase = AddressBaseGeocoderAdapter('CC11CC')
-        exception_thrown = False
-        try:
+        with self.assertRaises(MultipleCouncilsException):
             result = addressbase.geocode()
-        except MultipleCouncilsException:
-            exception_thrown = True
-        self.assertTrue(exception_thrown)
 
         # point only geocode should return a result anyway
         result = addressbase.geocode_point_only()

--- a/polling_stations/apps/uk_geo_utils/fixtures/addressbase_geocoder/AA11AA.json
+++ b/polling_stations/apps/uk_geo_utils/fixtures/addressbase_geocoder/AA11AA.json
@@ -1,0 +1,29 @@
+[
+    {
+        "fields": {
+            "address": "1 Foo Street, Bar Town",
+            "postcode": "AA1 1AA",
+            "location": "SRID=4326;POINT (-2.9 51.1)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000001"
+    },
+    {
+        "fields": {
+            "address": "2 Foo Street, Bar Town",
+            "postcode": "AA1 1AA",
+            "location": "SRID=4326;POINT (-2.8 51.1)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000002"
+    },
+    {
+        "fields": {
+            "address": "3 Foo Street, Bar Town",
+            "postcode": "AA1 1AA",
+            "location": "SRID=4326;POINT (-2.8 51.2)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000003"
+    }
+]

--- a/polling_stations/apps/uk_geo_utils/fixtures/addressbase_geocoder/BB11BB.json
+++ b/polling_stations/apps/uk_geo_utils/fixtures/addressbase_geocoder/BB11BB.json
@@ -1,0 +1,90 @@
+[
+    {
+        "fields": {
+            "address": "1 Baz Street, Bar Town",
+            "postcode": "BB1 1BB",
+            "location": "SRID=4326;POINT (-3.9 51.1)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000004"
+    },
+    {
+        "fields": {
+            "address": "2 Baz Street, Bar Town",
+            "postcode": "BB1 1BB",
+            "location": "SRID=4326;POINT (-3.8 51.1)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000005"
+    },
+    {
+        "fields": {
+            "address": "2 Baz Street, Bar Town",
+            "postcode": "BB1 1BB",
+            "location": "SRID=4326;POINT (-3.8 51.2)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000006"
+    },
+
+    {
+        "fields": {
+            "cty": "A01000001",
+            "lad": "B01000001",
+            "ward": "",
+            "hlthau": "",
+            "ctry": "",
+            "rgn": "",
+            "eer": "",
+            "ttwa": "",
+            "nuts": "",
+            "park": "",
+            "oa11": "",
+            "lsoa11": "",
+            "msoa11": "",
+            "parish": "",
+            "wz11": "",
+            "ccg": "",
+            "bua11": "",
+            "buasd11": "",
+            "ruc11": "",
+            "oac11": "",
+            "lep1": "",
+            "lep2": "",
+            "pfa": "",
+            "imd": ""
+        },
+        "model": "uk_geo_utils.onsud",
+        "pk": "00000004"
+    },
+    {
+        "fields": {
+            "cty": "A01000001",
+            "lad": "B01000001",
+            "ward": "",
+            "hlthau": "",
+            "ctry": "",
+            "rgn": "",
+            "eer": "",
+            "ttwa": "",
+            "nuts": "",
+            "park": "",
+            "oa11": "",
+            "lsoa11": "",
+            "msoa11": "",
+            "parish": "",
+            "wz11": "",
+            "ccg": "",
+            "bua11": "",
+            "buasd11": "",
+            "ruc11": "",
+            "oac11": "",
+            "lep1": "",
+            "lep2": "",
+            "pfa": "",
+            "imd": ""
+        },
+        "model": "uk_geo_utils.onsud",
+        "pk": "00000005"
+    }
+]

--- a/polling_stations/apps/uk_geo_utils/fixtures/addressbase_geocoder/CC11CC.json
+++ b/polling_stations/apps/uk_geo_utils/fixtures/addressbase_geocoder/CC11CC.json
@@ -1,0 +1,120 @@
+[
+    {
+        "fields": {
+            "address": "1 Qux Street, Bar Town",
+            "postcode": "CC1 1CC",
+            "location": "SRID=4326;POINT (-2.9 50.1)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000007"
+    },
+    {
+        "fields": {
+            "address": "2 Qux Street, Bar Town",
+            "postcode": "CC1 1CC",
+            "location": "SRID=4326;POINT (-2.8 50.1)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000008"
+    },
+    {
+        "fields": {
+            "address": "2 Qux Street, Bar Town",
+            "postcode": "CC1 1CC",
+            "location": "SRID=4326;POINT (-2.8 50.2)"
+        },
+        "model": "uk_geo_utils.address",
+        "pk": "00000009"
+    },
+
+    {
+        "fields": {
+            "cty": "A01000001",
+            "lad": "B01000001",
+            "ward": "",
+            "hlthau": "",
+            "ctry": "",
+            "rgn": "",
+            "eer": "",
+            "ttwa": "",
+            "nuts": "",
+            "park": "",
+            "oa11": "",
+            "lsoa11": "",
+            "msoa11": "",
+            "parish": "",
+            "wz11": "",
+            "ccg": "",
+            "bua11": "",
+            "buasd11": "",
+            "ruc11": "",
+            "oac11": "",
+            "lep1": "",
+            "lep2": "",
+            "pfa": "",
+            "imd": ""
+        },
+        "model": "uk_geo_utils.onsud",
+        "pk": "00000007"
+    },
+    {
+        "fields": {
+            "cty": "A01000001",
+            "lad": "B01000001",
+            "ward": "",
+            "hlthau": "",
+            "ctry": "",
+            "rgn": "",
+            "eer": "",
+            "ttwa": "",
+            "nuts": "",
+            "park": "",
+            "oa11": "",
+            "lsoa11": "",
+            "msoa11": "",
+            "parish": "",
+            "wz11": "",
+            "ccg": "",
+            "bua11": "",
+            "buasd11": "",
+            "ruc11": "",
+            "oac11": "",
+            "lep1": "",
+            "lep2": "",
+            "pfa": "",
+            "imd": ""
+        },
+        "model": "uk_geo_utils.onsud",
+        "pk": "00000008"
+    },
+    {
+        "fields": {
+            "cty": "A01000001",
+            "lad": "B01000002",
+            "ward": "",
+            "hlthau": "",
+            "ctry": "",
+            "rgn": "",
+            "eer": "",
+            "ttwa": "",
+            "nuts": "",
+            "park": "",
+            "oa11": "",
+            "lsoa11": "",
+            "msoa11": "",
+            "parish": "",
+            "wz11": "",
+            "ccg": "",
+            "bua11": "",
+            "buasd11": "",
+            "ruc11": "",
+            "oac11": "",
+            "lep1": "",
+            "lep2": "",
+            "pfa": "",
+            "imd": ""
+        },
+        "model": "uk_geo_utils.onsud",
+        "pk": "00000009"
+    }
+]

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -1,0 +1,96 @@
+import abc
+from django.core.exceptions import ObjectDoesNotExist
+from uk_geo_utils.helpers import (
+    get_address_model, get_onsud_model, Postcode)
+
+
+class CodesNotFoundException(Exception):
+    pass
+
+class MultipleCodesException(Exception):
+    pass
+
+class NorthernIrelandException(ObjectDoesNotExist):
+    pass
+
+class AddressBaseNotImportedException(ObjectDoesNotExist):
+    pass
+
+
+class BaseGeocoder(metaclass=abc.ABCMeta):
+
+    def __init__(self, postcode):
+        self.postcode = Postcode(postcode)
+
+    @property
+    @abc.abstractmethod
+    def centroid(self):
+        pass
+
+    @abc.abstractmethod
+    def get_code(code_type, uprn=None):
+        pass
+
+
+class AddressBaseGeocoder(BaseGeocoder):
+
+    def __init__(self, postcode):
+
+        self.postcode = Postcode(postcode)
+        if self.postcode.territory == 'NI':
+            raise NorthernIrelandException('Postcode is in Northern Ireland')
+
+        self.onsud_model = get_onsud_model()
+        self.address_model = get_address_model()
+
+        try:
+            # check if there are one or more records in the address table
+            self.address_model.objects.raw(
+                "SELECT uprn FROM %s LIMIT 1;" %\
+                (self.address_model._meta.db_table))[0]
+        except IndexError:
+            raise AddressBaseNotImportedException('Address Base table is empty')
+
+        self.addresses = self.address_model.objects.filter(
+            postcode=self.postcode.with_space)
+        if not self.addresses:
+            raise self.address_model.DoesNotExist(
+                'No addresses found for postcode %s' % (self.postcode))
+
+        self.uprns = self.onsud_model.objects.filter(
+            uprn__in=self._get_uprns())
+
+    def _get_uprns(self):
+        return [a.uprn for a in self.addresses]
+
+    @property
+    def centroid(self):
+        return self.addresses.centroid
+
+    def get_code(self, code_type, uprn=None):
+        # check the code_type field exists on our model
+        self.onsud_model._meta.get_field(code_type)
+
+        if uprn:
+            # TODO: implement this
+            raise NotImplementedError()
+
+        if len(self.uprns) == 0:
+            # No records in the ONSUD table were found for the given UPRNs
+            # because...reasons
+            raise CodesNotFoundException('Found no records in ONSUD for supplied UPRNs')
+        if len(self.addresses) != len(self.uprns):
+            # For the moment I'm going to do nothing about this, but lets
+            # leave this condition here to make that decision explicit
+            # TODO: maybe we should actually do....something else??
+            pass
+
+        codes = set([getattr(u, code_type, None) for u in self.uprns])
+        if len(codes) == 1:
+            # all the uprns supplied are in the same area
+            return list(codes)[0]
+        else:
+            raise MultipleCodesException(
+                "Postcode %s covers UPRNs in more than one '%s' area" %\
+                (self.postcode, code_type)
+            )

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -72,8 +72,8 @@ class AddressBaseGeocoder(BaseGeocoder):
         self.onsud_model._meta.get_field(code_type)
 
         if uprn:
-            # TODO: implement this
-            raise NotImplementedError()
+            self.addresses.get(uprn=uprn)
+            return getattr(self.uprns.get(uprn=uprn), code_type)
 
         if len(self.uprns) == 0:
             # No records in the ONSUD table were found for the given UPRNs
@@ -85,7 +85,7 @@ class AddressBaseGeocoder(BaseGeocoder):
             # TODO: maybe we should actually do....something else??
             pass
 
-        codes = set([getattr(u, code_type, None) for u in self.uprns])
+        codes = set([getattr(u, code_type) for u in self.uprns])
         if len(codes) == 1:
             # all the uprns supplied are in the same area
             return list(codes)[0]

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -68,15 +68,15 @@ class AddressBaseGeocoder(BaseGeocoder):
         return self.addresses.centroid
 
     def get_point(self, uprn):
-        return self.addresses.get(uprn=uprn).location
+        return self.addresses.get_cached(uprn).location
 
     def get_code(self, code_type, uprn=None):
         # check the code_type field exists on our model
         self.onsud_model._meta.get_field(code_type)
 
         if uprn:
-            self.addresses.get(uprn=uprn)
-            return getattr(self.uprns.get(uprn=uprn), code_type)
+            self.addresses.get_cached(uprn)
+            return getattr(self.uprns.get_cached(uprn), code_type)
 
         if len(self.uprns) == 0:
             # No records in the ONSUD table were found for the given UPRNs

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -52,13 +52,13 @@ class AddressBaseGeocoder(BaseGeocoder):
             raise AddressBaseNotImportedException('Address Base table is empty')
 
         self.addresses = self.address_model.objects.filter(
-            postcode=self.postcode.with_space)
+            postcode=self.postcode.with_space).order_by('uprn')
         if not self.addresses:
             raise self.address_model.DoesNotExist(
                 'No addresses found for postcode %s' % (self.postcode))
 
         self.uprns = self.onsud_model.objects.filter(
-            uprn__in=self._get_uprns())
+            uprn__in=self._get_uprns()).order_by('uprn')
 
     def _get_uprns(self):
         return [a.uprn for a in self.addresses]

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -43,12 +43,8 @@ class AddressBaseGeocoder(BaseGeocoder):
         self.onsud_model = get_onsud_model()
         self.address_model = get_address_model()
 
-        try:
-            # check if there are one or more records in the address table
-            self.address_model.objects.raw(
-                "SELECT uprn FROM %s LIMIT 1;" %\
-                (self.address_model._meta.db_table))[0]
-        except IndexError:
+        # check if there are one or more records in the address table
+        if not self.address_model.objects.all().exists():
             raise AddressBaseNotImportedException('Address Base table is empty')
 
         self.addresses = self.address_model.objects.filter(

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -67,6 +67,9 @@ class AddressBaseGeocoder(BaseGeocoder):
     def centroid(self):
         return self.addresses.centroid
 
+    def get_point(self, uprn):
+        return self.addresses.get(uprn=uprn).location
+
     def get_code(self, code_type, uprn=None):
         # check the code_type field exists on our model
         self.onsud_model._meta.get_field(code_type)

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -83,9 +83,29 @@ class AddressBaseGeocoder(BaseGeocoder):
             # because...reasons
             raise CodesNotFoundException('Found no records in ONSUD for supplied UPRNs')
         if len(self.addresses) != len(self.uprns):
-            # For the moment I'm going to do nothing about this, but lets
-            # leave this condition here to make that decision explicit
-            # TODO: maybe we should actually do....something else??
+            """
+            TODO: once you can easily map addresses in WhereDIV to a UPRN,
+            change this to:
+
+            for uprn in self._get_uprns():
+                try:
+                    self.uprns.get_cached(uprn)
+                except self.onsud_model.DoesNotExist:
+                    raise SomeException('oh noes!!')
+
+            Then you can handle it by calling something like
+            try:
+                code = g.get_code('lad')
+            except SomeException:
+                point = g.get_point(myuprn)
+                code = Council.objects.get(area__covers=point)
+
+            (this will make the BB1 1BB test case fail
+            so you'll need to update that too)
+
+            For the moment I'm going to leave it as-is
+            to maintain backwards-compatibility
+            """
             pass
 
         codes = set([getattr(u, code_type) for u in self.uprns])

--- a/polling_stations/apps/uk_geo_utils/models.py
+++ b/polling_stations/apps/uk_geo_utils/models.py
@@ -1,7 +1,16 @@
 from django.contrib.gis.db import models
 
 
-class AddressQuerySet(models.QuerySet):
+class CachedGetMixin:
+
+    def get_cached(self, pk):
+        for record in self:
+            if record.pk == pk:
+                return record
+        raise self.model.DoesNotExist()
+
+
+class AddressQuerySet(models.QuerySet, CachedGetMixin):
 
     @property
     def centroid(self):
@@ -39,6 +48,15 @@ class Address(AbstractAddress):
     pass
 
 
+class OnsudQuerySet(models.QuerySet, CachedGetMixin):
+    pass
+
+
+class AbstractOnsudManager(models.GeoManager):
+    def get_queryset(self):
+        return OnsudQuerySet(self.model, using=self._db)
+
+
 class AbstractOnsud(models.Model):
     uprn = models.CharField(primary_key=True, max_length=12)
     """
@@ -72,6 +90,7 @@ class AbstractOnsud(models.Model):
     lep2 = models.CharField(blank=True, max_length=9)
     pfa = models.CharField(blank=True, max_length=9)
     imd = models.CharField(blank=True, max_length=5)
+    objects = AbstractOnsudManager()
 
     class Meta:
         abstract = True

--- a/polling_stations/apps/uk_geo_utils/tests/test_addressbase_geocoder.py
+++ b/polling_stations/apps/uk_geo_utils/tests/test_addressbase_geocoder.py
@@ -1,0 +1,98 @@
+from django.test import TestCase, override_settings
+from django.core.exceptions import FieldDoesNotExist
+from django.contrib.gis.geos import Point
+from uk_geo_utils.geocoders import (
+    AddressBaseGeocoder,
+    get_address_model,
+    AddressBaseNotImportedException,
+    CodesNotFoundException,
+    MultipleCodesException,
+    NorthernIrelandException,
+)
+
+
+# TODO: This override can be removed when you spin this
+# out into a seperate package. It is only needed because
+# we're running the tests inside WhereDIV as a host app
+@override_settings(ADDRESS_MODEL='uk_geo_utils.Address')
+class AddressBaseGeocoderTest(TestCase):
+
+    fixtures = [
+        # records in Address, no corresponding records in ONSUD
+        'addressbase_geocoder/AA11AA.json',
+
+        # 3 records in Address, 2 corresponding records in ONSUD
+        # all in county A01000001 and local auth B01000001
+        'addressbase_geocoder/BB11BB.json',
+
+        # records in Address, corresponding records in ONSUD
+        # all in county A01000001 but split across
+        # local auths B01000001 and B01000002
+        'addressbase_geocoder/CC11CC.json',
+    ]
+
+    def test_empty_table(self):
+        """
+        The AddressBase table has no records in it
+        """
+        get_address_model().objects.all().delete()
+        with self.assertRaises(AddressBaseNotImportedException):
+            addressbase = AddressBaseGeocoder('AA11AA')
+
+    def test_northern_ireland(self):
+        with self.assertRaises(NorthernIrelandException):
+            addressbase = AddressBaseGeocoder('BT11AA')
+
+    def test_no_records(self):
+        """
+        We can't find any records for the given postcode in the AddressBase table
+        """
+        with self.assertRaises(get_address_model().DoesNotExist):
+            addressbase = AddressBaseGeocoder('ZZ1 1ZZ')
+
+    def test_no_codes(self):
+        """
+        We find records for the given postcode in the AddressBase table
+        but there are no corresponding records in the ONSUD for the UPRNs we found
+        """
+        addressbase = AddressBaseGeocoder('AA11AA')
+
+        with self.assertRaises(CodesNotFoundException):
+            result = addressbase.get_code('lad')
+
+        self.assertIsInstance(addressbase.centroid, Point)
+
+    def test_valid(self):
+        """
+        We find records for the given postcode in the AddressBase table
+        There are some corresponding records in the ONSUD for the UPRNs we found
+
+        Valid result should be returned
+
+        Note that in this case, the ONSUD table does not contain corresponding
+        records for *all* of the UPRNs we found, but we accept the result anyway
+        """
+        addressbase = AddressBaseGeocoder('bb 1   1B B')  # intentionally spurious whitespace and case
+        self.assertEqual('B01000001', addressbase.get_code('lad'))
+        self.assertIsInstance(addressbase.centroid, Point)
+
+    def test_multiple_codes(self):
+        """
+        We find records for the given postcode in the AddressBase table
+        There are corresponding records in the ONSUD for the UPRNs we found
+        The UPRNs described by this postcode map to more than one 'lad'
+        but they all map to the same 'cty'
+        """
+        addressbase = AddressBaseGeocoder('CC1 1CC')
+
+        with self.assertRaises(MultipleCodesException):
+            result = addressbase.get_code('lad')
+
+        self.assertEqual('A01000001', addressbase.get_code('cty'))
+
+        self.assertIsInstance(addressbase.centroid, Point)
+
+    def test_invalid_code_type(self):
+        addressbase = AddressBaseGeocoder('CC1 1CC')
+        with self.assertRaises(FieldDoesNotExist):
+            result = addressbase.get_code('foo')  # not a real code type

--- a/polling_stations/apps/uk_geo_utils/tests/test_addressbase_geocoder.py
+++ b/polling_stations/apps/uk_geo_utils/tests/test_addressbase_geocoder.py
@@ -104,7 +104,9 @@ class AddressBaseGeocoderTest(TestCase):
         """
         addressbase = AddressBaseGeocoder('CC1 1CC')
         self.assertEqual('B01000001', addressbase.get_code('lad', '00000008'))
+        self.assertIsInstance(addressbase.get_point('00000008'), Point)
         self.assertEqual('B01000002', addressbase.get_code('lad', '00000009'))
+        self.assertIsInstance(addressbase.get_point('00000009'), Point)
 
     def test_get_code_by_uprn_invalid_uprn(self):
         """
@@ -113,6 +115,8 @@ class AddressBaseGeocoderTest(TestCase):
         addressbase = AddressBaseGeocoder('CC1 1CC')
         with self.assertRaises(get_address_model().DoesNotExist):
             result = addressbase.get_code('lad', 'foo')
+        with self.assertRaises(get_address_model().DoesNotExist):
+            result = addressbase.get_point('foo')
 
     def test_get_code_by_uprn_invalid_uprn_for_postcode(self):
         """
@@ -123,6 +127,8 @@ class AddressBaseGeocoderTest(TestCase):
         addressbase = AddressBaseGeocoder('CC1 1CC')
         with self.assertRaises(get_address_model().DoesNotExist):
             result = addressbase.get_code('lad', '00000001')
+        with self.assertRaises(get_address_model().DoesNotExist):
+            result = addressbase.get_point('00000001')
 
     def test_get_code_by_uprn_no_onsud(self):
         """
@@ -131,3 +137,4 @@ class AddressBaseGeocoderTest(TestCase):
         addressbase = AddressBaseGeocoder('BB1 1BB')
         with self.assertRaises(get_onsud_model().DoesNotExist):
             result = addressbase.get_code('lad', '00000006')
+        self.assertIsInstance(addressbase.get_point('00000006'), Point)


### PR DESCRIPTION
* Move `AddressBaseGeocoder` to `uk_geo_utils` app
* Generalise `AddressBaseGeocoder` a bit:
  * Various changes to support working with UPRNs in anticipation of being able to query by UPRN as well as postcode (coming soon)
  * Throw a few new exception types (`NorthernIrelandException`, `AddressBaseNotImportedException`) in anticipation of the `uk_geo_utils` library being used in EE/WhereDIV Northn Ireland is in-scope or where we may only going to want to import the ONSPD and easily fall back to it (coming in [part 4](https://github.com/DemocracyClub/UK-Polling-Stations/pull/1070) ).
* Replace `data_finder.helpers.AddressBaseGeocoder` with a `AddressBaseGeocoderAdapter` layer. Ultimately as part of this larger project, I think I'm going to modify the calling code to talk directly to `uk_geo_utils.geocoders.AddressBaseGeocoder` and remove this abstraction, but this is a useful 'intermediate' step which helps break this big task down into smaller chunks which are easier to review.
* MOAR unit tests
* Performance optimisations
* There is one can which I've chosen to kick down the road: e8c3a5a The reason I've chosen not to make this change now is that until we can query by UPRN, this would be a breaking change (i.e: we need to be able to show an address picker and get back a UPRN before this is non-breaking). By retaining the existing behaviour for now, it keeps this change deploy-able. That means we can merge this and if we need to deploy it tomorrow then we can and the site continues to perform consistently, which I think is a useful property to retain.