### PR TITLE
Add sandbox API outputs

### DIFF
--- a/polling_stations/apps/api/router.py
+++ b/polling_stations/apps/api/router.py
@@ -4,6 +4,7 @@ from .councils import CouncilViewSet
 from .pollingdistricts import PollingDistrictViewSet
 from .pollingstations import PollingStationViewSet
 from .postcode import PostcodeViewSet
+from .sandbox import SandboxView
 
 
 router = routers.DefaultRouter()
@@ -12,3 +13,18 @@ router.register(r'pollingstations', PollingStationViewSet)
 router.register(r'pollingdistricts', PollingDistrictViewSet)
 router.register(r'postcode', PostcodeViewSet, base_name="postcode")
 router.register(r'address', ResidentialAddressViewSet, base_name="address")
+
+
+from django.conf.urls import url
+router.urls.append(
+    url(
+        r"^sandbox/postcode/(?P<postcode>[A-Za-z0-9 +]+)/$",
+        SandboxView.as_view()
+    )
+)
+router.urls.append(
+    url(
+        r"^sandbox/address/(?P<slug>[-\w]+)/$",
+        SandboxView.as_view()
+    )
+)

--- a/polling_stations/apps/api/sandbox-responses/AA12AA.json
+++ b/polling_stations/apps/api/sandbox-responses/AA12AA.json
@@ -1,0 +1,50 @@
+{
+    "polling_station_known": true,
+    "postcode_location": {
+        "properties": null,
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -1.2491514412601963,
+                53.09878716696975
+            ]
+        },
+        "type": "Feature"
+    },
+    "custom_finder": null,
+    "addresses": [],
+    "polling_station": {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -1.248013,
+                53.100064
+            ]
+        },
+        "type": "Feature",
+        "id": "E07000170.KXP3",
+        "properties": {
+            "address": "Councillors' Room, ADC Offices\nUrban Road, Kirkby in Ashfield",
+            "station_id": "KXP3",
+            "council": "https://wheredoivote.co.uk/api/beta/councils/W06000015/",
+            "urls": {
+                "geo": "",
+                "detail": ""
+            },
+            "postcode": ""
+        }
+    },
+    "council": {
+        "url": "https://wheredoivote.co.uk/api/beta/councils/E07000170/",
+        "council_id": "E07000170",
+        "name": "Ashfield District Council",
+        "email": "regelec@ashfield-dc.gov.uk",
+        "phone": "01623 457321",
+        "website": "http://www.ashfield-dc.gov.uk/residents/democracy,-elections-and-legal/elections/registering-to-vote.aspx",
+        "postcode": "NG17 8DA",
+        "address": "Ashfield District Council\nCouncil Offices\nUrban Road\nKirkby-in-Ashfield\nNottingham"
+    },
+    "report_problem_url": "https://wheredoivote.co.uk/report_problem/?source=api&source_url=%2Fapi%2Fbeta%2FTEST.json",
+    "metadata": null,
+    "ballots": []
+}

--- a/polling_stations/apps/api/sandbox-responses/AA12AB.json
+++ b/polling_stations/apps/api/sandbox-responses/AA12AB.json
@@ -1,0 +1,30 @@
+{
+    "polling_station_known": false,
+    "postcode_location": {
+        "properties": null,
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -0.14320717529002294,
+                51.50086373251905
+            ]
+        },
+        "type": "Feature"
+    },
+    "custom_finder": null,
+    "addresses": [],
+    "polling_station": null,
+    "council": {
+        "website": "https://www.westminster.gov.uk/contact-electoral-services",
+        "name": "Westminster City Council",
+        "phone": "020 7641 2730",
+        "url": "https://wheredoivote.co.uk/api/beta/councils/E09000033/",
+        "council_id": "E09000033",
+        "postcode": "SW1E 6QP",
+        "address": "Westminster City Council\nElectoral Services\nWestminster City Hall\n64 Victoria Street\nLondon",
+        "email": "electoralservices@westminster.gov.uk"
+    },
+    "report_problem_url": null,
+    "metadata": null,
+    "ballots": []
+}

--- a/polling_stations/apps/api/sandbox-responses/AA13AA.json
+++ b/polling_stations/apps/api/sandbox-responses/AA13AA.json
@@ -1,0 +1,45 @@
+{
+    "polling_station_known": false,
+    "postcode_location": {
+        "properties": null,
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -0.26353977212676555,
+                50.84477241345472
+            ]
+        },
+        "type": "Feature"
+    },
+    "custom_finder": null,
+    "addresses": [
+        {
+            "url": "https://wheredoivote.co.uk/api/beta/sandbox/address/e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw/",
+            "polling_station_id": "527",
+            "postcode": "BN436HW",
+            "council": "https://wheredoivote.co.uk/api/beta/councils/E07000223/",
+            "address": "5 Truleigh Way, Shoreham-by-Sea, West Sussex"
+        },
+        {
+            "url": "https://wheredoivote.co.uk/api/beta/sandbox/address/e07000223-524-2-truleigh-way-shoreham-by-sea-west-sussex-bn436hw/",
+            "polling_station_id": "524",
+            "postcode": "BN436HW",
+            "council": "https://wheredoivote.co.uk/api/beta/councils/E07000223/",
+            "address": "2 Truleigh Way, Shoreham-by-Sea, West Sussex"
+        }
+    ],
+    "polling_station": null,
+    "council": {
+        "website": "http://adur-worthing.gov.uk/elections-and-voting/register-to-vote/",
+        "name": "Adur District Council",
+        "phone": "01903 221014/5/6",
+        "url": "https://wheredoivote.co.uk/api/beta/councils/E07000223/",
+        "council_id": "E07000223",
+        "postcode": "BN11 1HA",
+        "address": "Adur District Council\nTown Hall\nChapel Road\nWorthing\nWest Sussex",
+        "email": "elections@adur-worthing.gov.uk"
+    },
+    "report_problem_url": null,
+    "metadata": null,
+    "ballots": []
+}

--- a/polling_stations/apps/api/sandbox-responses/e07000223-524-2-truleigh-way-shoreham-by-sea-west-sussex-bn436hw.json
+++ b/polling_stations/apps/api/sandbox-responses/e07000223-524-2-truleigh-way-shoreham-by-sea-west-sussex-bn436hw.json
@@ -1,0 +1,38 @@
+{
+    "polling_station_known": false,
+    "postcode_location": {
+        "properties": null,
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -0.26353977212676555,
+                50.84477241345472
+            ]
+        },
+        "type": "Feature"
+    },
+    "custom_finder": null,
+    "addresses": [
+        {
+            "url": "https://wheredoivote.co.uk/api/beta/sandbox/address/e07000223-524-2-truleigh-way-shoreham-by-sea-west-sussex-bn436hw/",
+            "polling_station_id": "524",
+            "postcode": "BN436HW",
+            "council": "https://wheredoivote.co.uk/api/beta/councils/E07000223/",
+            "address": "2 Truleigh Way, Shoreham-by-Sea, West Sussex"
+        }
+    ],
+    "polling_station": null,
+    "council": {
+        "url": "https://wheredoivote.co.uk/api/beta/councils/E07000223/",
+        "council_id": "E07000223",
+        "name": "Adur District Council",
+        "email": "elections@adur-worthing.gov.uk",
+        "phone": "01903 221014/5/6",
+        "website": "http://adur-worthing.gov.uk/elections-and-voting/register-to-vote/",
+        "postcode": "BN11 1HA",
+        "address": "Adur District Council\nTown Hall\nChapel Road\nWorthing\nWest Sussex"
+    },
+    "report_problem_url": "https://wheredoivote.co.uk/report_problem/?source=api&source_url=%2Fapi%2Fbeta%2FTEST.json",
+    "metadata": null,
+    "ballots": []
+}

--- a/polling_stations/apps/api/sandbox-responses/e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw.json
+++ b/polling_stations/apps/api/sandbox-responses/e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw.json
@@ -1,0 +1,58 @@
+{
+    "polling_station_known": true,
+    "postcode_location": {
+        "properties": null,
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -0.26353977212676555,
+                50.84477241345472
+            ]
+        },
+        "type": "Feature"
+    },
+    "custom_finder": null,
+    "addresses": [
+        {
+            "url": "https://wheredoivote.co.uk/api/beta/sandbox/address/e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw/",
+            "address": "5 Truleigh Way, Shoreham-by-Sea, West Sussex",
+            "postcode": "BN436HW",
+            "council": "https://wheredoivote.co.uk/api/beta/councils/E07000223/",
+            "polling_station_id": "527"
+        }
+    ],
+    "polling_station": {
+        "id": "E07000223.527",
+        "type": "Feature",
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -0.2693240568181819,
+                50.83494864772728
+            ]
+        },
+        "properties": {
+            "urls": {
+                "detail": "",
+                "geo": ""
+            },
+            "council": "https://wheredoivote.co.uk/api/beta/councils/E07000223/",
+            "station_id": "527",
+            "postcode": "BN43 6WF",
+            "address": "Shoreham Free Church Hall\nBuckingham Road/Gordon Road\nShoreham-by-Sea"
+        }
+    },
+    "council": {
+        "url": "https://wheredoivote.co.uk/api/beta/councils/E07000223/",
+        "council_id": "E07000223",
+        "name": "Adur District Council",
+        "email": "elections@adur-worthing.gov.uk",
+        "phone": "01903 221014/5/6",
+        "website": "http://adur-worthing.gov.uk/elections-and-voting/register-to-vote/",
+        "postcode": "BN11 1HA",
+        "address": "Adur District Council\nTown Hall\nChapel Road\nWorthing\nWest Sussex"
+    },
+    "report_problem_url": "https://wheredoivote.co.uk/report_problem/?source=api&source_url=%2Fapi%2Fbeta%2FTEST.json",
+    "metadata": null,
+    "ballots": []
+}

--- a/polling_stations/apps/api/sandbox.py
+++ b/polling_stations/apps/api/sandbox.py
@@ -1,0 +1,54 @@
+import json
+import os
+import re
+from django.http import HttpResponse
+from django.views import View
+
+class SandboxView(View):
+    def get(self, request, *args, **kwargs):
+
+        base_path = os.path.dirname(__file__)
+        get_fixture = lambda filename: open(
+            os.path.join(base_path, "sandbox-responses", filename + ".json")
+        )
+
+        example_postcodes = (
+            "AA12AA",  # station known
+            "AA12AB",  # station not known
+            "AA13AA",  # address picker
+        )
+
+        if "postcode" in kwargs:
+            postcode = re.sub("[^A-Z0-9]", "", kwargs["postcode"].upper())
+            if postcode in example_postcodes:
+                return HttpResponse(
+                    get_fixture(postcode), content_type="application/json", status=200
+                )
+            return HttpResponse(
+                json.dumps({"message": "Could not geocode from any source"}),
+                content_type="application/json",
+                status=400,
+            )
+
+        example_slugs = (
+            "e07000223-524-2-truleigh-way-shoreham-by-sea-west-sussex-bn436hw",
+            "e07000223-527-5-truleigh-way-shoreham-by-sea-west-sussex-bn436hw",
+        )
+        if "slug" in kwargs:
+            if kwargs["slug"] in example_slugs:
+                return HttpResponse(
+                    get_fixture(kwargs["slug"]),
+                    content_type="application/json",
+                    status=200,
+                )
+            return HttpResponse(
+                json.dumps({"message": "Address not found"}),
+                content_type="application/json",
+                status=404,
+            )
+
+        return HttpResponse(
+            json.dumps({"message": "Internal Server Error"}),
+            content_type="application/json",
+            status=500,
+        )

--- a/polling_stations/apps/councils/tests/test_council_importer.py
+++ b/polling_stations/apps/councils/tests/test_council_importer.py
@@ -58,6 +58,14 @@ class TestCouncilImporter(TestCase):
     def test_import_councils(self):
         assert Council.objects.count() == 0
         cmd = MockCouncilsImporter()
+        cmd.get_contact_info_from_yvm = lambda x: {
+            'name': "",
+            'website': "",
+            'email': "",
+            'phone': "",
+            'address': "",
+            'postcode': "",
+        }
 
         # supress output
         out = StringIO()


### PR DESCRIPTION
I was looking at how to make the behaviour of the widget more demonstrate-able / test-able and decided to basically nick the idea from https://github.com/DemocracyClub/aggregator-api/commit/a53c92e0851907985ca468984a45d434cb3c63e0 and make some 'sandbox', URLs which serve static examples.

This is more difficult to do well here because there is a lot of 'internal linking' between endpoints in this API which is difficult to replicate (so I'm not massively keen to expose this in the docs yet, at least in its current form). What this does allow us to do though is grab a local copy of the widget and set

`REACT_APP_WDIV_API_URL=https://wheredoivote.co.uk/api/beta/sandbox`

in

https://github.com/DemocracyClub/WhereDoIVote-Widget/blob/master/.env.development

Then we've got test postcodes we can use to run through each of the major cases we support. This will be handy next week, but also for general testing/development. This probably isn't my favourite solution for this problem forever. OTOH I could knock it up in a couple of hours, so its got that going for it..