### PR TITLE
ignore group ids when working out if there is an election

### DIFF
--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -188,10 +188,12 @@ class EveryElectionWrapper:
             # assume there *is* an upcoming election
             return True
 
-        if len(self.elections) > 0:
+        ballots = filter(lambda e: e['group_type'] is None, self.elections)
+        try:
+            next(ballots)
             return True
-
-        return False
+        except StopIteration:
+            return False
 
     def get_explanations(self):
         explanations = []

--- a/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
+++ b/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
@@ -10,11 +10,34 @@ def get_data_exception(self, postcode):
 def get_data_no_elections(self, postcode):
     return []
 
+def get_data_only_group(self, postcode):
+    return [
+        { 'election_title': 'some election', 'group_type': 'election' },
+        { 'election_title': 'some election', 'group_type': 'organisation' }
+    ]
+
+def get_data_group_and_ballot(self, postcode):
+    return [
+        { 'election_title': 'some election', 'group_type': 'organisation' },
+        { 'election_title': 'some election', 'group_type': None }
+    ]
+
 def get_data_with_elections(self, postcode):
     return [
-        {'election_title': 'some election'},  # no explanation key
-        {'election_title': 'some election', 'explanation': None},  # null explanation key
-        {'election_title': 'some election', 'explanation': 'some text'},  # explanation key contains text
+        {
+            'election_title': 'some election',
+            'group_type': 'organisation'
+        },  # no explanation key
+        {
+            'election_title': 'some election',
+            'group_type': None,
+            'explanation': None  # null explanation key
+        },
+        {
+            'election_title': 'some election',
+            'group_type': None,
+            'explanation': 'some text'  # explanation key contains text
+        },
     ]
 
 class EveryElectionWrapperTest(TestCase):
@@ -41,3 +64,17 @@ class EveryElectionWrapperTest(TestCase):
         self.assertEqual([
             {'title': 'some election', 'explanation': 'some text'}
         ], ee.get_explanations())
+
+    @mock.patch("data_finder.helpers.EveryElectionWrapper.get_data", get_data_only_group)
+    def test_elections_only_group(self):
+        ee = EveryElectionWrapper('AA11AA')
+        self.assertTrue(ee.request_success)
+        self.assertFalse(ee.has_election())
+        self.assertEqual([], ee.get_explanations())
+
+    @mock.patch("data_finder.helpers.EveryElectionWrapper.get_data", get_data_group_and_ballot)
+    def test_elections_group_and_ballot(self):
+        ee = EveryElectionWrapper('AA11AA')
+        self.assertTrue(ee.request_success)
+        self.assertTrue(ee.has_election())
+        self.assertEqual([], ee.get_explanations())

--- a/polling_stations/settings/testing.py
+++ b/polling_stations/settings/testing.py
@@ -1,5 +1,6 @@
 from .base import *
 
+EVERY_ELECTION['CHECK'] = True
 DISABLE_GA = True  # don't log to Google Analytics when we are running tests
 INSTALLED_APPS = list(INSTALLED_APPS)
 INSTALLED_APPS.append('aloe_django',)

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-my-address-not-in-list/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-my-address-not-in-list/then-i-submit-the-only-form.yaml
@@ -9,7 +9,7 @@ interactions:
     method: GET
     uri: https://elections.democracyclub.org.uk/api/elections.json?postcode=BB1%201BB&future=1
   response:
-    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla"}]}'}
+    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla", "group_type":null}]}'}
     headers:
       Allow: ['GET, OPTIONS']
       Connection: [keep-alive]

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-northern-ireland/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-northern-ireland/then-i-submit-the-only-form.yaml
@@ -9,7 +9,7 @@ interactions:
     method: GET
     uri: https://elections.democracyclub.org.uk/api/elections.json?postcode=BT15%203JX&future=1
   response:
-    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla"}]}'}
+    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla", "group_type":null}]}'}
     headers:
       Allow: ['GET, OPTIONS']
       Connection: [keep-alive]

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-with-address-picker-invalid-station-id/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-with-address-picker-invalid-station-id/then-i-submit-the-only-form.yaml
@@ -9,7 +9,7 @@ interactions:
     method: GET
     uri: https://elections.democracyclub.org.uk/api/elections.json?postcode=BB11BB&future=1
   response:
-    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla"}]}'}
+    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla", "group_type":null}]}'}
     headers:
       Allow: ['GET, OPTIONS']
       Connection: [keep-alive]

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-with-address-picker-valid-station-id/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-with-address-picker-valid-station-id/then-i-submit-the-only-form.yaml
@@ -591,7 +591,7 @@ interactions:
     method: GET
     uri: https://elections.democracyclub.org.uk/api/elections.json?postcode=BB11BB&future=1
   response:
-    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla"}]}'}
+    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla", "group_type":null}]}'}
     headers:
       Allow: ['GET, OPTIONS']
       Connection: [keep-alive]

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-without-address-picker/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-without-address-picker/then-i-submit-the-only-form.yaml
@@ -61,7 +61,7 @@ interactions:
     method: GET
     uri: https://elections.democracyclub.org.uk/api/elections.json?postcode=NP205GN&future=1
   response:
-    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla"}]}'}
+    body: {string: '{"count":1,"next":null,"previous":null,"results":[{"election_id":"blablabla.bla", "group_type":null}]}'}
     headers:
       Allow: ['GET, OPTIONS']
       Connection: [keep-alive]


### PR DESCRIPTION
If we've got a (by-)election happening in one ward, querying EE with any postcode in that local auth will return the 'organisation group' election object but there is only an election happening in the specific ward that has a 'ballot' type object.