### PR TITLE
present a single date-level elections metadata object

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -123,7 +123,7 @@ class ResidentialAddressViewSet(ViewSet, LogLookUpMixin):
                 ret["polling_station"] = polling_station
                 ret["polling_station_known"] = True
 
-        ret["metadata"] = None
+        ret["metadata"] = ee.get_metadata()
 
         if request.query_params.get("all_future_ballots", None):
             ret["ballots"] = ee.get_all_ballots()

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -115,7 +115,7 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
         if not ret["polling_station_known"] and loc:
             ret["custom_finder"] = self.generate_custom_finder(loc, postcode)
 
-        ret["metadata"] = None
+        ret["metadata"] = ee.get_metadata()
 
         if request.query_params.get("all_future_ballots", None):
             ret["ballots"] = ee.get_all_ballots()

--- a/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
+++ b/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
@@ -58,6 +58,7 @@ def get_data_with_elections(self, query_url):
             "election_id": "foo.bar.date",
             "election_title": "some election",
             "group_type": "organisation",
+            "metadata": None,
             "cancelled": False,
             "poll_open_date": datetime.now().strftime("%Y-%m-%d"),
         },  # no explanation or metadata keys
@@ -76,7 +77,7 @@ def get_data_with_elections(self, query_url):
             "group_type": None,
             "explanation": "some text",  # explanation key contains text
             "metadata": {
-                "this election": "has some metadata"
+                "2019-05-02-id-pilot": {"this election": "has an ID pilot"}
             },  # metadata key is an object
             "cancelled": False,
             "poll_open_date": datetime.now().strftime("%Y-%m-%d"),
@@ -95,6 +96,7 @@ class EveryElectionWrapperTests(TestCase):
         cancelled_info = ee.get_cancelled_election_info()
         self.assertEqual(cancelled_info["cancelled"], False)
         self.assertEqual(None, ee.get_metadata())
+        self.assertEqual(None, ee.get_id_pilot_info())
 
     @override_settings(EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True})
     @mock.patch(
@@ -108,6 +110,7 @@ class EveryElectionWrapperTests(TestCase):
         cancelled_info = ee.get_cancelled_election_info()
         self.assertEqual(cancelled_info["cancelled"], False)
         self.assertEqual(None, ee.get_metadata())
+        self.assertEqual(None, ee.get_id_pilot_info())
 
     @override_settings(EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True})
     @mock.patch(
@@ -123,7 +126,10 @@ class EveryElectionWrapperTests(TestCase):
         )
         cancelled_info = ee.get_cancelled_election_info()
         self.assertEqual(cancelled_info["cancelled"], False)
-        self.assertEqual({"this election": "has some metadata"}, ee.get_metadata())
+        self.assertEqual(
+            {"voter_id": {"this election": "has an ID pilot"}}, ee.get_metadata()
+        )
+        self.assertEqual({"this election": "has an ID pilot"}, ee.get_id_pilot_info())
 
     @override_settings(EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True})
     @mock.patch(
@@ -137,6 +143,7 @@ class EveryElectionWrapperTests(TestCase):
         cancelled_info = ee.get_cancelled_election_info()
         self.assertEqual(cancelled_info["cancelled"], False)
         self.assertEqual(None, ee.get_metadata())
+        self.assertEqual(None, ee.get_id_pilot_info())
 
     @override_settings(EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True})
     @mock.patch(
@@ -150,6 +157,7 @@ class EveryElectionWrapperTests(TestCase):
         cancelled_info = ee.get_cancelled_election_info()
         self.assertEqual(cancelled_info["cancelled"], False)
         self.assertEqual(None, ee.get_metadata())
+        self.assertEqual(None, ee.get_id_pilot_info())
 
     @override_settings(EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": False})
     @mock.patch(

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -142,10 +142,7 @@ class BasePollingStationView(
         context["has_election"] = ee.has_election()
         context["election_explainers"] = ee.get_explanations()
         context["cancelled_election"] = ee.get_cancelled_election_info()
-        metadata = ee.get_metadata()
-        context["voter_id_pilot"] = None
-        if metadata and "2018-05-03-id-pilot" in metadata:
-            context["voter_id_pilot"] = metadata["2018-05-03-id-pilot"]
+        context["voter_id_pilot"] = ee.get_id_pilot_info()
 
         context["postcode"] = self.postcode.with_space
         context["location"] = self.location


### PR DESCRIPTION
Having thought through https://github.com/DemocracyClub/UK-Polling-Stations/issues/1456 I think the right decisions to take here are:

Data model:
* Special-case voter id pilots and accept that we also need to special-case any other category of spurious election event we add
* In Every Election we must store this stuff at ballot-level not group (by convention). We seem to be standardising on the ballot object as the canonical "unit of election" we expose via our various APIs

WDIV Front-end:
* Assume we won't have >1 pilots with different requirements on the same day at the same polling station :pray:  - if there's one ballot happening with a pilot, just pick one and show that info

WDIV API:
* Continue to present a single top-level `metadata` object aggregating info from all applicable ballot objects.
* Instead of trying mash _everything_ into a consistent meta-data object (which is hard if there are >1 ballots), be slightly "editorial" about it. If there is a cancelled election, that trumps everything else. If there are >=1 ballots with an id trial, give the user one info object (again assuming we won't have >1 pilots with different requirements at the same polling station at the same time) instead of expecting them to disambiguate >1 objects.

This changes how we assemble the `metadata` object, but avoids making a backwards-incompatible API change on WDIV. Its easier for us to explain to API consumers and its easier for them to consume than having to extract this from the ballots array in their own app.

Happy to discuss this if necessary @symroe as it took me about a day to absorb all the context and get my head back into the problem-space in the end.

closes #1456