### PR TITLE
route contenttypes app to logger db

### DIFF
--- a/polling_stations/db_routers.py
+++ b/polling_stations/db_routers.py
@@ -5,6 +5,7 @@ class LoggerRouter(object):
         "auth",
         "authtoken",
         "bug_reports",
+        "contenttypes",
         "data_finder",
         "feedback",
     ]


### PR DESCRIPTION
Closes #1360

This probably causes the inverse problem if we ever try to use Generic FKs on the default DB connection, but that's probably a good incentive to.. not do that :)