### PR TITLE
Update lxml from 4.2.4 to 4.2.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ djangorestframework==3.7.7
 djangorestframework-gis==0.12.0
 django-cors-headers==2.4.0
 fastkml==0.11
-lxml==4.2.4
+lxml==4.2.5
 psycopg2-binary==2.7.5
 pyshp==1.2.12
 requests==2.19.1


### PR DESCRIPTION
For some reason Pyup pushed this to a branch but didn't open a PR :confused: 
Its opened a PR on EE today. I'll have to keep an eye on it. If it persists I'll raise a support ticket