### PR TITLE
remove some deprecated calls

### DIFF
--- a/polling_stations/apps/data_collection/urls.py
+++ b/polling_stations/apps/data_collection/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import include, url
 from django.conf import settings
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.views.generic import RedirectView
 
 from .views import data_quality

--- a/polling_stations/apps/data_finder/middleware.py
+++ b/polling_stations/apps/data_finder/middleware.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.core.urlresolvers import set_script_prefix
 
 
 class UTMTrackerMiddleware(object):

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -3,7 +3,7 @@ import json
 
 from django.conf import settings
 from django.contrib.gis.geos import Point
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import validate_email
 from django.forms import ValidationError
 from django.http import HttpResponse, HttpResponseRedirect, Http404

--- a/polling_stations/apps/whitelabel/middleware.py
+++ b/polling_stations/apps/whitelabel/middleware.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.urlresolvers import set_script_prefix
+from django.urls import set_script_prefix
 from django.utils import translation
 
 

--- a/polling_stations/urls.py
+++ b/polling_stations/urls.py
@@ -53,7 +53,7 @@ extra_patterns = [
     url(r'^i18n/', include('django.conf.urls.i18n')),
     url(r'^api/beta/', include(router.urls)),
     url(r'^api/$', ApiDocsView.as_view(), name='api_docs'),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^feedback/', include('feedback.urls')),
     url(r'^report_problem/', include('bug_reports.urls')),
     url(r'^league_table/', include('data_collection.urls')),


### PR DESCRIPTION
This fixes the following deprecation warnings:

* `RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.`
* `RemovedInDjango20Warning: Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated. Set the app_name attribute in the included module, or pass a 2-tuple containing the list of patterns and app_name instead.`