### PR TITLE
Don't make unnecessary DB queries

### DIFF
--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -281,20 +281,14 @@ class RoutingHelper():
 
     @property
     def has_addresses(self):
-        if not getattr(self, 'addresses', None):
-            self.get_addresses()
         return bool(self.addresses)
 
     @property
     def has_single_address(self):
-        if not getattr(self, 'addresses', None):
-            self.get_addresses()
         return self.addresses.count == 1
 
     @property
     def address_have_single_station(self):
-        if not getattr(self, 'addresses', None):
-            self.get_addresses()
         stations = self.addresses.values('polling_station_id').distinct()
         return len(stations) == 1
 

--- a/polling_stations/apps/data_finder/helpers.py
+++ b/polling_stations/apps/data_finder/helpers.py
@@ -281,19 +281,19 @@ class RoutingHelper():
 
     @property
     def has_addresses(self):
-        if getattr(self, 'addresses', None):
+        if not getattr(self, 'addresses', None):
             self.get_addresses()
         return bool(self.addresses)
 
     @property
     def has_single_address(self):
-        if getattr(self, 'addresses', None):
+        if not getattr(self, 'addresses', None):
             self.get_addresses()
         return self.addresses.count == 1
 
     @property
     def address_have_single_station(self):
-        if getattr(self, 'addresses', None):
+        if not getattr(self, 'addresses', None):
             self.get_addresses()
         stations = self.addresses.values('polling_station_id').distinct()
         return len(stations) == 1


### PR DESCRIPTION
No idea how I've never spotted this in the last 2 years!

This was causing unnecessary DB queries because it's basically saying "if we've already run this query run it again".
I think the original intention was that it should be written like this: 170a48d (i.e: "if we _haven't_ already run this query run it")
but we run this query in the constructor, so if the object exists, by definition, we must have run it anyway (unless `@property` implies `@staticmethod` ??), so we can just completely delete this code: 7f29b86 . This saves making multiple unnecessary round trips to the DB on every request. Note that I've deleted this code and all the `RoutingHelper` tests pass.

@symroe - can you just sanity check this.. I've done it as 2 commits just so I can show what I think the original idea was, but I'll squash to merge.