### PR TITLE
back out changes in 92df1e8

### DIFF
--- a/polling_stations/apps/data_finder/features/index.feature
+++ b/polling_stations/apps/data_finder/features/index.feature
@@ -57,3 +57,8 @@ Feature: Check Postcodes
     Then I should see "Contact Your Council"
     And I should see "Residents in DD11DD may be in one of the following council areas:"
     And No errors were thrown
+
+    Scenario: Check invalid postcode
+    When I visit site page "/postcode/foo"
+    Then I should see "This doesn't appear to be a valid postcode."
+    And No errors were thrown

--- a/polling_stations/apps/uk_geo_utils/helpers.py
+++ b/polling_stations/apps/uk_geo_utils/helpers.py
@@ -21,9 +21,9 @@ def get_onspd_model():
 
 class Postcode:
 
-    def __init__(self, postcode):
+    def __init__(self, postcode, validate=False):
         self.postcode = re.sub('[^A-Z0-9]', '', str(postcode).upper())
-        if len(str(self.postcode)) < 5:
+        if validate and len(str(self.postcode)) < 5:
             raise ValueError("Postcode must have at least 5 characters")
 
     def __str__(self):

--- a/polling_stations/apps/uk_geo_utils/tests/test_postcode_helper.py
+++ b/polling_stations/apps/uk_geo_utils/tests/test_postcode_helper.py
@@ -74,7 +74,19 @@ class PostcodeHelperTest(TestCase):
 
     def test_create_invalid(self):
         with self.assertRaises(ValueError):
-            Postcode('abc')
+            Postcode('abc', validate=True)
+
+    def test_with_space_less_than_three_chars(self):
+        # these aren't necessarily terribly useful outputs but these tests
+        # demonstrate that with_space() does not raise in the situation
+        pc = Postcode('abc')
+        self.assertEqual(' ABC', pc.with_space)
+        pc = Postcode('ab')
+        self.assertEqual(' AB', pc.with_space)
+        pc = Postcode('a')
+        self.assertEqual(' A', pc.with_space)
+        pc = Postcode('')
+        self.assertEqual(' ', pc.with_space)
 
     def test_equality_equal(self):
         self.assertEqual(Postcode('AA1 1AA'), Postcode('AA11AA'))


### PR DESCRIPTION
92df1e8 seemed like a really good idea... until I realised it was a really bad idea.

Basically, there are a number of places where we are relying on postcode being able to be not-a-postcode. I tried building in cases to handle it, but I just ended up chasing errors further down the stack. I think the best solution is to back out the change but make `validate` an optional constructor param. This will allow us to add in the validation where we want it in a controlled way rather than sledgehammer in loads of places where the app can throw an exception all at once.

Note that although it looks like I'm removing useful validation here, this basically just puts us back where we were before 6339794 but with the postcode functions moved into a class.

Closes #1077
