### PR TITLE
Remove greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ cache:
 
 before_install:
   - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
-  - npm install -g greenkeeper-lockfile
 
 install:
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
@@ -51,13 +50,8 @@ install:
 before_script:
   - psql -U postgres -c "create extension postgis"
   - export BOTO_CONFIG=/dev/null
-  - greenkeeper-lockfile-update
-
 script:
   - tox
-
-after_script:
-  - greenkeeper-lockfile-upload
 
 after_success:
   - coveralls
@@ -65,7 +59,3 @@ after_success:
 notifications:
   slack:
     secure: XDoMlbyJR1HOfF3ibOGNEizbb7MYGG8abDPrVTdTBscV5d3vm7qE0Uvd7Hq7YefwhSv8dJ+psrnWwMxBH7Z8zQmyLDyeVCNysOIfc3JfLi/cgrxZ0x0GoqUiiW8sgMl4Um/9jlEpcd5te5HpIeCFp0PHDO3GIWpzxx7xMbS6/0Q=
-
-env:
-  global:
-    secure: eVOPFkgEc94XlURUren+zrSRGRsFZo1ayp+BfctIPfdXx5Zb8gc1l/0eZPH6W9iEHycNSLWs/JyCt/ZFiiFQCEvqqcLfmtoiPMfcQPhSXZgbsjxIDLgb2n2LDIhEUw4sjeVTHmXe16RFQKNBeFssaPPfhMFN3W5TbgHcGs2+9+L2MYnHFW1Y+itKJR9wzZTrMxatANTemFLBKw2sELF9Gf1mOsPdUr6sT9Ao+rzNknnyt6l7SGxmspWji4IYYZxGT0tCr9bybE/URTgLkUM2HAqWysHe3hEpMIFNwPCnC6XnzgHp+838VSQb1SuCTCS6j9U3JWcXFf8eLBnCTTgUnYU/KrUCs0FRC+NF8T4A7KX5YjQDDAK9hb7ffkn/Vzfk4rkgSAlKYh9KKQ9HWMTpHNjCFz9Ng/tuA8u8gKvzxyiwy2i0NqnNr1kUGCdvEQ6JJLoGhlWSpBrS1464mktRNsXx5sN1h6mM/5nw3kl7R0myu7BB2Q2qoOp22S0mzscB0AMD0gJPUtVGiW/tgoKiMpASpfzov3VuaBSHMvq/oC/epMDF1ozOF7jyNZopi+NnqLjKs58u1gvB5I2BMblSKDuzFLdemB7Hpp9EYOl0sFa7nD+2Gu2n3jIf0WVsU5S+TrVV6Fb8+95wMFBAGrROJli98GGXNDpNc25/aJPo0/E=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Stories in Ready](https://badge.waffle.io/democracyclub/uk-polling-stations.png?label=ready&title=Ready)](https://waffle.io/democracyclub/uk-polling-stations)
 
-[![Build Status](https://travis-ci.org/DemocracyClub/UK-Polling-Stations.svg?branch=master)](https://travis-ci.org/DemocracyClub/UK-Polling-Stations) [![Coverage Status](https://coveralls.io/repos/github/DemocracyClub/UK-Polling-Stations/badge.svg)](https://coveralls.io/github/DemocracyClub/UK-Polling-Stations) [![Greenkeeper badge](https://badges.greenkeeper.io/DemocracyClub/UK-Polling-Stations.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.org/DemocracyClub/UK-Polling-Stations.svg?branch=master)](https://travis-ci.org/DemocracyClub/UK-Polling-Stations) [![Coverage Status](https://coveralls.io/repos/github/DemocracyClub/UK-Polling-Stations/badge.svg)](https://coveralls.io/github/DemocracyClub/UK-Polling-Stations)
 
 # UK-Polling-Stations
 


### PR DESCRIPTION
Quick - we've been using the same javascript tooling for nearly a month. Replace this archaic legacy code!

(more seriously, I've switched out greenkeeper for dependabot because dependabot seems to be an objectively better solution for projects that use a lockfile, whereas greenkeeper seems to be more suited to use in library/module style projects)