### PR TITLE
make postcode_location key a valid GeoJSON feature

### DIFF
--- a/polling_stations/apps/api/fields.py
+++ b/polling_stations/apps/api/fields.py
@@ -14,14 +14,13 @@ class PointField(serializers.Field):
 
         value = {
             "type": "Feature",
+            "properties": None,
             "geometry": {
-                "point": {
-                    "type": "Point",
-                    "coordinates": [
-                        value.x,
-                        value.y
-                    ],
-                },
+                "type": "Point",
+                "coordinates": [
+                    value.x,
+                    value.y
+                ],
             },
         }
         return value

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/BN436HW.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/BN436HW.apibp
@@ -1,14 +1,13 @@
             {
                 "polling_station_known": false,
                 "postcode_location": {
+                    "properties": null,
                     "geometry": {
-                        "point": {
-                            "type": "Point",
-                            "coordinates": [
-                                -0.26353977212676555,
-                                50.84477241345472
-                            ]
-                        }
+                        "type": "Point",
+                        "coordinates": [
+                            -0.26353977212676555,
+                            50.84477241345472
+                        ]
                     },
                     "type": "Feature"
                 },

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/NG178AA.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/NG178AA.apibp
@@ -1,14 +1,13 @@
             {
                 "polling_station_known": true,
                 "postcode_location": {
+                    "properties": null,
                     "geometry": {
-                        "point": {
-                            "type": "Point",
-                            "coordinates": [
-                                -1.2491514412601963,
-                                53.09878716696975
-                            ]
-                        }
+                        "type": "Point",
+                        "coordinates": [
+                            -1.2491514412601963,
+                            53.09878716696975
+                        ]
                     },
                     "type": "Feature"
                 },

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/SW1A1AA.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/SW1A1AA.apibp
@@ -1,14 +1,13 @@
             {
                 "polling_station_known": false,
                 "postcode_location": {
+                    "properties": null,
                     "geometry": {
-                        "point": {
-                            "type": "Point",
-                            "coordinates": [
-                                -0.14320717529002294,
-                                51.50086373251905
-                            ]
-                        }
+                        "type": "Point",
+                        "coordinates": [
+                            -0.14320717529002294,
+                            51.50086373251905
+                        ]
                     },
                     "type": "Feature"
                 },

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw.apibp
@@ -1,14 +1,13 @@
             {
                 "polling_station_known": true,
                 "postcode_location": {
+                    "properties": null,
                     "geometry": {
-                        "point": {
-                            "type": "Point",
-                            "coordinates": [
-                                -0.26353977212676555,
-                                50.84477241345472
-                            ]
-                        }
+                        "type": "Point",
+                        "coordinates": [
+                            -0.26353977212676555,
+                            50.84477241345472
+                        ]
                     },
                     "type": "Feature"
                 },

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/schema.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/schema.apibp
@@ -24,6 +24,12 @@
                     },
                     "type": {
                       "type": "string"
+                    },
+                    "properties": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
                     }
                   },
                   "description": "A GeoJSON Feature containing a Point object describing the centroid of the input postcode."


### PR DESCRIPTION
Closes #1047

Note this is a backwards-compatibility breaking change so we need to consider impact on consumers:

* It doesn't affect WhoCIVF because we don't use the origin point (only the station point, which *is* a valid GeoJSON feature)
* It doesn't affect the EC - they only use the station address
* We need to update the widget. I'll submit a PR to update https://github.com/DemocracyClub/WhereDoIVote-Widget/blob/9b291eeac792954c8e68add4d60581c454007edd/src/WdivAPI.js#L27-L30 when this is deployed.
* It may affect some of: Labour Party, Best for Britain, Democratic Dashboard. We should probably drop our contacts at those orgs an email in the run-up to May