### PR TITLE
Remove last few mapit references

### DIFF
--- a/polling_stations/apps/data_collection/google_geocoding_api_wrapper.py
+++ b/polling_stations/apps/data_collection/google_geocoding_api_wrapper.py
@@ -30,23 +30,8 @@ class GoogleGeocodingApiWrapper:
         json_response = json.loads(str_response)
         return json_response
 
-    """
-    If self.area_code is set, use mapit to check that
-    the postcode we've found is in the area
-    (probably local auth, but if we have ward or something, use that)
-    that it is supposed to be in
-    Otherwise raises exception of class PostcodeNotFoundException
-    """
     def sanity_check(self, postcode):
-        sleep(1)  # ensure we don't hit mapit's usage limit
-        res = requests.get("%s/postcode/%s" % (settings.MAPIT_URL, postcode))
-        res_json = res.json()
-
-        for area in res_json['areas']:
-            if res_json['areas'][area]['type'] == self.area_type:
-                if res_json['areas'][area]['codes']['gss'] != self.area_code:
-                    raise PostcodeNotFoundException("Postcode found but sanity check failed")
-        return True
+        raise NotImplementedError()
 
     """
     Returns postcode if we have a decent match

--- a/polling_stations/apps/data_finder/checks.py
+++ b/polling_stations/apps/data_finder/checks.py
@@ -23,25 +23,6 @@ def mapquest_sdk_check(app_configs, **kwargs):
 
 
 @register()
-def mapit_ua_check(app_configs, **kwargs):
-    errors = []
-
-    if (app_configs is None or\
-        apps.get_app_config('data_finder') in app_configs):
-
-        if settings.MAPIT_UA is None:
-            errors.append(
-                Info(
-                    "Mapit user agent is not set - usage limits will apply",
-                    hint='Define MAPIT_UA as an env var or in local.py',
-                    obj='data_finder',
-                    id='data_finder.I001',
-                )
-            )
-    return errors
-
-
-@register()
 def google_api_check(app_configs, **kwargs):
     errors = []
 

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -276,7 +276,6 @@ from .constants.councils import *  # noqa
 from .constants.directions import *  # noqa
 from .constants.elections import *  # noqa
 from .constants.importers import *  # noqa
-from .constants.mapit import *  # noqa
 from .constants.tiles import *  # noqa
 
 # Import .local.py last - settings in local.py override everything else

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -3,12 +3,3 @@
 YVM_LA_URL = "https://www.yourvotematters.co.uk/_design/nested-content/results-page2/search-voting-locations-by-districtcode?queries_distcode_query="  # noqa
 GB_BOUNDARIES_URL = "https://opendata.arcgis.com/datasets/686603e943f948acaa13fb5d2b0f1275_1.geojson"
 NI_BOUNDARIES_URL = "https://opendata.arcgis.com/datasets/bba0392d214b4ac0a8e0d559cdf6013f_2.geojson"
-
-COUNCIL_TYPES = [
-    "LBO",
-    "DIS",
-    "MTD",
-    "LGD",
-    "UTA",
-    "COI",
-]

--- a/polling_stations/settings/constants/mapit.py
+++ b/polling_stations/settings/constants/mapit.py
@@ -1,4 +1,0 @@
-import os
-
-MAPIT_URL = os.environ.get('MAPIT_URL', "http://mapit.democracyclub.org.uk/")
-MAPIT_UA = os.environ.get('MAPIT_UA', None)


### PR DESCRIPTION
Once PRs #1070 and #1071 are merged, all of the code that interacts with mapit will be removed. Once those are done, this PR finishes the cleanup and removes the last few references and settings. When those PRs are reviewed/merged I can rebase this changes on to `master` and then the tests should pass. Obvs the build is currently broken as there is still code under test on this branch which is expecting these settings to exist.