### PR TITLE
Suggest appropriate method of transport based on distance

### DIFF
--- a/polling_stations/apps/data_finder/features/index.feature
+++ b/polling_stations/apps/data_finder/features/index.feature
@@ -10,7 +10,7 @@ Feature: Check Postcodes
     Then I submit the only form
     Then The browser's URL should contain "/address/4/"
     And I should see "Your polling station"
-    And I should see "Walking directions"
+    And I should see "Walking/driving directions"
     And No errors were thrown
 
     Scenario: Check postcode with address picker invalid station id
@@ -34,7 +34,7 @@ Feature: Check Postcodes
     Then I submit the only form
     Then The browser's URL should contain "/postcode/NP205GN/"
     And I should see "Your polling station"
-    And I should see "Walking directions"
+    And I should see "Walking/driving directions"
     And No errors were thrown
 
     Scenario: Check my address not in list

--- a/polling_stations/templates/fragments/polling_station_known.html
+++ b/polling_stations/templates/fragments/polling_station_known.html
@@ -25,7 +25,7 @@
     </p>
     Get
     <a href="https://www.google.com/maps/dir/{{ location.y }},{{ location.x }}/{{ station.location.y }},{{ station.location.x }}" target="_top">
-      {% trans "Walking directions from Google" %}
+      {% trans "Walking/driving directions from Google" %}
     </a>
     or
     <a href="https://www.cyclestreets.net/journey/{{ location.y }},{{ location.x }}/{{ station.location.y }},{{ station.location.x }}/" target="_top">

--- a/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-with-address-picker-valid-station-id/then-i-submit-the-only-form.yaml
+++ b/test_data/vcr_cassettes/integration_tests/feature-check-postcodes/scenario-check-postcode-with-address-picker-valid-station-id/then-i-submit-the-only-form.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.7.0 CPython/3.4.3 Darwin/15.2.0]
     method: GET
-    uri: https://maps.googleapis.com/maps/api/directions/json?units=imperial&key=&mode=walking&origin=51.13333333333333,-3.8333333333333335&destination=51.595814835763214,-2.995147704661227
+    uri: https://maps.googleapis.com/maps/api/directions/json?units=imperial&key=&mode=driving&origin=51.13333333333333,-3.8333333333333335&destination=51.595814835763214,-2.995147704661227
   response:
     body:
       string: !!binary |


### PR DESCRIPTION
closes #1271

I've used a crude as-the-crow-flies distance instead of making 2 API calls for performance reasons (and also not rinsing our API key reasons). This is going to be a bit variable depending on how "wiggly" your route is (if you see what I mean), but it should get us into a sensible ballpark and stops us from providing overly ambitious journey suggestions like

> It's about 2.7 miles away or a 53 minute walk from [foo]

Not sure if 1.5km is the _ideal_ threshold (for the most part we're going to stop suggesting walking around the ~half hour walk mark) but this is better than it was before and we've at least now got a threshold we can tweak.