### PR TITLE
don't include aloe/selenium code in coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,4 @@ omit =
     */lib/python3.5/site-packages/*
     polling_stations/apps/data_collection/management/commands/import_*
     polling_stations/apps/data_collection/management/commands/misc_fixes.py
+    polling_stations/apps/data_finder/features/index.py


### PR DESCRIPTION
This is making the stats go wobbly