### PR TITLE
Show info about expected dwellings in local auth before import 

### DIFF
--- a/polling_stations/apps/addressbase/migrations/0008_auto_20180102_1606.py
+++ b/polling_stations/apps/addressbase/migrations/0008_auto_20180102_1606.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('addressbase', '0007_delete_onsud'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Onsud',
+            fields=[
+                ('uprn', models.CharField(max_length=12, primary_key=True, serialize=False)),
+                ('ctry_flag', models.CharField(max_length=1, blank=True)),
+                ('cty', models.CharField(max_length=9, blank=True)),
+                ('lad', models.CharField(max_length=9, blank=True)),
+                ('ward', models.CharField(max_length=9, blank=True)),
+                ('hlthau', models.CharField(max_length=9, blank=True)),
+                ('ctry', models.CharField(max_length=9, blank=True)),
+                ('rgn', models.CharField(max_length=9, blank=True)),
+                ('pcon', models.CharField(max_length=9, blank=True)),
+                ('eer', models.CharField(max_length=9, blank=True)),
+                ('ttwa', models.CharField(max_length=9, blank=True)),
+                ('nuts', models.CharField(max_length=9, blank=True)),
+                ('park', models.CharField(max_length=9, blank=True)),
+                ('oa11', models.CharField(max_length=9, blank=True)),
+                ('lsoa11', models.CharField(max_length=9, blank=True)),
+                ('msoa11', models.CharField(max_length=9, blank=True)),
+                ('parish', models.CharField(max_length=9, blank=True)),
+                ('wz11', models.CharField(max_length=9, blank=True)),
+                ('ccg', models.CharField(max_length=9, blank=True)),
+                ('bua11', models.CharField(max_length=9, blank=True)),
+                ('buasd11', models.CharField(max_length=9, blank=True)),
+                ('ruc11', models.CharField(max_length=2, blank=True)),
+                ('oac11', models.CharField(max_length=3, blank=True)),
+                ('lep1', models.CharField(max_length=9, blank=True)),
+                ('lep2', models.CharField(max_length=9, blank=True)),
+                ('pfa', models.CharField(max_length=9, blank=True)),
+                ('imd', models.CharField(max_length=5, blank=True)),
+            ],
+        ),
+        migrations.AlterIndexTogether(
+            name='onsud',
+            index_together=set([('lad',)]),
+        ),
+    ]

--- a/polling_stations/apps/addressbase/models.py
+++ b/polling_stations/apps/addressbase/models.py
@@ -1,5 +1,6 @@
 from django.contrib.gis.db import models
-from uk_geo_utils.models import AbstractAddress, AbstractAddressManager
+from uk_geo_utils.models import (
+    AbstractAddress, AbstractAddressManager, AbstractOnsud)
 
 
 class AddressManager(AbstractAddressManager):
@@ -16,6 +17,11 @@ class AddressManager(AbstractAddressManager):
 
 class Address(AbstractAddress):
     objects = AddressManager()
+
+
+class Onsud(AbstractOnsud):
+    class Meta:
+        index_together = (('lad',))
 
 
 class Blacklist(models.Model):

--- a/polling_stations/apps/data_collection/contexthelpers.py
+++ b/polling_stations/apps/data_collection/contexthelpers.py
@@ -1,0 +1,23 @@
+import requests
+from addressbase.models import Onsud, Address
+
+
+def get_stat_from_nomis(dataset, measure, gss_code):
+    url = "http://www.nomisweb.co.uk/api/v01/dataset/{dataset}.data.json?date=latest&geography={gss_code}&rural_urban=0&cell=0&measures={measures}".format(
+            dataset=dataset, gss_code=gss_code, measures=measure)
+    r = requests.get(url)
+    r.raise_for_status()
+    data = r.json()
+    return data['obs'][0]['obs_value']['value']
+
+
+class Dwellings:
+
+    def from_census(self, gss_code):
+        return get_stat_from_nomis('NM_618_1', '20100', gss_code)
+
+    def from_onsud(self, council_id):
+        return Onsud.objects.filter(lad=council_id).count()
+
+    def from_addressbase(self, polygon):
+        return Address.objects.filter(location__within=polygon).count()

--- a/polling_stations/apps/data_collection/tests/test_importers.py
+++ b/polling_stations/apps/data_collection/tests/test_importers.py
@@ -23,6 +23,7 @@ class ImporterTest(TestCase):
 
     opts = {
         'noclean': False,
+        'nochecks': True,
         'verbosity': 0
     }
 

--- a/polling_stations/apps/data_finder/fixtures/integration_tests_addressbase.json
+++ b/polling_stations/apps/data_finder/fixtures/integration_tests_addressbase.json
@@ -53,7 +53,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000004"
     },
     {
@@ -83,7 +83,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000005"
     },
     {
@@ -113,7 +113,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000006"
     },
 
@@ -153,7 +153,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000010"
     }
 

--- a/polling_stations/apps/data_finder/fixtures/test_addressbase.json
+++ b/polling_stations/apps/data_finder/fixtures/test_addressbase.json
@@ -110,7 +110,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000004"
     },
     {
@@ -140,7 +140,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000005"
     },
 
@@ -171,7 +171,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000007"
     },
     {
@@ -201,7 +201,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000008"
     },
     {
@@ -231,7 +231,7 @@
             "pfa": "",
             "imd": ""
         },
-        "model": "uk_geo_utils.onsud",
+        "model": "addressbase.onsud",
         "pk": "00000009"
     }
 ]

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -12,7 +12,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 
 from addressbase.models import Address, Blacklist
-from uk_geo_utils.models import Onsud
 from uk_geo_utils.helpers import Postcode
 from uk_geo_utils.geocoders import (
     AddressBaseGeocoder,

--- a/polling_stations/apps/uk_geo_utils/tests/test_addressbase_geocoder.py
+++ b/polling_stations/apps/uk_geo_utils/tests/test_addressbase_geocoder.py
@@ -31,6 +31,7 @@ class FuzzyInt(int):
 # out into a seperate package. It is only needed because
 # we're running the tests inside WhereDIV as a host app
 @override_settings(ADDRESS_MODEL='uk_geo_utils.Address')
+@override_settings(ONSUD_MODEL='uk_geo_utils.Onsud')
 class AddressBaseGeocoderTest(TestCase):
 
     fixtures = [

--- a/polling_stations/apps/uk_geo_utils/tests/test_import_onsud.py
+++ b/polling_stations/apps/uk_geo_utils/tests/test_import_onsud.py
@@ -1,10 +1,14 @@
 import os
 from io import StringIO
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from uk_geo_utils.models import Onsud
 from uk_geo_utils.management.commands.import_onsud import Command
 
 
+# TODO: This override can be removed when you spin this
+# out into a seperate package. It is only needed because
+# we're running the tests inside WhereDIV as a host app
+@override_settings(ONSUD_MODEL='uk_geo_utils.Onsud')
 class OnsudImportTest(TestCase):
 
     def test_import_onsud(self):

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -263,6 +263,7 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 
 ADDRESS_MODEL = 'addressbase.Address'
+ONSUD_MODEL = 'addressbase.Onsud'
 
 
 EMAIL_SIGNUP_ENDPOINT = 'https://democracyclub.org.uk/mailing_list/api_signup/v1/'


### PR DESCRIPTION
Refs #1045

This PR adds the ability to print some contextual information which gives us some idea how many addresses we would expect to find in the input file if it is complete. Because this adds some overhead to the start of the script, I've set it so it doesn't run if we pass the `--nochecks` flags (this means we won't run this code when we do a bulk import to build an image and we can pass it over in unit tests, etc).

I don't really have a good handle yet on which of these numbers is the most useful comparison point or what a sensible warning range is going to be. I think 'Total Dwellings from 2011 Census' is actually going to be the closest number mostly (but a bit on the low side because its fairly out-of-date now) because both of the UPRN totals include non-residential addresses whereas the Census number is only residential dwellings. Predictably none of the numbers we can easily generate or get hold of neatly map on to the exact number of records we would expect in the input file.

Either way, having these numbers gives us a good picture check - if we've got an incomplete file or a file that contains data from >1 local auth, its should be much more obvious now. Maybe once I've written a bunch of input scripts I'll have a feel for a reasonable warning threshold.