### PR TITLE
fetch GB and NI boundaries in one request

### DIFF
--- a/polling_stations/apps/councils/management/commands/import_councils.py
+++ b/polling_stations/apps/councils/management/commands/import_councils.py
@@ -107,12 +107,9 @@ class Command(BaseCommand):
             Council.objects.all().delete()
 
         councils = []
-        self.stdout.write("Downloading GB boundaries from ONS...")
+        self.stdout.write("Downloading boundaries from ONS...")
         councils = councils + self.get_councils(
-            settings.GB_BOUNDARIES_URL, id_field='lad16cd', name_field='lad16nm')
-        self.stdout.write("Downloading NI boundaries from ONS...")
-        councils = councils + self.get_councils(
-            settings.NI_BOUNDARIES_URL, id_field='LGDCode', name_field='LGDNAME')
+            settings.BOUNDARIES_URL, id_field='lad16cd', name_field='lad16nm')
 
         for council in councils:
             self.stdout.write("Getting contact info for %s from YourVoteMatters" %\

--- a/polling_stations/apps/councils/tests/test_council_importer.py
+++ b/polling_stations/apps/councils/tests/test_council_importer.py
@@ -21,32 +21,29 @@ class MockCouncilsImporter(Command):
             { 'code': "E09000005", 'name': "London Borough of Brent" },
             { 'code': "E09000006", 'name': "London Borough of Bromley" }
         ]
-        if url == settings.GB_BOUNDARIES_URL:
-            out = []
-            for auth in auths:
-                out.append({
-                    "type": "Feature",
-                    "properties": {
-                        "objectid": 1,
-                        "lad16cd": auth['code'],
-                        "lad16nm": auth['name'],
-                        "lad14nmw": " ",
-                        "st_areashape": 123,
-                        "st_lengthshape": 4564
-                    },
-                    "geometry": {
-                        "type": "Polygon",
-                        "coordinates": [[
-                            [-0.354931354522705, 51.462162607847056],
-                            [-0.3518199920654297, 51.462162607847056],
-                            [-0.354931354522705, 51.46355294206526],
-                            [-0.354931354522705, 51.462162607847056]
-                        ]]
-                    }
-                })
-            return {'features': out}
-        if url == settings.NI_BOUNDARIES_URL:
-            return {'features': []}
+        out = []
+        for auth in auths:
+            out.append({
+                "type": "Feature",
+                "properties": {
+                    "objectid": 1,
+                    "lad16cd": auth['code'],
+                    "lad16nm": auth['name'],
+                    "lad14nmw": " ",
+                    "st_areashape": 123,
+                    "st_lengthshape": 4564
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                        [-0.354931354522705, 51.462162607847056],
+                        [-0.3518199920654297, 51.462162607847056],
+                        [-0.354931354522705, 51.46355294206526],
+                        [-0.354931354522705, 51.462162607847056]
+                    ]]
+                }
+            })
+        return {'features': out}
 
 
 class TestCouncilImporter(TestCase):

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -1,5 +1,4 @@
 # settings for councils scraper
 
 YVM_LA_URL = "https://www.yourvotematters.co.uk/_design/nested-content/results-page2/search-voting-locations-by-districtcode?queries_distcode_query="  # noqa
-GB_BOUNDARIES_URL = "https://opendata.arcgis.com/datasets/686603e943f948acaa13fb5d2b0f1275_1.geojson"
-NI_BOUNDARIES_URL = "https://opendata.arcgis.com/datasets/bba0392d214b4ac0a8e0d559cdf6013f_2.geojson"
+BOUNDARIES_URL = "https://opendata.arcgis.com/datasets/e3634984fe1143da9fb31671627f5443_1.geojson"


### PR DESCRIPTION
Closes #1081

I hit some issues with the ONS geo portal being a bit flaky today. Not happened before, but if I hit it again I might add a command line param we can use to easily override this URL with a local file or alternative URL (e.g: if we grab a copy and stick it on S3).