### PR TITLE
add status check endpoint

### DIFF
--- a/polling_stations/apps/pollingstations/views.py
+++ b/polling_stations/apps/pollingstations/views.py
@@ -1,3 +1,22 @@
-from django.shortcuts import render
+import os
+from django.conf import settings
+from django.db import connections
+from django.db.utils import OperationalError
+from django.http import HttpResponse
 
-# Create your views here.
+
+def status_check(request):
+
+    if settings.CHECK_SERVER_CLEAN:
+        if not os.path.exists(os.path.expanduser(settings.CLEAN_SERVER_FILE)):
+            return HttpResponse('service unavailable', status=503)
+
+    # check we can connect to all our DBs
+    # (default + logger)
+    for conn in connections:
+        try:
+            connections[conn].cursor()
+        except OperationalError:
+            return HttpResponse('service unavailable', status=503)
+
+    return HttpResponse('OK', status=200)

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -278,6 +278,11 @@ EMAIL_SIGNUP_API_KEY = ''
 BASICAUTH_DISABLE = True
 
 
+# settings for load balancer status check
+CHECK_SERVER_CLEAN = True
+CLEAN_SERVER_FILE = '~/clean'
+
+
 # import application constants
 from .constants.councils import *  # noqa
 from .constants.directions import *  # noqa

--- a/polling_stations/urls.py
+++ b/polling_stations/urls.py
@@ -18,12 +18,14 @@ from data_finder.views import (
     WeDontKnowView,
     MultipleCouncilsView,
 )
+from pollingstations.views import status_check
 
 from django.contrib import admin
 admin.autodiscover()
 
 
 core_patterns = [
+    url(r'^status_check/$', status_check, name='status_check'),
     url(r'^postcode/(?P<postcode>.+)/$',
         PostcodeView.as_view(), name='postcode_view'),
     url(r'^postcode/$',


### PR DESCRIPTION
This adds a status check endpoint for use with ELB status checking. It checks for a "clean" file (if applicable) and makes sure it can connect to any defined DB connections before returning a `200 OK`. I miiiight look to add some more handy checks to this at some point, but lets ignore that for now.

I've tried deploying this off a branch and it does the job. I'm quite keen to get this deployment work finished off this sprint if possible, so would be handy to get a quick :+1:  on this if you get a chance @symroe 