### PR TITLE
add copyright notices

### DIFF
--- a/polling_stations/templates/base.html
+++ b/polling_stations/templates/base.html
@@ -49,7 +49,13 @@
       <li><a href="https://facebook.com/DemocracyClub">Facebook</a></li>
       <li><a href="https://github.com/DemocracyClub">GitHub</a></li>
     </ul>
-    <p>Copyright © 2017 Democracy Club Community Interest Company Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
+
+    <p>Copyright © {% now "Y" %} Democracy Club Community Interest Company Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a></p>
+    <p>
+      Contains OS data © Crown copyright and database right {% now "Y" %}<br>
+      Contains Royal Mail data © Royal Mail copyright and database right {% now "Y" %}<br>
+      Contains National Statistics data © Crown copyright and database right {% now "Y" %}<br>
+    </p>
 
   </div>
 </footer>


### PR DESCRIPTION
There are a bunch of notices and attributions we are supposed to have on our site where we use postcode lookups, boundaries, etc (see https://www.ons.gov.uk/methodology/geography/licences ). Lets bung them at the bottom of the footer.