### PR TITLE
Tidying up and finishing off on geocoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ python manage.py migrate
 
 ### Import initial data
 
+#### Import ONSPD
+
+For development purposes, you can use the ONSPD for geocoding. Grab the latest release from http://geoportal.statistics.gov.uk/datasets?q=ONS%20Postcode%20Directory%20(ONSPD)&sort=-updatedAt unzip the data and import it using:
+
+```
+python manage.py import_onspd /path/to/data
+```
+
 #### Import Councils
 
 ```

--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -2,7 +2,6 @@ from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from django.contrib.gis.geos import Point
 from django.core.exceptions import ObjectDoesNotExist
 from data_finder.views import LogLookUpMixin
 from data_finder.helpers import (
@@ -69,7 +68,7 @@ class ResidentialAddressViewSet(ViewSet, LogLookUpMixin):
         # in this situation, failure to geocode is non-fatal
         try:
             l = geocoder(address.postcode)
-            location = Point(l['wgs84_lon'], l['wgs84_lat'])
+            location = l.centroid
         except (PostcodeError, RateLimitError) as e:
             location = None
         ret['postcode_location'] = location

--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -7,7 +7,6 @@ from data_finder.views import LogLookUpMixin
 from data_finder.helpers import (
     geocode_point_only,
     PostcodeError,
-    RateLimitError,
 )
 from pollingstations.models import PollingStation, ResidentialAddress
 from uk_geo_utils.helpers import Postcode
@@ -69,7 +68,7 @@ class ResidentialAddressViewSet(ViewSet, LogLookUpMixin):
         try:
             l = geocoder(address.postcode)
             location = l.centroid
-        except (PostcodeError, RateLimitError) as e:
+        except PostcodeError as e:
             location = None
         ret['postcode_location'] = location
 

--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -68,7 +68,7 @@ class ResidentialAddressViewSet(ViewSet, LogLookUpMixin):
         # attempt to attach point
         # in this situation, failure to geocode is non-fatal
         try:
-            l = geocoder(address.postcode, sleep=False)
+            l = geocoder(address.postcode)
             location = Point(l['wgs84_lon'], l['wgs84_lat'])
         except (PostcodeError, RateLimitError) as e:
             location = None

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -8,7 +8,6 @@ from data_finder.helpers import (
     get_council,
     geocode,
     PostcodeError,
-    RateLimitError,
     MultipleCouncilsException,
     RoutingHelper
 )
@@ -74,8 +73,6 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
             location = loc.centroid
         except PostcodeError as e:
             return Response({'detail': e.args[0]}, status=400)
-        except RateLimitError as e:
-            return Response({'detail': e.args[0]}, status=403)
         except MultipleCouncilsException as e:
             loc = None
             location = None

--- a/polling_stations/apps/api/tests/test_address.py
+++ b/polling_stations/apps/api/tests/test_address.py
@@ -5,7 +5,7 @@ from api.address import ResidentialAddressViewSet
 
 
 # Test double for geocode function: always returns the same point
-def mock_geocode(postcode, sleep):
+def mock_geocode(postcode):
     return {
         'wgs84_lon': 0.22247314453125,
         'wgs84_lat': 53.149405955929744,

--- a/polling_stations/apps/api/tests/test_address.py
+++ b/polling_stations/apps/api/tests/test_address.py
@@ -1,16 +1,16 @@
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.gis.geos import Point
 from rest_framework.test import APIRequestFactory
 from api.address import ResidentialAddressViewSet
 
 
 # Test double for geocode function: always returns the same point
 def mock_geocode(postcode):
-    return {
-        'wgs84_lon': 0.22247314453125,
-        'wgs84_lat': 53.149405955929744,
-        'gss_codes': [],
-    }
+    return type(
+        "Geocoder", (object, ),
+        { "centroid": Point(0.22247314453125, 53.149405955929744, srid=4326) }
+    )
 
 
 class AddressTest(TestCase):

--- a/polling_stations/apps/api/tests/test_postcode.py
+++ b/polling_stations/apps/api/tests/test_postcode.py
@@ -1,8 +1,22 @@
 from django.test import TestCase
+from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.gis.geos import Point
 from rest_framework.test import APIRequestFactory
 from api.postcode import PostcodeViewSet
 from data_finder.helpers import MultipleCouncilsException
+
+
+class StubGeocoder:
+
+    def __init__(self, centroid, code):
+        self.centroid = centroid
+        self.code = code
+
+    def get_code(self, codetype):
+        if not self.code:
+            raise ObjectDoesNotExist
+        return self.code
 
 
 """
@@ -14,35 +28,23 @@ def mock_geocode(postcode):
     postcode = postcode.without_space
     # list of addresses
     if (postcode == 'AA11AA'):
-        return {
-            'wgs84_lon': 0.22247314453125,
-            'wgs84_lat': 53.149405955929744,
-            'gss_codes': [],
-        }
+        return StubGeocoder(
+            Point(0.22247314453125, 53.149405955929744, srid=4326), 'X01000001')
 
     # council with no data
     if (postcode == 'BB11BB'):
-        return {
-            'wgs84_lon': -3.54583740234375,
-            'wgs84_lat': 52.019712234868464,
-            'gss_codes': [],
-        }
+        return StubGeocoder(
+            Point(-3.54583740234375, 52.019712234868464, srid=4326), 'X01000002')
 
     # polling station 1
     if (postcode == 'CC11CC'):
-        return {
-            'wgs84_lon': -2.1533203125,
-            'wgs84_lat': 52.858517622387716,
-            'gss_codes': [],
-        }
+        return StubGeocoder(
+            Point(-2.1533203125, 52.858517622387716, srid=4326), 'X01000001')
 
     # no council
     if (postcode == 'DD11DD'):
-        return {
-            'wgs84_lon': -4.6142578125,
-            'wgs84_lat': 57.45913526799062,
-            'gss_codes': [],
-        }
+        return StubGeocoder(
+            Point(-4.6142578125, 57.45913526799062, srid=4326), None)
 
     # multiple councils
     if (postcode == 'EE11EE'):

--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -41,7 +41,6 @@ from pollingstations.models import (
 )
 from data_collection.models import DataQuality
 from uk_geo_utils.helpers import Postcode
-from data_finder.helpers import geocode_point_only, PostcodeError
 from addressbase.helpers import create_address_records_for_council
 
 

--- a/polling_stations/apps/data_collection/ems_importers.py
+++ b/polling_stations/apps/data_collection/ems_importers.py
@@ -87,10 +87,7 @@ class BaseXpressCsvImporter(BaseCsvStationsCsvAddressesImporter,
 
             try:
                 location_data = geocode_point_only(postcode)
-                location = Point(
-                    location_data['wgs84_lon'],
-                    location_data['wgs84_lat'],
-                    srid=4326)
+                location = location_data.centroid
             except PostcodeError:
                 location = None
 
@@ -274,10 +271,7 @@ class BaseHalaroseCsvImporter(BaseCsvStationsCsvAddressesImporter,
 
         try:
             location_data = geocode_point_only(postcode)
-            location = Point(
-                location_data['wgs84_lon'],
-                location_data['wgs84_lat'],
-                srid=4326)
+            location = location_data.centroid
         except PostcodeError:
             location = None
 
@@ -404,10 +398,7 @@ class BaseDemocracyCountsCsvImporter(BaseCsvStationsCsvAddressesImporter,
 
             try:
                 location_data = geocode_point_only(postcode)
-                location = Point(
-                    location_data['wgs84_lon'],
-                    location_data['wgs84_lat'],
-                    srid=4326)
+                location = location_data.centroid
             except PostcodeError:
                 location = None
 

--- a/polling_stations/apps/data_collection/management/commands/import_barnsley.py
+++ b/polling_stations/apps/data_collection/management/commands/import_barnsley.py
@@ -1,4 +1,3 @@
-from django.contrib.gis.geos import Point
 from data_collection.base_importers import BaseCsvStationsCsvAddressesImporter
 from data_finder.helpers import geocode_point_only, PostcodeError
 
@@ -32,10 +31,7 @@ class Command(BaseCsvStationsCsvAddressesImporter):
 
         try:
             location_data = geocode_point_only(postcode)
-            location = Point(
-                location_data['wgs84_lon'],
-                location_data['wgs84_lat'],
-                srid=4326)
+            location = location_data.centroid
         except PostcodeError:
             location = None
         return location

--- a/polling_stations/apps/data_collection/management/commands/import_bexley.py
+++ b/polling_stations/apps/data_collection/management/commands/import_bexley.py
@@ -52,14 +52,9 @@ class Command(BaseCsvStationsCsvAddressesImporter):
             # no points supplied, so attempt to attach them by geocoding
             try:
                 location_data = geocode_point_only(postcode)
+                location = location_data.centroid
             except PostcodeError:
                 pass
-
-            if location_data:
-                location = Point(
-                    location_data['wgs84_lon'],
-                    location_data['wgs84_lat'],
-                    srid=4326)
 
         return {
             'internal_council_id': record.poll_stn_number,

--- a/polling_stations/apps/data_collection/management/commands/import_bromley.py
+++ b/polling_stations/apps/data_collection/management/commands/import_bromley.py
@@ -3,10 +3,8 @@ Import Bromley
 """
 from time import sleep
 
-from django.contrib.gis.geos import Point
-
 from data_collection.management.commands import BaseCsvStationsCsvAddressesImporter
-from data_finder.helpers import geocode, geocode_point_only, PostcodeError
+from data_finder.helpers import geocode, PostcodeError
 from addressbase.models import Address
 
 
@@ -33,14 +31,9 @@ class Command(BaseCsvStationsCsvAddressesImporter):
         if record.postcode_if_available:
             try:
                 location_data = geocode_point_only(postcode_if_available)
+                location = location_data.centroid
             except PostcodeError:
                 pass
-
-            if location_data:
-                location = Point(
-                    location_data['wgs84_lon'],
-                    location_data['wgs84_lat'],
-                    srid=4326)
 
         desc = record.description_of_persons_entitled_to_vote
         district = desc.split('-')[0].strip()

--- a/polling_stations/apps/data_collection/management/commands/import_calderdale.py
+++ b/polling_stations/apps/data_collection/management/commands/import_calderdale.py
@@ -1,8 +1,6 @@
-from django.contrib.gis.geos import Point
 from django.db import connection
 from pollingstations.models import PollingDistrict
 from data_collection.management.commands import BaseShpStationsShpDistrictsImporter
-from data_finder.helpers import geocode_point_only, PostcodeError
 
 
 class Command(BaseShpStationsShpDistrictsImporter):

--- a/polling_stations/apps/data_collection/management/commands/import_hillingdon.py
+++ b/polling_stations/apps/data_collection/management/commands/import_hillingdon.py
@@ -50,14 +50,9 @@ class Command(BaseCsvStationsCsvAddressesImporter):
             # no points supplied, so attempt to attach them by geocoding
             try:
                 location_data = geocode_point_only(record.pollingplaceaddress7)
+                location = location_data.centroid
             except PostcodeError:
                 pass
-
-            if location_data:
-                location = Point(
-                    location_data['wgs84_lon'],
-                    location_data['wgs84_lat'],
-                    srid=4326)
 
         return {
             'internal_council_id': record.pollingplaceid,

--- a/polling_stations/apps/data_collection/management/commands/import_rct.py
+++ b/polling_stations/apps/data_collection/management/commands/import_rct.py
@@ -3,7 +3,6 @@ Import Rhondda Cynon Taf
 
 note: this script takes quite a long time to run
 """
-from django.contrib.gis.geos import Point
 from data_collection.management.commands import BaseCsvStationsCsvAddressesImporter
 from data_finder.helpers import geocode_point_only, PostcodeError
 from data_collection.google_geocoding_api_wrapper import (
@@ -58,8 +57,8 @@ class Command(BaseCsvStationsCsvAddressesImporter):
         """
         if postcode:
             try:
-                gridref = geocode_point_only(postcode)
-                location = Point(gridref['wgs84_lon'], gridref['wgs84_lat'], srid=4326)
+                location_data = geocode_point_only(postcode)
+                location = location_data.centroid
             except PostcodeError:
                 location = None
         else:

--- a/polling_stations/apps/data_collection/management/commands/import_redbridge.py
+++ b/polling_stations/apps/data_collection/management/commands/import_redbridge.py
@@ -3,7 +3,6 @@ Import Redbridge
 
 note: this script takes quite a long time to run
 """
-from django.contrib.gis.geos import Point
 from data_collection.management.commands import BaseCsvStationsCsvAddressesImporter
 from data_finder.helpers import geocode_point_only, PostcodeError
 
@@ -23,8 +22,8 @@ class Command(BaseCsvStationsCsvAddressesImporter):
         # no points supplied, so attempt to attach them by geocoding
         if record.postcode:
             try:
-                gridref = geocode_point_only(record.postcode)
-                location = Point(gridref['wgs84_lon'], gridref['wgs84_lat'], srid=4326)
+                location_data = geocode_point_only(record.postcode)
+                location = location_data.centroid
             except PostcodeError:
                 location = None
         else:

--- a/polling_stations/apps/data_collection/management/commands/import_richmond.py
+++ b/polling_stations/apps/data_collection/management/commands/import_richmond.py
@@ -1,8 +1,6 @@
 """
 Import Richmond
 """
-from django.contrib.gis.geos import Point
-
 from data_collection.slugger import Slugger
 from data_collection.management.commands import BaseCsvStationsCsvAddressesImporter
 from data_finder.helpers import geocode, geocode_point_only, PostcodeError
@@ -54,14 +52,9 @@ class Command(BaseCsvStationsCsvAddressesImporter):
         if len(postcode) > 5:
             try:
                 location_data = geocode_point_only(postcode)
+                location = location_data.centroid
             except PostcodeError:
                 pass
-            if location_data:
-                location = Point(
-                    location_data['wgs84_lon'],
-                    location_data['wgs84_lat'],
-                    srid=4326)
-
 
         return {
             'internal_council_id': self._mk_place_id(record),

--- a/polling_stations/apps/data_collection/management/commands/import_torfaen.py
+++ b/polling_stations/apps/data_collection/management/commands/import_torfaen.py
@@ -1,4 +1,3 @@
-from django.contrib.gis.geos import Point
 from data_collection.base_importers import BaseCsvStationsCsvAddressesImporter
 from data_finder.helpers import geocode_point_only, PostcodeError
 
@@ -34,10 +33,7 @@ class Command(BaseCsvStationsCsvAddressesImporter):
 
         try:
             location_data = geocode_point_only(postcode)
-            location = Point(
-                location_data['wgs84_lon'],
-                location_data['wgs84_lat'],
-                srid=4326)
+            location = location_data.centroid
         except PostcodeError:
             location = None
         return location

--- a/polling_stations/apps/data_collection/management/commands/import_tower_hamlets.py
+++ b/polling_stations/apps/data_collection/management/commands/import_tower_hamlets.py
@@ -55,14 +55,9 @@ class Command(BaseCsvStationsCsvAddressesImporter):
             # no points supplied, so attempt to attach them by geocoding
             try:
                 location_data = geocode_point_only(postcode)
+                location = location_data.centroid
             except PostcodeError:
                 pass
-
-            if location_data:
-                location = Point(
-                    location_data['wgs84_lon'],
-                    location_data['wgs84_lat'],
-                    srid=4326)
 
         return {
             'internal_council_id': record.code,

--- a/polling_stations/apps/data_collection/management/commands/import_westminster.py
+++ b/polling_stations/apps/data_collection/management/commands/import_westminster.py
@@ -3,8 +3,6 @@ Import Southwark
 """
 from time import sleep
 
-from django.contrib.gis.geos import Point
-
 from data_collection.management.commands import BaseCsvStationsCsvAddressesImporter
 from data_finder.helpers import geocode, geocode_point_only, PostcodeError
 from addressbase.models import Address
@@ -48,14 +46,9 @@ class Command(BaseCsvStationsCsvAddressesImporter):
         location_data = None
         try:
             location_data = geocode_point_only(postcode)
+            location = location_data.centroid
         except PostcodeError:
             pass
-
-        if location_data:
-            location = Point(
-                location_data['wgs84_lon'],
-                location_data['wgs84_lat'],
-                srid=4326)
 
         return {
             'internal_council_id': record.pollingstationnumber,

--- a/polling_stations/apps/data_collection/management/commands/import_wycombe.py
+++ b/polling_stations/apps/data_collection/management/commands/import_wycombe.py
@@ -1,4 +1,3 @@
-from django.contrib.gis.geos import Point
 from data_collection.management.commands import BaseCsvStationsShpDistrictsImporter
 from data_finder.helpers import geocode_point_only, PostcodeError
 
@@ -30,8 +29,8 @@ class Command(BaseCsvStationsShpDistrictsImporter):
         address, postcode = self.format_address(record.polling_place)
 
         try:
-            point = geocode_point_only(postcode)
-            location = Point(point['wgs84_lon'], point['wgs84_lat'], srid=4326)
+            location_data = geocode_point_only(postcode)
+            location = location_data.centroid
         except PostcodeError:
             location = None
 

--- a/polling_stations/apps/data_finder/features/smoke_tests.feature
+++ b/polling_stations/apps/data_finder/features/smoke_tests.feature
@@ -34,3 +34,8 @@ Feature: Smoke tests
     When I visit site page "/nus_wales"
     Then I should see "Cymraeg"
     And No errors were thrown
+
+    Scenario: Check Example page
+    When I visit site page "/example"
+    Then I should see "Your polling station"
+    And No errors were thrown

--- a/polling_stations/apps/data_finder/fixtures/test_routing.json
+++ b/polling_stations/apps/data_finder/fixtures/test_routing.json
@@ -27,6 +27,19 @@
     },
     {
         "fields": {
+            "name": "Bristol Council",
+            "email": "",
+            "phone": "",
+            "website": "",
+            "postcode": "",
+            "address": "",
+            "area": "MULTIPOLYGON(((-2.6181793212890625 51.4739416782317,-2.5275421142578125 51.4739416782317,-2.5275421142578125 51.43115250328755,-2.6181793212890625 51.43115250328755,-2.6181793212890625 51.4739416782317)))"
+        },
+        "model": "councils.council",
+        "pk": "E06000023"
+    },
+    {
+        "fields": {
             "address": "1 Foo Street, Bar Town",
             "postcode": "AA11AA",
             "polling_station_id": "1",

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -101,11 +101,7 @@ class OnspdGeocoderAdapter(BaseGeocoder):
         centre = geocoder.centroid
         if not centre:
             raise PostcodeError("No location information")
-        return {
-            'source': 'onspd',
-            'wgs84_lon': centre.x,
-            'wgs84_lat': centre.y,
-        }
+        return geocoder
 
 
 class AddressBaseGeocoderAdapter(BaseGeocoder):
@@ -145,13 +141,7 @@ class AddressBaseGeocoderAdapter(BaseGeocoder):
         }
 
     def geocode_point_only(self):
-        geocoder = AddressBaseGeocoder(self.postcode)
-        centre = geocoder.centroid
-        return {
-            'source': 'addressbase',
-            'wgs84_lon': centre.x,
-            'wgs84_lat': centre.y,
-        }
+        return AddressBaseGeocoder(self.postcode)
 
 
 def geocode_point_only(postcode):

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -178,10 +178,6 @@ def geocode_point_only(postcode):
             # re-raise the exception.
             # Note: in future we may want to fall back to yet another source
             raise
-        except:
-            # something else went wrong:
-            # lets give the next source a try anyway
-            continue
 
     # All of our attempts to geocode this failed. Raise a generic exception
     raise PostcodeError('Could not geocode from any source')
@@ -213,10 +209,6 @@ def geocode(postcode):
             # re-raise the exception.
             # Note: in future we may want to fall back to yet another source
             raise
-        except:
-            # something else went wrong:
-            # lets give the next source a try anyway
-            continue
 
     # All of our attempts to geocode this failed. Raise a generic exception
     raise PostcodeError('Could not geocode from any source')

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -55,12 +55,6 @@ class BaseGeocoder(metaclass=abc.ABCMeta):
     def geocode(self):
         pass
 
-    def run(self, point_only=False):
-        if point_only:
-            return self.geocode_point_only()
-        else:
-            return self.geocode()
-
 
 class OnspdGeocoderAdapter(BaseGeocoder):
     """
@@ -164,7 +158,7 @@ def geocode_point_only(postcode):
     geocoders = (AddressBaseGeocoderAdapter(postcode), OnspdGeocoderAdapter(postcode))
     for geocoder in geocoders:
         try:
-            return geocoder.run(True)
+            return geocoder.geocode_point_only()
         except ObjectDoesNotExist:
             # we couldn't find this postcode in AddressBase
             # this might be because
@@ -187,7 +181,7 @@ def geocode(postcode):
     geocoders = (AddressBaseGeocoderAdapter(postcode), OnspdGeocoderAdapter(postcode))
     for geocoder in geocoders:
         try:
-            return geocoder.run(False)
+            return geocoder.geocode()
         except ObjectDoesNotExist:
             # we couldn't find this postcode in AddressBase
             # this might be because

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -3,7 +3,6 @@ import logging
 import lxml.etree
 import re
 import requests
-import time
 from collections import namedtuple
 from operator import itemgetter
 
@@ -161,7 +160,7 @@ class AddressBaseGeocoderAdapter(BaseGeocoder):
         }
 
 
-def geocode_point_only(postcode, sleep=True):
+def geocode_point_only(postcode):
     geocoders = (AddressBaseGeocoderAdapter(postcode), OnspdGeocoderAdapter(postcode))
     for geocoder in geocoders:
         try:
@@ -169,11 +168,6 @@ def geocode_point_only(postcode, sleep=True):
         except ObjectDoesNotExist:
             # we couldn't find this postcode in AddressBase
             # fall back to the next source
-
-            # optional sleep to avoid hammering external services
-            if sleep:
-                time.sleep(1.3)
-
             continue
         except PostcodeError:
             # we were unable to geocode this postcode using ONSPD
@@ -183,11 +177,6 @@ def geocode_point_only(postcode, sleep=True):
         except:
             # something else went wrong:
             # lets give the next source a try anyway
-
-            # optional sleep to avoid hammering external services
-            if sleep:
-                time.sleep(1.3)
-
             continue
 
     # All of our attempts to geocode this failed. Raise a generic exception

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -33,12 +33,6 @@ class MultipleCouncilsException(MultipleCodesException):
     pass
 
 
-class RateLimitError(Exception):
-    def __init__(self, message):
-        logger = logging.getLogger('django.request')
-        logger.error(message)
-
-
 class BaseGeocoder(metaclass=abc.ABCMeta):
 
     def __init__(self, postcode):

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -17,7 +17,7 @@ from uk_geo_utils.helpers import Postcode
 from uk_geo_utils.geocoders import (
     AddressBaseGeocoder,
     OnspdGeocoder,
-    CodesNotFoundException,
+    AddressBaseException,
     MultipleCodesException
 )
 
@@ -167,6 +167,10 @@ def geocode_point_only(postcode):
             return geocoder.run(True)
         except ObjectDoesNotExist:
             # we couldn't find this postcode in AddressBase
+            # this might be because
+            # - The postcode isn't in AddressBase
+            # - The postcode is in Northern Ireland
+            # - AddressBase hasn;t been imported
             # fall back to the next source
             continue
         except PostcodeError:
@@ -190,16 +194,20 @@ def geocode(postcode):
             return geocoder.run(False)
         except ObjectDoesNotExist:
             # we couldn't find this postcode in AddressBase
+            # this might be because
+            # - The postcode isn't in AddressBase
+            # - The postcode is in Northern Ireland
+            # - AddressBase hasn;t been imported
             # fall back to the next source
-            continue
-        except CodesNotFoundException:
-            # we did find this postcode in AddressBase, but there were no
-            # corresponding codes in ONSUD: fall back to the next source
             continue
         except MultipleCouncilsException:
             # this postcode contains uprns in multiple local authorities
             # re-raise the exception.
             raise
+        except AddressBaseException:
+            # we did find this postcode in AddressBase, but there were no
+            # corresponding codes in ONSUD: fall back to the next source
+            continue
         except PostcodeError:
             # we were unable to geocode this postcode using ONSPD
             # re-raise the exception.

--- a/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
+++ b/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
@@ -2,7 +2,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from data_finder.helpers import (
     AddressBaseGeocoderAdapter, MultipleCouncilsException)
-from uk_geo_utils.geocoders import CodesNotFoundException
+from uk_geo_utils.geocoders import (
+    AddressBaseGeocoder,
+    CodesNotFoundException
+)
 
 
 class AddressBaseGeocoderAdapterTest(TestCase):
@@ -36,7 +39,7 @@ class AddressBaseGeocoderAdapterTest(TestCase):
 
         # point only geocode should return a result anyway
         result = addressbase.geocode_point_only()
-        self.assertEqual('addressbase', result['source'])
+        self.assertIsInstance(result, AddressBaseGeocoder)
 
     def test_multiple_councils(self):
         """
@@ -52,7 +55,7 @@ class AddressBaseGeocoderAdapterTest(TestCase):
 
         # point only geocode should return a result anyway
         result = addressbase.geocode_point_only()
-        self.assertEqual('addressbase', result['source'])
+        self.assertIsInstance(result, AddressBaseGeocoder)
 
     def test_valid(self):
         """

--- a/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
+++ b/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
@@ -69,5 +69,5 @@ class AddressBaseGeocoderAdapterTest(TestCase):
         """
         addressbase = AddressBaseGeocoderAdapter('bb 1   1B B')  # intentionally spurious whitespace and case
         result = addressbase.geocode()
-        self.assertEqual('addressbase', result['source'])
-        self.assertEqual('B01000001', result['council_gss'])
+        self.assertIsInstance(result, AddressBaseGeocoder)
+        self.assertEqual('B01000001', result.get_code('lad'))

--- a/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
+++ b/polling_stations/apps/data_finder/tests/test_addressbase_geocoder_adapter.py
@@ -1,8 +1,8 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from data_finder.helpers import (
-    AddressBaseGeocoderAdapter, CodesNotFoundException, MultipleCouncilsException
-)
+    AddressBaseGeocoderAdapter, MultipleCouncilsException)
+from uk_geo_utils.geocoders import CodesNotFoundException
 
 
 class AddressBaseGeocoderAdapterTest(TestCase):

--- a/polling_stations/apps/data_finder/tests/test_geocoders.py
+++ b/polling_stations/apps/data_finder/tests/test_geocoders.py
@@ -78,7 +78,7 @@ class GeocodePointOnlyTest(TestCase):
 
         We should fall back to centroid-based geocoding using ONSPD
         """
-        result = geocode_point_only('DD1 1DD', sleep=False)
+        result = geocode_point_only('DD1 1DD')
         self.assertEqual('onspd', result['source'])
 
     @mock.patch("data_finder.helpers.OnspdGeocoderAdapter.geocode_point_only", mock_geocode)
@@ -89,5 +89,5 @@ class GeocodePointOnlyTest(TestCase):
 
         Valid result should be returned based on geocoding using AddressBase
         """
-        result = geocode_point_only('BB1 1BB', sleep=False)
+        result = geocode_point_only('BB1 1BB')
         self.assertEqual('addressbase', result['source'])

--- a/polling_stations/apps/data_finder/tests/test_geocoders.py
+++ b/polling_stations/apps/data_finder/tests/test_geocoders.py
@@ -6,14 +6,19 @@ from data_finder.helpers import (
 from uk_geo_utils.geocoders import AddressBaseGeocoder, OnspdGeocoder
 
 
+class StubOnspdGeocoder(OnspdGeocoder):
+
+    def __init__(self, postcode):
+        pass
+
+
 """
 Mock out a stub response from OnspdGeocoder
 we don't really care about the actual data for these tests
 just where it came from
 """
 def mock_geocode(self):
-    # TODO: return a OnspdGeocoder instance
-    return { 'source': 'onspd' }
+    return StubOnspdGeocoder('foo')
 
 
 class GeocodeTest(TestCase):
@@ -28,7 +33,7 @@ class GeocodeTest(TestCase):
         We should fall back to centroid-based geocoding using ONSPD
         """
         result = geocode('DD1 1DD')
-        self.assertEqual('onspd', result['source'])
+        self.assertIsInstance(result, OnspdGeocoder)
 
     @mock.patch("data_finder.helpers.OnspdGeocoderAdapter.geocode", mock_geocode)
     def test_no_codes(self):
@@ -39,7 +44,7 @@ class GeocodeTest(TestCase):
         We should fall back to centroid-based geocoding using ONSPD
         """
         result = geocode('AA11AA')
-        self.assertEqual('onspd', result['source'])
+        self.assertIsInstance(result, OnspdGeocoder)
 
     @mock.patch("data_finder.helpers.OnspdGeocoderAdapter.geocode", mock_geocode)
     def test_multiple_councils(self):
@@ -66,7 +71,7 @@ class GeocodeTest(TestCase):
         Valid result should be returned based on geocoding using AddressBase
         """
         result = geocode('BB1 1BB')
-        self.assertEqual('addressbase', result['source'])
+        self.assertIsInstance(result, AddressBaseGeocoder)
 
 
 class GeocodePointOnlyTest(TestCase):
@@ -81,8 +86,7 @@ class GeocodePointOnlyTest(TestCase):
         We should fall back to centroid-based geocoding using ONSPD
         """
         result = geocode_point_only('DD1 1DD')
-        # TODO: self.assertIsInstance(result, OnspdGeocoder)
-        self.assertEqual('onspd', result['source'])
+        self.assertIsInstance(result, OnspdGeocoder)
 
     @mock.patch("data_finder.helpers.OnspdGeocoderAdapter.geocode_point_only", mock_geocode)
     def test_valid(self):

--- a/polling_stations/apps/data_finder/tests/test_geocoders.py
+++ b/polling_stations/apps/data_finder/tests/test_geocoders.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from data_finder.helpers import (
     geocode, geocode_point_only, OnspdGeocoderAdapter, MultipleCouncilsException
 )
+from uk_geo_utils.geocoders import AddressBaseGeocoder, OnspdGeocoder
 
 
 """
@@ -11,6 +12,7 @@ we don't really care about the actual data for these tests
 just where it came from
 """
 def mock_geocode(self):
+    # TODO: return a OnspdGeocoder instance
     return { 'source': 'onspd' }
 
 
@@ -79,6 +81,7 @@ class GeocodePointOnlyTest(TestCase):
         We should fall back to centroid-based geocoding using ONSPD
         """
         result = geocode_point_only('DD1 1DD')
+        # TODO: self.assertIsInstance(result, OnspdGeocoder)
         self.assertEqual('onspd', result['source'])
 
     @mock.patch("data_finder.helpers.OnspdGeocoderAdapter.geocode_point_only", mock_geocode)
@@ -90,4 +93,4 @@ class GeocodePointOnlyTest(TestCase):
         Valid result should be returned based on geocoding using AddressBase
         """
         result = geocode_point_only('BB1 1BB')
-        self.assertEqual('addressbase', result['source'])
+        self.assertIsInstance(result, AddressBaseGeocoder)

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -143,7 +143,7 @@ class BasePollingStationView(
             # AddressView.get_location() may legitimately return None
             self.location = None
         else:
-            self.location = Point(loc['wgs84_lon'], loc['wgs84_lat'])
+            self.location = loc.centroid
 
         self.council = self.get_council(loc)
         self.station = self.get_station()
@@ -172,7 +172,7 @@ class BasePollingStationView(
                 context['custom'] = None
             else:
                 context['custom'] = CustomFinder.objects.get_custom_finder(
-                    loc['gss_codes'], self.postcode.without_space)
+                    loc, self.postcode.without_space)
 
         self.log_postcode(self.postcode, context, type(self).__name__)
 
@@ -270,11 +270,10 @@ class ExamplePostcodeView(BasePollingStationView):
         return self.render_to_response(context)
 
     def get_location(self):
-        return {
-            "wgs84_lat": 51.43921783606831,
-            "wgs84_lon": -2.54333651887832,
-            'gss_codes': [],
-        }
+        return type(
+            "Geocoder", (object, ),
+            { "centroid": Point(-2.54333651887832, 51.43921783606831, srid=4326) }
+        )
 
     def get_council(self, geocode_result):
         return Council.objects.defer("area").get(pk='E06000023')

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -31,7 +31,6 @@ from .helpers import (
     EveryElectionWrapper,
     MultipleCouncilsException,
     PostcodeError,
-    RateLimitError,
     RoutingHelper
 )
 
@@ -135,7 +134,7 @@ class BasePollingStationView(
 
         try:
             loc = self.get_location()
-        except (PostcodeError, RateLimitError) as e:
+        except PostcodeError as e:
             context['error'] = str(e)
             return context
 

--- a/polling_stations/apps/pollingstations/models.py
+++ b/polling_stations/apps/pollingstations/models.py
@@ -135,9 +135,10 @@ class ResidentialAddress(models.Model):
 
 class CustomFinderManager(models.Manager):
 
-    def get_custom_finder(self, gss_codes, postcode):
+    def get_custom_finder(self, geocoder, postcode):
         try:
-            finder = self.get(pk__in=gss_codes)
+            finder = self.get(pk__in=[
+                geocoder.get_code('lad'), geocoder.get_code('eer')])
             finder.message = _(finder.message)
             """
             EONI's poling station finder requires postcode to have a space :(

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -120,7 +120,7 @@ class OnspdGeocoder(BaseGeocoder):
     def __init__(self, postcode):
         self.postcode = Postcode(postcode)
         self.onspd_model = get_onspd_model()
-        self.record = self.onspd_model.get(pcds=self.postcode.with_space)
+        self.record = self.onspd_model.objects.get(pcds=self.postcode.with_space)
 
     @property
     def centroid(self):

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -10,6 +10,9 @@ class CodesNotFoundException(Exception):
 class MultipleCodesException(Exception):
     pass
 
+class StrictMatchException(Exception):
+    pass
+
 class NorthernIrelandException(ObjectDoesNotExist):
     pass
 
@@ -66,7 +69,7 @@ class AddressBaseGeocoder(BaseGeocoder):
     def get_point(self, uprn):
         return self.addresses.get_cached(uprn).location
 
-    def get_code(self, code_type, uprn=None):
+    def get_code(self, code_type, uprn=None, strict=False):
         # check the code_type field exists on our model
         self.onsud_model._meta.get_field(code_type)
 
@@ -79,30 +82,16 @@ class AddressBaseGeocoder(BaseGeocoder):
             # because...reasons
             raise CodesNotFoundException('Found no records in ONSUD for supplied UPRNs')
         if len(self.addresses) != len(self.uprns):
-            """
-            TODO: once you can easily map addresses in WhereDIV to a UPRN,
-            change this to:
-
-            for uprn in self._get_uprns():
-                try:
-                    self.uprns.get_cached(uprn)
-                except self.onsud_model.DoesNotExist:
-                    raise SomeException('oh noes!!')
-
-            Then you can handle it by calling something like
-            try:
-                code = g.get_code('lad')
-            except SomeException:
-                point = g.get_point(myuprn)
-                code = Council.objects.get(area__covers=point)
-
-            (this will make the BB1 1BB test case fail
-            so you'll need to update that too)
-
-            For the moment I'm going to leave it as-is
-            to maintain backwards-compatibility
-            """
-            pass
+            if strict:
+                for uprn in self._get_uprns():
+                    try:
+                        self.uprns.get_cached(uprn)
+                    except self.onsud_model.DoesNotExist:
+                        raise StrictMatchException(
+                            'expected UPRN %s not found in ONSUD' % uprn)
+            else:
+                # if not strict, ignore this condition
+                pass
 
         codes = set([getattr(u, code_type) for u in self.uprns])
         if len(codes) == 1:

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -119,5 +119,4 @@ class OnspdGeocoder(BaseGeocoder):
         return self.record.location
 
     def get_code(self, code_type):
-
         return getattr(self.record, code_type)

--- a/polling_stations/apps/uk_geo_utils/geocoders.py
+++ b/polling_stations/apps/uk_geo_utils/geocoders.py
@@ -4,13 +4,16 @@ from uk_geo_utils.helpers import (
     get_address_model, get_onspd_model, get_onsud_model, Postcode)
 
 
-class CodesNotFoundException(Exception):
+class AddressBaseException(Exception):
     pass
 
-class MultipleCodesException(Exception):
+class CodesNotFoundException(AddressBaseException):
     pass
 
-class StrictMatchException(Exception):
+class MultipleCodesException(AddressBaseException):
+    pass
+
+class StrictMatchException(AddressBaseException):
     pass
 
 class NorthernIrelandException(ObjectDoesNotExist):

--- a/polling_stations/apps/uk_geo_utils/tests/test_addressbase_geocoder.py
+++ b/polling_stations/apps/uk_geo_utils/tests/test_addressbase_geocoder.py
@@ -9,6 +9,7 @@ from uk_geo_utils.geocoders import (
     CodesNotFoundException,
     MultipleCodesException,
     NorthernIrelandException,
+    StrictMatchException,
 )
 
 
@@ -95,6 +96,20 @@ class AddressBaseGeocoderTest(TestCase):
             addressbase = AddressBaseGeocoder('bb 1   1B B')  # intentionally spurious whitespace and case
             self.assertEqual('B01000001', addressbase.get_code('lad'))
             self.assertIsInstance(addressbase.centroid, Point)
+
+    def test_strict_mode(self):
+        """
+        We find records for the given postcode in the AddressBase table
+        There are some corresponding records in the ONSUD for the UPRNs we found
+
+        Note that in this case, the ONSUD table does not contain corresponding
+        records for *all* of the UPRNs we found, and we are passing strict=True
+        so we raise a StrictMatchException
+        """
+        with self.assertNumQueries(FuzzyInt(0, 3)):
+            addressbase = AddressBaseGeocoder('BB11BB')
+            with self.assertRaises(StrictMatchException):
+                addressbase.get_code('lad', strict=True)
 
     def test_multiple_codes(self):
         """

--- a/test_data/vcr_cassettes/integration_tests/feature-smoke-tests/scenario-check-example-page/given-i-visit-httplocalhost8081example.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-smoke-tests/scenario-check-example-page/given-i-visit-httplocalhost8081example.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://maps.googleapis.com/maps/api/directions/json?units=imperial&key=&mode=walking&origin=51.43921783606831,-2.54333651887832&destination=51.440043287399604,-2.5417780465622686
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/81YW1LjOBT9ZxUqf0PGrxDoqq5yCD28Q0PD9Ex3KJewlERgWy5JjjswqZo99Cpm
+        G7OUWcnIdgh2bGOHBqb947Lu8b3nSvfodb8GAFBGmDoUYWRHcBpQ4guugHfga2yTz/38nUEymwso
+        wgSmnB4p6xlI4EIH2wQltt744HDvwrn5ODr66FyOzo/H0Smit13zw23uJzENcBoUKFwwjIUNEWKY
+        y8arOW62/kKE9Isz0o5OE0KuiK796V3n8JKvTih+XyV/KYyGAld22zUNfZRYM62xwadMjDHkomiL
+        zS5MDG2tZZqqsdU214sQfxRDNvRW29RMVd3KIWb5HxQuaY4j3CCesdXpbG4/Hc8wNzU9H+/xKxta
+        cWgwZWQ0TitLOYEBQFBA8M/fuqp1wB6lIxfnBsDFo1x3pk+RMiJy5H0HlyYUAwT+liSlqC0deEQp
+        pBSDJtANExeGaSzbZ8VOQCGDglC/PmhbhvR5XVBtu0FQ7KPHGpSutY4Juq5LOPXBOVoHO0x2BXXB
+        zicTmP0v6+DyqBg38eJS52n6ubqTT7EOwHLptQ3dbJCEHCwm8mloYB8yFBHnFvTc5TSOK9JI/ayS
+        iLGtaR2jNpFiTVclgoOSAk2fMi6gQbHOYYvq0VUDDEVp9cyhixraLJCuov7ApaaGl7locSU3omJu
+        rkilSU3OofUzVAabGVa9s6kXlF1Dayw815bqFSx0Ymppve5jiMAgVFXDuU5eOJlU40k8bf1l3gyk
+        LnO4TJkvIQWNpC2P/uSMqZTBOcpjq0ZACag7dYlfV1uP67tCw9m3fRbRvtX7Qq3fZtbxH8qKXdRM
+        hnNwIzE+YOskWUNMMDjBru3JvUGS6+fu8dFBf68sv1IfL6VgtaVVLTpz6EI22lZhAn2CIHiGhI3q
+        xahIpvMmIq7Y1mSwWREbqr7q3FIu4ouQLYnTxcOifgX9MU160MfhBLMkppAxN+IwLyjhWy4lPOS0
+        jy3HGllne72D7knvpEu7B+HO6Zup+bVn4p9Fzbraabwer5rj663HK28NnitlfbtxFRSPKvW0mko5
+        OWjUavlx6/xsMSeBXlDN3kyq+Sag/V3S3b23dj3rrRT86tPwz6JgTdObKth47eW4uYKLR6saKs9V
+        cNVZ7wFbd+KrofUDCk6/EJkALqYufj9QhlLTG5zc4Xdqaxt7AyUF7mIuiJ9kDiLiuuA62YnLHTrI
+        upWe/ne93/8p9T65of076/e3U/orz9KrKH257ap4zpbuhkPi2DzAGNnYF2yanLpLoBMCFzeYKabq
+        bir7s0LlGE8IjuzqASw9NQ0G3EJW1J1vvc4+wF9t6xD35LSdH8/cTRgPPQ+mOSiL7WTu5kseBX3i
+        l91+KZ+heytNABGGUwEByDAgvixyAVsx5pJj4MAwKf9///oOLsaEg+R2EnhwGovBI5zHTjhBOJIO
+        OaAMBBhJ3TACfRBAMeYtpaK3HjrYpgyl2vhadh+av45dm639B7OWgHBqFgAA
+    headers:
+      Alt-Svc: ['hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303338;
+          quic=51303337; quic=51303335,quic=":443"; ma=2592000; v="41,39,38,37,35"']
+      Cache-Control: ['public, max-age=86400']
+      Content-Encoding: [gzip]
+      Content-Length: ['1128']
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Tue, 28 Nov 2017 17:14:02 GMT']
+      Expires: ['Wed, 29 Nov 2017 17:14:02 GMT']
+      Server: [mafe]
+      Vary: [Accept-Language]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://elections.democracyclub.org.uk/api/elections.json?postcode=EXAM%20PLE&future=1
+  response:
+    body: {string: '{"detail":"Invalid postcode"}'}
+    headers:
+      Allow: ['GET, OPTIONS']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Tue, 28 Nov 2017 17:15:12 GMT']
+      Server: [nginx]
+      Vary: ['Accept, Cookie']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 400, message: Bad Request}
+version: 1


### PR DESCRIPTION
Closes #1087
Closes #1088

This PR is mainly about accounting for the consequences of changes I've made to the geocoders through the rest of the codebase and formalising the decision that we're going to continue with our 'additive' approach to importing data.

To resolve #1087 I have added a `strict` mode in 75edfa0 so that if we're using this library in another application we can use `strict=True` to require that every UPRN in our AddressBase table is matched in the ONSUD before returning a result if we have the option follow up by querying by UPRN. Alternatively we can use `strict=False` in a situation like this where our address data isn't necessarily keyed by UPRN (and if it is those UPRNs aren't necessarily in AddressBase, and so on..)

Most of the rest of it is cleanup to address the points in #1088.

There are also a couple of bits of related cleanup/additional test cases that are not strictly covered by those issues but were sensible to address while I was working on this area of the codebase (e.g: 4a72bff, fd4a362, 1064a61).