### PR TITLE
voter ID pilot info

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -48,6 +48,7 @@ class PostcodeResponseSerializer(serializers.Serializer):
     polling_station = PollingStationGeoSerializer(read_only=True)
     addresses = ResidentialAddressSerializer(read_only=True, many=True)
     report_problem_url = serializers.CharField(read_only=True)
+    metadata = serializers.DictField(read_only=True)
 
 
 class ResidentialAddressViewSet(ViewSet, LogLookUpMixin):
@@ -105,6 +106,8 @@ class ResidentialAddressViewSet(ViewSet, LogLookUpMixin):
             if polling_station:
                 ret['polling_station'] = polling_station
                 ret['polling_station_known'] = True
+
+        ret['metadata'] = ee.get_metadata()
 
         # create log entry
         log_data = {}

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -118,6 +118,8 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
         if not ret['polling_station_known'] and loc:
             ret['custom_finder'] = self.generate_custom_finder(loc, postcode)
 
+        ret['metadata'] = ee.get_metadata()
+
         # create log entry
         log_data = {}
         log_data['we_know_where_you_should_vote'] = ret['polling_station_known']

--- a/polling_stations/apps/api/tests/mocks.py
+++ b/polling_stations/apps/api/tests/mocks.py
@@ -1,0 +1,13 @@
+class EEMock:
+    def get_metadata(self):
+        return None
+
+
+class EEMockWithElection(EEMock):
+    def has_election(self):
+        return True
+
+
+class EEMockWithoutElection(EEMock):
+    def has_election(self):
+        return False

--- a/polling_stations/apps/api/tests/test_address.py
+++ b/polling_stations/apps/api/tests/test_address.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.gis.geos import Point
 from rest_framework.test import APIRequestFactory
 from api.address import ResidentialAddressViewSet
+from .mocks import EEMockWithElection, EEMockWithoutElection
 
 
 # Test double for geocode function: always returns the same point
@@ -11,16 +12,6 @@ def mock_geocode(postcode):
         "Geocoder", (object, ),
         { "centroid": Point(0.22247314453125, 53.149405955929744, srid=4326) }
     )
-
-
-class EEMockWithElection:
-    def has_election(self):
-        return True
-
-
-class EEMockWithoutElection:
-    def has_election(self):
-        return False
 
 
 class AddressTest(TestCase):

--- a/polling_stations/apps/api/tests/test_postcode.py
+++ b/polling_stations/apps/api/tests/test_postcode.py
@@ -5,6 +5,7 @@ from django.contrib.gis.geos import Point
 from rest_framework.test import APIRequestFactory
 from api.postcode import PostcodeViewSet
 from data_finder.helpers import MultipleCouncilsException, PostcodeError
+from .mocks import EEMockWithElection, EEMockWithoutElection
 
 
 class StubGeocoder:
@@ -17,16 +18,6 @@ class StubGeocoder:
         if not self.code:
             raise ObjectDoesNotExist
         return self.code
-
-
-class EEMockWithElection:
-    def has_election(self):
-        return True
-
-
-class EEMockWithoutElection:
-    def has_election(self):
-        return False
 
 
 """

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -237,8 +237,7 @@ class EveryElectionWrapper:
                     continue
                 if not election['metadata']:
                     continue
-                if election['group_type'] == 'organisation':
-                    return election['metadata']
+                return election['metadata']
         return None
 
 

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -228,6 +228,19 @@ class EveryElectionWrapper:
                     })
         return explanations
 
+    def get_metadata(self):
+        if not self.request_success:
+            return None
+        if len(self.elections) > 0:
+            for election in self.elections:
+                if not 'metadata' in election:
+                    continue
+                if not election['metadata']:
+                    continue
+                if election['group_type'] == 'organisation':
+                    return election['metadata']
+        return None
+
 
 class DirectionsHelper():
 

--- a/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
+++ b/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
@@ -26,17 +26,21 @@ def get_data_with_elections(self, query_url):
     return [
         {
             'election_title': 'some election',
-            'group_type': 'organisation'
-        },  # no explanation key
+            'group_type': 'organisation',
+        },  # no explanation or metadata keys
         {
             'election_title': 'some election',
             'group_type': None,
-            'explanation': None  # null explanation key
-        },
+            'explanation': None,
+            'metadata': None
+        },  # null explanation and metsdata keys
         {
             'election_title': 'some election',
             'group_type': None,
-            'explanation': 'some text'  # explanation key contains text
+            'explanation': 'some text',  # explanation key contains text
+            'metadata': {
+                'this election': 'has some metadata'
+            }  # metadata key is an object
         },
     ]
 
@@ -49,6 +53,7 @@ class EveryElectionWrapperTest(TestCase):
         self.assertFalse(ee.request_success)
         self.assertTrue(ee.has_election())
         self.assertEqual([], ee.get_explanations())
+        self.assertEqual(None, ee.get_metadata())
 
     @override_settings(EVERY_ELECTION={'CHECK': True, 'HAS_ELECTION': True})
     @mock.patch("data_finder.helpers.EveryElectionWrapper.get_data", get_data_no_elections)
@@ -57,6 +62,7 @@ class EveryElectionWrapperTest(TestCase):
         self.assertTrue(ee.request_success)
         self.assertFalse(ee.has_election())
         self.assertEqual([], ee.get_explanations())
+        self.assertEqual(None, ee.get_metadata())
 
     @override_settings(EVERY_ELECTION={'CHECK': True, 'HAS_ELECTION': True})
     @mock.patch("data_finder.helpers.EveryElectionWrapper.get_data", get_data_with_elections)
@@ -67,6 +73,7 @@ class EveryElectionWrapperTest(TestCase):
         self.assertEqual([
             {'title': 'some election', 'explanation': 'some text'}
         ], ee.get_explanations())
+        self.assertEqual({'this election': 'has some metadata'}, ee.get_metadata())
 
     @override_settings(EVERY_ELECTION={'CHECK': True, 'HAS_ELECTION': True})
     @mock.patch("data_finder.helpers.EveryElectionWrapper.get_data", get_data_only_group)
@@ -75,6 +82,7 @@ class EveryElectionWrapperTest(TestCase):
         self.assertTrue(ee.request_success)
         self.assertFalse(ee.has_election())
         self.assertEqual([], ee.get_explanations())
+        self.assertEqual(None, ee.get_metadata())
 
     @override_settings(EVERY_ELECTION={'CHECK': True, 'HAS_ELECTION': True})
     @mock.patch("data_finder.helpers.EveryElectionWrapper.get_data", get_data_group_and_ballot)
@@ -83,6 +91,7 @@ class EveryElectionWrapperTest(TestCase):
         self.assertTrue(ee.request_success)
         self.assertTrue(ee.has_election())
         self.assertEqual([], ee.get_explanations())
+        self.assertEqual(None, ee.get_metadata())
 
     @override_settings(EVERY_ELECTION={'CHECK': True, 'HAS_ELECTION': False})
     @mock.patch("data_finder.helpers.EveryElectionWrapper.get_data", get_data_group_and_ballot)

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -158,6 +158,10 @@ class BasePollingStationView(
         if not context['has_election']:
             context['error'] = "We don't know of any upcoming elections in your area"
         context['election_explainers'] = ee.get_explanations()
+        metadata = ee.get_metadata()
+        context['voter_id_pilot'] = None
+        if metadata and '2018-05-03-id-pilot' in metadata:
+            context['voter_id_pilot'] = metadata['2018-05-03-id-pilot']
 
         context['postcode'] = self.postcode.with_space
         context['location'] = self.location

--- a/polling_stations/templates/api_docs/blueprints/finder.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder.apibp
@@ -20,6 +20,38 @@ A `200 OK` response from `/postcode` or `/address` is an object containing the f
   an election, particularly if there is some unusual condition or event for voters to be aware of.
 
 
+<p>
+<h4>May 2018 Voter ID Pilots</h4>
+
+<p>In May 2018 voters in Bromley, Gosport, Swindon, Watford and Woking will be
+required to present identification in order to vote at a polling station.
+Each area has slightly different requirements. API responses for a postcode
+or address in an authority which is participating in the pilot will have a
+key <code>2018-05-03-id-pilot</code> under the <code>metadata</code> object.</p>
+
+An example API response:
+
+<pre><code>{
+  ...
+  "metadata": {
+    "2018-05-03-id-pilot": {
+      "title": "You need to show ID to vote at this election",
+      "url": "https://www.woking.gov.uk/voterid",
+      "detail": "Voters in Woking will be required to show photo ID before they can vote."
+    }
+  }
+}
+</code></pre>
+
+<p>This information will be provided in all responses from the
+<code>/address</code> and <code>/postcode</code> API endpoints,
+even if we are not able to provide a polling station result.
+We encourage our API consumers to provide users in these areas with
+information about the pilots.</p>
+
+</p>
+
+
 ## Postcode search [/postcode/{postcode}.json]
 
 The entry point to a polling station search is a call to the `/postcode` endpoint.

--- a/polling_stations/templates/api_docs/blueprints/finder.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder.apibp
@@ -16,7 +16,8 @@ A `200 OK` response from `/postcode` or `/address` is an object containing the f
   sometimes we can provide the URL of a polling station finder provided by their local council.
 * `report_problem_url`: (string, nullable) - If we provide a polling station result,
   this URL may be used to provide a user with a back-channel to report inaccurate data.
-
+* `metadata`: (object, nullable) - This field may be used to supply additional information about
+  an election, particularly if there is some unusual condition or event for voters to be aware of.
 
 
 ## Postcode search [/postcode/{postcode}.json]

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/BN436HW.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/BN436HW.apibp
@@ -67,5 +67,6 @@
                     "address": "Adur District Council\nTown Hall\nChapel Road\nWorthing\nWest Sussex",
                     "email": "elections@adur-worthing.gov.uk"
                 },
-                "report_problem_url": null
+                "report_problem_url": null,
+                "metadata": null
             }

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/NG178AA.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/NG178AA.apibp
@@ -44,5 +44,6 @@
                     "postcode": "NG17 8DA",
                     "address": "Ashfield District Council\nCouncil Offices\nUrban Road\nKirkby-in-Ashfield\nNottingham"
                 },
-                "report_problem_url": "https://wheredoivote.co.uk/report_problem/?source=api&source_url=%2Fapi%2Fbeta%2FTEST.json"
+                "report_problem_url": "https://wheredoivote.co.uk/report_problem/?source=api&source_url=%2Fapi%2Fbeta%2FTEST.json",
+                "metadata": null
             }

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/SW1A1AA.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/SW1A1AA.apibp
@@ -24,5 +24,6 @@
                     "address": "Westminster City Council\nElectoral Services\nWestminster City Hall\n64 Victoria Street\nLondon",
                     "email": "electoralservices@westminster.gov.uk"
                 },
-                "report_problem_url": null
+                "report_problem_url": null,
+                "metadata": null
             }

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw.apibp
@@ -52,5 +52,6 @@
                     "postcode": "BN11 1HA",
                     "address": "Adur District Council\nTown Hall\nChapel Road\nWorthing\nWest Sussex"
                 },
-                "report_problem_url": "https://wheredoivote.co.uk/report_problem/?source=api&source_url=%2Fapi%2Fbeta%2FTEST.json"
+                "report_problem_url": "https://wheredoivote.co.uk/report_problem/?source=api&source_url=%2Fapi%2Fbeta%2FTEST.json",
+                "metadata": null
             }

--- a/polling_stations/templates/api_docs/blueprints/finder_responses/schema.apibp
+++ b/polling_stations/templates/api_docs/blueprints/finder_responses/schema.apibp
@@ -155,6 +155,13 @@
                     "null"
                   ],
                   "description": "If we provide a polling station result, this URL may be used to provide a user with a back-channel to report inaccurate data."
-                }
+                },
+                "metadata": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "description": "This field may be used to supply additional information about an election."
+                },
               }
             }

--- a/polling_stations/templates/fragments/you_dont_need_poll_card.html
+++ b/polling_stations/templates/fragments/you_dont_need_poll_card.html
@@ -1,4 +1,14 @@
 {% load i18n %}
+  {% if voter_id_pilot %}
+    <div class="card">
+        <h3>{{ voter_id_pilot.title }}</h3>
+        <p>{{ voter_id_pilot.detail }}</p>
+        <p>
+          <a href="{{ voter_id_pilot.url }}">More information on voter ID pilots</a>
+        </p>
+        <p>{% trans "You must vote at your assigned polling station." %}</p>
+    </div>
+  {% else %}
     <div class="card">
         {% blocktrans %}
         <h3>You don't need your poll card to vote</h3>
@@ -26,3 +36,4 @@
           </a></p>
         {% endif %}
     </div>
+  {% endif%}


### PR DESCRIPTION
Closes #1059
Closes #1128

Definitely don't review/merge this. It is based on assumptions about PRs that haven't been merged and data structures that do not yet exist which may end up not being true. Also needs rebasing onto other stuff to properly finish.

TODO:
* Haven't done the API docs as I'll end up doing it twice to sort out the merge conflict with https://github.com/DemocracyClub/UK-Polling-Stations/pull/1145/commits/ddfa9b52dde25af787a767b168e6c28d7bd44e13 but the format will be roughly that, with an object.
* Write a test for `get_metadata()`
* Once we've got https://github.com/DemocracyClub/EveryElection/pull/223 merged/deployed and started serving up some data I'll finish this off.

In current design we will show something like

![screenshot at 2018-03-12 17 34 48](https://user-images.githubusercontent.com/6025893/37300275-7a8ac472-261d-11e8-9cf7-eb0cffbcc528.png)

but that's in the old theme and we should aim to merge #1137 ahead of this and rebase on to it.