### PR TITLE
Deal with stations represented as polygons, import Calderdale

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_calderdale.py
+++ b/polling_stations/apps/data_collection/management/commands/import_calderdale.py
@@ -1,13 +1,16 @@
+from django.db import transaction
 from django.db import connection
+from data_collection.data_types import StationSet
 from pollingstations.models import PollingDistrict
 from data_collection.management.commands import BaseShpStationsShpDistrictsImporter
 
 
 class Command(BaseShpStationsShpDistrictsImporter):
-    council_id       = 'E08000033'
-    districts_name   = 'parl.2017-06-08/Version 2/Polling Districts.shp'
-    stations_name    = 'parl.2017-06-08/Version 2/polling-stations.shp'
-    elections        = ['parl.2017-06-08']
+    council_id        = 'E08000033'
+    districts_name    = 'local.2018-05-03/Version 1/POLLING_DISTRICTS_region.shp'
+    stations_name     = 'local.2018-05-03/Version 1/POLLING_STATIONS_region.shp'
+    elections         = ['local.2018-05-03']
+    station_addresses = {}
 
     def parse_string(self, text):
         try:
@@ -16,14 +19,20 @@ class Command(BaseShpStationsShpDistrictsImporter):
             return text.strip()
 
     def district_record_to_dict(self, record):
-        # exclude duplicate/ambiguous code
-        if str(record[0]).strip() == 'DC':
-            return None
+        code = self.parse_string(record[0])
+        name = self.parse_string(record[1])
+        address = self.parse_string(record[5])
 
+        """
+        Some of the districts don't have a corresponding station point
+        in the stations file but every district has a station address.
+        We can use these to fill the gaps in later.
+        """
+        self.station_addresses[code] = address
         return {
-            'internal_council_id': str(record[0]).strip(),
-            'name': str(record[1]).strip(),
-            'polling_station_id': str(record[0]).strip(),
+            'internal_council_id': code,
+            'name': name,
+            'polling_station_id': code,
         }
 
     def station_record_to_dict(self, record):
@@ -33,8 +42,45 @@ class Command(BaseShpStationsShpDistrictsImporter):
         if code == '' and address == '':
             return None
 
+        # remove station addresses from the districts file
+        # as we find them in the stations file
+        if code in self.station_addresses:
+            del(self.station_addresses[code])
+
         return {
             'internal_council_id': code,
             'address': address,
             'postcode': '',
         }
+
+    @transaction.atomic
+    def fix_bad_polygon(self):
+        # fix self-intersecting polygon
+        self.stdout.write("running fixup SQL")
+        table_name = PollingDistrict()._meta.db_table
+
+        cursor = connection.cursor()
+        cursor.execute("""
+        UPDATE {0}
+         SET area=ST_Multi(ST_CollectionExtract(ST_MakeValid(area), 3))
+         WHERE NOT ST_IsValid(area);
+        """.format(table_name))
+
+    @transaction.atomic
+    def fill_the_blanks(self):
+        # mop up any districts where we have a station address
+        # attached to a district code but no point
+        self.stations = StationSet()
+        for code in self.station_addresses:
+            self.add_polling_station({
+                'internal_council_id': code,
+                'postcode': '',
+                'address': self.station_addresses[code],
+                'location': None,
+                'council': self.council
+            })
+        self.stations.save()
+
+    def post_import(self):
+        self.fill_the_blanks()
+        self.fix_bad_polygon()


### PR DESCRIPTION
Uniquely, Calderdale are now representing their polling stations as a polygon of the building rather than just a point:

![screenshot at 2018-03-07 13 15 59](https://user-images.githubusercontent.com/6025893/37106804-9f865378-222a-11e8-8295-0fc30f03226e.png)

Quite cool, but no other council does this, so I'm not particularly keen to handle it beyond reducing it to a point on import. This PR allows us to explicitly handle this case. Note it also chucks out a bunch of warnings because in 99% of cases if the station isn't a point it is more likely to indicate that I'm trying to import the wrong file or something.