### PR TITLE
Update dc_signup_form to 2.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,4 +21,4 @@ git+https://github.com/mysociety/django-pipeline-csscompressor
 libsass==0.13.6  # pyup: >=0.13.6,<0.13.7
 
 git+git://github.com/DemocracyClub/dc_base_theme.git@94d172df89342072c25f29c4c2de34fe9a27886b
-git+https://github.com/DemocracyClub/dc_signup_form.git@1.0.0
+git+https://github.com/DemocracyClub/dc_signup_form.git@2.0.0


### PR DESCRIPTION
2.0.0 drops support for Django < 1.10, Adds support for Django 2.0 and drops support for Postgres < 9.4

This dependency can be safely upgraded on the 'client' installs independently of upgrading the main website ( https://github.com/DemocracyClub/Website/pull/102 ) because the API does not change in 2.0.0. All the BC-breaks are just platform compatibility