### PR TITLE
truncate really long data in utm tracker params

### DIFF
--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -59,7 +59,7 @@ class LogLookUpMixin(object):
         }
         if 'api_user' in context:
             kwargs['api_user'] = context['api_user']
-        kwargs.update(self.request.session['utm_data'])
+        kwargs.update({k:v[0:100] for k, v in self.request.session['utm_data'].items()})
         LoggedPostcode.objects.create(**kwargs)
 
 


### PR DESCRIPTION
In principle, if we call a url on WhereDIV with a very long string in the UTM tracker vars like

`?utm_source=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`

we will throw `value too long for type character varying(100)` trying to log it.
