### PR TITLE
re-order results page content

### DIFF
--- a/polling_stations/templates/fragments/polling_station_known.html
+++ b/polling_stations/templates/fragments/polling_station_known.html
@@ -34,6 +34,8 @@
   </div>
 {% endif %}
 
+<p><strong>Polling stations are open from 7am to 10pm on Thursday 3 May.</strong></p>
+
 {% if station.location %}
   <div id="area_map" class="card_inset"></div>
 {% endif %}

--- a/polling_stations/templates/fragments/polling_station_unknown.html
+++ b/polling_stations/templates/fragments/polling_station_unknown.html
@@ -2,12 +2,13 @@
 
 <h2>{% blocktrans with council.name as council_name %}Contact {{ council_name }}{% endblocktrans %}</h2>
 
-{% blocktrans with council.phone as council_phone %}
+{% blocktrans with council.phone as council_phone and council.name as council_name %}
   <p>We don't have data for your area.</p>
   <p>
     Your polling station address should be printed on your polling card, which is delivered by post before an election.
   </p>
   <p>
-    Or, you need to contact the council. You can call them on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong>
+    Or, you need to contact your local council. You can call {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong>
   </p>
+  <p><strong>Polling stations are open from 7am to 10pm on Thursday 3 May.</strong></p>
 {% endblocktrans %}

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -56,6 +56,9 @@
 
     </div>
 
+    {% include "fragments/you_dont_need_poll_card.html" %}
+    {% include "fragments/register_to_vote.html" %}
+
     {% if we_know_where_you_should_vote and election_explainers %}
       {% include "election_explainers.html" %}
     {% endif %}
@@ -71,14 +74,11 @@
       {% endif %}
     {% endif %}
 
-
-    {% include "fragments/you_dont_need_poll_card.html" %}
-    {% include "fragments/register_to_vote.html" %}
-    {# include "fragments/info_on_your_candidates.html" #}
-
     {% if council.address or council.postcode or council.phone or council.email %}
       {% include "fragments/contact_details.html" %}
     {% endif %}
+
+    {% include "fragments/info_on_your_candidates.html" %}
 
     {% if not error or error == "We don't know of any upcoming elections in your area" %}
       {% if request.brand == 'democracyclub' and not messages %}


### PR DESCRIPTION
Closes #1207

* Move the opening hours on to the same card as the address/map/etc
* Move polling card/voter id info much higher up the page
* Move 'register to vote' card higher up the page (we will remove this card after the deadline on 17th April)
* Move 'information on your candidates' card lower down the page (very few people wanted this or said it was useful)

Although it is useful to look at the diff, it might also be easier to look at screenshots to review this. Rather than pasting lots of large screenshots into a GH issue, I've uploaded them to: https://drive.google.com/drive/folders/1SrJ_CZXJEORrpxwMrvrSxeiOEx28iZkY

There are screenshots for each of the following cases:

* Station not known, without voter ID pilot
* Station known, with map (without voter ID pilot)
* Station known, no map (without voter ID pilot)
* Station not known, voter ID pilot
* Station known, (with map) voter ID pilot
* No Election
* Multiple Councils

I have intentionally done the screenshots with a narrow resolution as this is the experience we're trying to optimise for.

