### PR TITLE
exclude area column on councils list route

### DIFF
--- a/polling_stations/apps/api/councils.py
+++ b/polling_stations/apps/api/councils.py
@@ -34,7 +34,7 @@ class CouncilGeoSerializer(GeoFeatureModelSerializer):
 
 
 class CouncilViewSet(ReadOnlyModelViewSet):
-    queryset = Council.objects.all()
+    queryset = Council.objects.all().defer("area")
     serializer_class = CouncilDataSerializer
 
     @detail_route(url_path='geo')


### PR DESCRIPTION
this should fix the random crashes on WDIV when we're deployed on a small instance

Tests will probably fail for unrelated reason and need the fix from 9e17dea