### PR TITLE
Update CI build to reflect new live env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 python:
-  - '3.5'
   - '3.6'
 addons:
   chrome: stable
-  postgresql: '9.5'
+  postgresql: '10'
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - postgresql-9.5-postgis-2.3
+      - postgresql-10-postgis-2.4
       - gcc-5
       - g++-5
       - chromium-chromedriver
 
 before_cache:
-    - rm -f .tox/py35-django111/log/*.log
     - rm -f .tox/py36-django111/log/*.log
     - rm -f .cache/pip/log/*.log
 cache:

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{35,36}-django111
+envlist = py{36}-django111
 skipsdist = True
 
 [tox:travis]
-3.5 = py35
 3.6 = py36
 
 [testenv]


### PR DESCRIPTION
- drop testing on python 3.5
- run tests on Postgres 10