### PR TITLE
add unique constraint to feedback token

### DIFF
--- a/polling_stations/apps/feedback/migrations/0002_auto_20171129_1424.py
+++ b/polling_stations/apps/feedback/migrations/0002_auto_20171129_1424.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feedback', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='feedback',
+            name='token',
+            field=models.CharField(max_length=100, blank=True, unique=True),
+        ),
+    ]

--- a/polling_stations/apps/feedback/models.py
+++ b/polling_stations/apps/feedback/models.py
@@ -15,4 +15,4 @@ class Feedback(TimeStampedModel):
     )
     comments = models.TextField(blank=True)
     source_url = models.CharField(blank=True, max_length=800)
-    token = models.CharField(blank=True, max_length=100)
+    token = models.CharField(blank=True, max_length=100, unique=True)


### PR DESCRIPTION
Requires applying a migration to logger to deploy.

I've done a local compile of the static assets and I can't find any evidence of https://github.com/DemocracyClub/WhoCanIVoteFor/issues/238 happening here so no js fixes to apply but

1. I'll check it on a staging deploy as well next time I do a build
2. Before I attempt to apply this migration to logger I will check for and fix any duplicate tokens
