### PR TITLE
Various Changes to residential address imports class

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -17,7 +17,7 @@ from django.contrib.gis import geos
 from django.contrib.gis.geos import Point, GEOSGeometry, GEOSException
 
 from councils.models import Council
-from data_collection.data_types import AddressSet, DistrictSet, StationSet
+from data_collection.data_types import AddressList, DistrictSet, StationSet
 from data_collection.data_quality_report import (
     DataQualityReportBuilder,
     StationReport,
@@ -599,7 +599,7 @@ class BaseAddressesImporter(BaseImporter, metaclass=abc.ABCMeta):
         slug = self.get_slug(address_info)
         address_info["slug"] = slug
 
-        self.addresses.add(address_info)
+        self.addresses.append(address_info)
 
 
 class BaseStationsDistrictsImporter(BaseStationsImporter, BaseDistrictsImporter):
@@ -635,7 +635,7 @@ class BaseStationsAddressesImporter(BaseStationsImporter, BaseAddressesImporter)
             pass
 
         self.stations = StationSet()
-        self.addresses = AddressSet(self.logger)
+        self.addresses = AddressList(self.logger)
         self.import_residential_addresses()
         self.import_polling_stations()
         self.addresses.save(self.batch_size)

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -192,6 +192,12 @@ class AddressList:
         self.remove_ambiguous_addresses(address_lookup, "address_slug")
 
     def remove_ambiguous_addresses_by_uprn(self):
+        """
+        Note this function assumes that UPRNs and postcodes match
+        this means we either need to ensure this function is called
+        _after_ remove_invalid_uprns() (which is what we're doing now)
+        or we'd need to switch it to index the dict on (UPRN, Postcode)
+        """
         uprn_lookup = self.get_uprn_lookup()
         self.remove_ambiguous_addresses(uprn_lookup, "uprn")
 

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -5,7 +5,11 @@ Data type classes used by base importers
 import abc
 import logging
 from collections import namedtuple
+
 from django.db import connection
+from django.forms import ValidationError
+from localflavor.gb.forms import GBPostcodeField
+
 from data_collection.slugger import Slugger
 from pollingstations.models import PollingStation, PollingDistrict, ResidentialAddress
 from uk_geo_utils.helpers import Postcode
@@ -36,6 +40,9 @@ District = namedtuple(
         "polling_station_id",
     ],
 )
+
+
+postcode_validator = GBPostcodeField()
 
 
 class CustomSet(metaclass=abc.ABCMeta):
@@ -136,8 +143,17 @@ class AddressList:
             return
 
         if address["slug"] not in self.seen:
-            self.elements.append(address)
-            self.seen.add(address["slug"])
+            try:
+                postcode_validator.clean(address["postcode"])
+                self.elements.append(address)
+                self.seen.add(address["slug"])
+            except ValidationError:
+                self.logger.log_message(
+                    logging.INFO,
+                    "Discarding record with invalid postcode:\n%s",
+                    variable=address,
+                    pretty=True,
+                )
         else:
             self.logger.log_message(
                 logging.DEBUG,

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -366,6 +366,26 @@ class AddressList:
         for e in self.elements:
             return e["council"].council_id
 
+    def report_duplicate_uprns(self):
+        uprn_counts = {}
+
+        for e in self.elements:
+            if not e["uprn"]:
+                continue
+            if e["uprn"] in uprn_counts:
+                uprn_counts[e["uprn"]] += 1
+            else:
+                uprn_counts[e["uprn"]] = 1
+
+        for uprn, count in uprn_counts.items():
+            if count > 1:
+                self.logger.log_message(
+                    logging.INFO,
+                    "Found duplicate UPRN {uprn} in Residential Addresses ({count} occurrences)".format(
+                        uprn=uprn, count=count
+                    ),
+                )
+
     def save(self, batch_size):
 
         self.remove_ambiguous_addresses_by_address()
@@ -374,6 +394,7 @@ class AddressList:
         self.attach_doorstep_gridrefs(addressbase_data)
         self.remove_addresses_outside_target_auth()
         self.remove_ambiguous_addresses_by_uprn()
+        self.report_duplicate_uprns()
 
         addresses_db = []
         for address in self.elements:

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -140,9 +140,9 @@ class AddressList:
             )
             record["address_slug"] = address_slug
             if address_slug in address_lookup:
-                address_lookup[address_slug].append(record["polling_station_id"])
+                address_lookup[address_slug].add(record["polling_station_id"])
             else:
-                address_lookup[address_slug] = [record["polling_station_id"]]
+                address_lookup[address_slug] = set([record["polling_station_id"]])
 
         return address_lookup
 

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -120,6 +120,21 @@ class AddressList:
         self.logger = logger
 
     def append(self, address):
+
+        if (
+            not address["address"]
+            or not address["postcode"]
+            or not address["council"]
+            or not address["slug"]
+        ):
+            self.logger.log_message(
+                logging.DEBUG,
+                "Record with empty required fields found:\n%s",
+                variable=address,
+                pretty=True,
+            )
+            return
+
         if address["slug"] not in self.seen:
             self.elements.append(address)
             self.seen.add(address["slug"])

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -190,6 +190,9 @@ class AddressList:
     def remove_ambiguous_addresses_by_address(self):
         address_lookup = self.get_address_lookup()
         self.remove_ambiguous_addresses(address_lookup, "address_slug")
+        # cleanup
+        for el in self.elements:
+            el.pop("address_slug")
 
     def remove_ambiguous_addresses_by_uprn(self):
         """

--- a/polling_stations/apps/data_collection/tests/test_address_list.py
+++ b/polling_stations/apps/data_collection/tests/test_address_list.py
@@ -1,5 +1,6 @@
-from data_collection.data_types import Address, AddressSet
+from copy import deepcopy
 from django.test import TestCase
+from data_collection.data_types import AddressList
 
 
 class MockLogger:
@@ -7,63 +8,59 @@ class MockLogger:
         pass
 
 
-class AddressSetTest(TestCase):
+class AddressListTest(TestCase):
     def test_add_with_duplicates(self):
         in_list = [
             {
                 "address": "foo",
                 "slug": "foo",
-                "postcode": "",
-                "council": "",
-                "polling_station_id": "",
+                "postcode": "AA11AA",
+                "council": "X01000001",
+                "polling_station_id": "01",
                 "uprn": "",
             },
             {
                 "address": "bar",
                 "slug": "bar",
-                "postcode": "",
-                "council": "",
-                "polling_station_id": "",
+                "postcode": "AA11AA",
+                "council": "X01000001",
+                "polling_station_id": "01",
                 "uprn": "",
             },
             {
                 "address": "foo",
                 "slug": "foo",
-                "postcode": "",
-                "council": "",
-                "polling_station_id": "",
+                "postcode": "AA11AA",
+                "council": "X01000001",
+                "polling_station_id": "01",
                 "uprn": "",
             },
         ]
 
-        expected = set(
-            [
-                Address(
-                    address="foo",
-                    slug="foo",
-                    postcode="",
-                    council="",
-                    polling_station_id="",
-                    uprn="",
-                    location=None,
-                ),
-                Address(
-                    address="bar",
-                    slug="bar",
-                    postcode="",
-                    council="",
-                    polling_station_id="",
-                    uprn="",
-                    location=None,
-                ),
-            ]
-        )
+        expected = [
+            {
+                "address": "foo",
+                "slug": "foo",
+                "postcode": "AA11AA",
+                "council": "X01000001",
+                "polling_station_id": "01",
+                "uprn": "",
+            },
+            {
+                "address": "bar",
+                "slug": "bar",
+                "postcode": "AA11AA",
+                "council": "X01000001",
+                "polling_station_id": "01",
+                "uprn": "",
+            },
+        ]
 
-        address_set = AddressSet(MockLogger())
+        address_list = AddressList(MockLogger())
         for el in in_list:
-            address_set.add(el)
+            address_list.append(el)
 
-        self.assertEqual(expected, address_set.elements)
+        self.assertEqual(expected, address_list.elements)
 
     def test_remove_ambiguous_addresses_exactmatch(self):
         in_list = [
@@ -71,7 +68,7 @@ class AddressSetTest(TestCase):
                 "address": "Haringey Park, London",
                 "postcode": "N89JG",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "haringey-park-london-n89jg-aa",
                 "uprn": "",
             },
@@ -79,7 +76,7 @@ class AddressSetTest(TestCase):
                 "address": "Haringey Park, London",
                 "postcode": "N89JG",
                 "polling_station_id": "AB",
-                "council": "",
+                "council": "X01000001",
                 "slug": "haringey-park-london-n89jg-ab",
                 "uprn": "",
             },
@@ -87,18 +84,18 @@ class AddressSetTest(TestCase):
                 "address": "Haringey Park, London",
                 "postcode": "N89JG",
                 "polling_station_id": "AC",
-                "council": "",
+                "council": "X01000001",
                 "slug": "haringey-park-london-n89jg-ac",
                 "uprn": "",
             },
         ]
 
-        address_set = AddressSet(MockLogger())
+        address_list = AddressList(MockLogger())
         for el in in_list:
-            address_set.add(el)
-        result = address_set.remove_ambiguous_addresses()
+            address_list.append(el)
+        address_list.remove_ambiguous_addresses_by_address()
 
-        self.assertEqual(set(), result)
+        self.assertEqual([], address_list.elements)
 
     def test_remove_ambiguous_addresses_fuzzymatch(self):
         """
@@ -118,7 +115,7 @@ class AddressSetTest(TestCase):
                 "address": "5-6 Mickleton Dr, Southport",
                 "postcode": "PR82QX",
                 "polling_station_id": "A01",
-                "council": "",
+                "council": "X01000001",
                 "slug": "a",
                 "uprn": "",
             },
@@ -126,7 +123,7 @@ class AddressSetTest(TestCase):
                 "address": "5/6, Mickleton Dr.  Southport",
                 "postcode": "PR82QX",
                 "polling_station_id": "A02",
-                "council": "",
+                "council": "X01000001",
                 "slug": "b",
                 "uprn": "",
             },
@@ -134,7 +131,7 @@ class AddressSetTest(TestCase):
                 "address": "5-6 mickleton dr southport",
                 "postcode": "PR82QX",
                 "polling_station_id": "A03",
-                "council": "",
+                "council": "X01000001",
                 "slug": "c",
                 "uprn": "",
             },
@@ -142,7 +139,7 @@ class AddressSetTest(TestCase):
                 "address": "56 Mickleton Dr, Southport",
                 "postcode": "PR82QX",
                 "polling_station_id": "A04",
-                "council": "",
+                "council": "X01000001",
                 "slug": "d",
                 "uprn": "",
             },
@@ -150,7 +147,7 @@ class AddressSetTest(TestCase):
                 "address": "5-6 Mickleton Dr, Southport",
                 "postcode": "BT281QZ",
                 "polling_station_id": "A05",
-                "council": "",
+                "council": "X01000001",
                 "slug": "e",
                 "uprn": "",
             },
@@ -158,41 +155,37 @@ class AddressSetTest(TestCase):
                 "address": "56 Mickleton Dr, Southport",
                 "postcode": "BT281QZ",
                 "polling_station_id": "A04",
-                "council": "",
+                "council": "X01000001",
                 "slug": "f",
                 "uprn": "",
             },
         ]
 
-        expected = set(
-            [
-                Address(
-                    address="5-6 Mickleton Dr, Southport",
-                    postcode="BT281QZ",
-                    polling_station_id="A05",
-                    council="",
-                    slug="e",
-                    uprn="",
-                    location=None,
-                ),
-                Address(
-                    address="56 Mickleton Dr, Southport",
-                    postcode="BT281QZ",
-                    polling_station_id="A04",
-                    council="",
-                    slug="f",
-                    uprn="",
-                    location=None,
-                ),
-            ]
-        )
+        expected = [
+            {
+                "address": "5-6 Mickleton Dr, Southport",
+                "postcode": "BT281QZ",
+                "polling_station_id": "A05",
+                "council": "X01000001",
+                "slug": "e",
+                "uprn": "",
+            },
+            {
+                "address": "56 Mickleton Dr, Southport",
+                "postcode": "BT281QZ",
+                "polling_station_id": "A04",
+                "council": "X01000001",
+                "slug": "f",
+                "uprn": "",
+            },
+        ]
 
-        address_set = AddressSet(MockLogger())
+        address_list = AddressList(MockLogger())
         for el in in_list:
-            address_set.add(el)
-        result = address_set.remove_ambiguous_addresses()
+            address_list.append(el)
+        address_list.remove_ambiguous_addresses_by_address()
 
-        self.assertEqual(expected, result)
+        self.assertEqual(expected, address_list.elements)
 
     def test_remove_ambiguous_addresses_some_stations_match(self):
         # if one polling station doesn't match, we should remove all of them
@@ -201,7 +194,7 @@ class AddressSetTest(TestCase):
                 "address": "Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "a",
                 "uprn": "",
             },
@@ -209,7 +202,7 @@ class AddressSetTest(TestCase):
                 "address": "Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "b",
                 "uprn": "",
             },
@@ -217,7 +210,7 @@ class AddressSetTest(TestCase):
                 "address": "Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AB",
-                "council": "",
+                "council": "X01000001",
                 "slug": "c",
                 "uprn": "",
             },
@@ -225,18 +218,19 @@ class AddressSetTest(TestCase):
                 "address": "Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "d",
                 "uprn": "",
             },
         ]
 
-        address_set = AddressSet(MockLogger())
+        address_list = AddressList(MockLogger())
         for el in in_list:
-            address_set.add(el)
-        result = address_set.remove_ambiguous_addresses()
+            address_list.append(el)
 
-        self.assertEqual(set(), result)
+        self.assertEqual(4, len(address_list.elements))
+        address_list.remove_ambiguous_addresses_by_address()
+        self.assertEqual([], address_list.elements)
 
     def test_remove_ambiguous_addresses_whole_postcode(self):
         # if we've got one ambiguous address,
@@ -246,7 +240,7 @@ class AddressSetTest(TestCase):
                 "address": "1 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "a",
                 "uprn": "",
             },
@@ -254,7 +248,7 @@ class AddressSetTest(TestCase):
                 "address": "2 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "b",
                 "uprn": "",
             },
@@ -262,7 +256,7 @@ class AddressSetTest(TestCase):
                 "address": "3 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AB",
-                "council": "",
+                "council": "X01000001",
                 "slug": "c",
                 "uprn": "",
             },
@@ -270,18 +264,19 @@ class AddressSetTest(TestCase):
                 "address": "3 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "d",
                 "uprn": "",
             },
         ]
 
-        address_set = AddressSet(MockLogger())
+        address_list = AddressList(MockLogger())
         for el in in_list:
-            address_set.add(el)
-        result = address_set.remove_ambiguous_addresses()
+            address_list.append(el)
 
-        self.assertEqual(set(), result)
+        self.assertEqual(4, len(address_list.elements))
+        address_list.remove_ambiguous_addresses_by_address()
+        self.assertEqual([], address_list.elements)
 
     def test_remove_ambiguous_addresses_no_issues(self):
         # if there are no ambiguous addresses,
@@ -292,7 +287,7 @@ class AddressSetTest(TestCase):
                 "address": "1 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "a",
                 "uprn": "",
             },
@@ -300,7 +295,7 @@ class AddressSetTest(TestCase):
                 "address": "2 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "b",
                 "uprn": "",
             },
@@ -308,7 +303,7 @@ class AddressSetTest(TestCase):
                 "address": "3 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AB",
-                "council": "",
+                "council": "X01000001",
                 "slug": "c",
                 "uprn": "",
             },
@@ -316,19 +311,19 @@ class AddressSetTest(TestCase):
                 "address": "4 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "d",
                 "uprn": "",
             },
         ]
 
-        address_set = AddressSet(MockLogger())
+        address_list = AddressList(MockLogger())
         for el in in_list:
-            address_set.add(el)
-        expected = set(address_set.elements)
-        result = address_set.remove_ambiguous_addresses()
+            address_list.append(el)
 
-        self.assertEqual(expected, result)
+        expected = deepcopy(address_list.elements)
+        address_list.remove_ambiguous_addresses_by_address()
+        self.assertEqual(expected, address_list.elements)
 
     def test_attach_doorstep_grid_refs(self):
         in_list = [
@@ -336,7 +331,7 @@ class AddressSetTest(TestCase):
                 "address": "1 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "a",
                 "uprn": "00001",
             },
@@ -344,29 +339,31 @@ class AddressSetTest(TestCase):
                 "address": "4 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "d",
                 "uprn": "00004",
             },
         ]
 
-        address_set = AddressSet(MockLogger())
+        address_list = AddressList(MockLogger())
         for el in in_list:
-            address_set.add(el)
+            address_list.append(el)
 
         addressbase = {
             # 00001 is in here but 00004 isn't
             "00001": {"location": "SRID=4326;POINT(-0.9288492 53.3119342)"}
         }
 
-        address_set.elements = address_set.attach_doorstep_gridrefs(addressbase)
+        address_list.attach_doorstep_gridrefs(addressbase)
 
-        self.assertEqual(2, len(address_set.elements))
-        for el in address_set.elements:
-            if el.uprn == "00001":
-                self.assertEqual("SRID=4326;POINT(-0.9288492 53.3119342)", el.location)
-            if el.uprn == "00004":
-                self.assertEqual(None, el.location)
+        self.assertEqual(2, len(address_list.elements))
+        for el in address_list.elements:
+            if el["uprn"] == "00001":
+                self.assertEqual(
+                    "SRID=4326;POINT(-0.9288492 53.3119342)", el["location"]
+                )
+            if el["uprn"] == "00004":
+                self.assertEqual(None, el.get("location", None))
 
     def test_remove_invalid_uprns(self):
         in_list = [
@@ -374,7 +371,7 @@ class AddressSetTest(TestCase):
                 "address": "1 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "a",
                 "uprn": "00001",
             },
@@ -382,7 +379,7 @@ class AddressSetTest(TestCase):
                 "address": "2 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "b",
                 "uprn": "00002",
             },
@@ -390,7 +387,7 @@ class AddressSetTest(TestCase):
                 "address": "3 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AB",
-                "council": "",
+                "council": "X01000001",
                 "slug": "c",
                 "uprn": "00003",
             },
@@ -398,15 +395,15 @@ class AddressSetTest(TestCase):
                 "address": "4 Abbeyvale Dr, Liverpool",
                 "postcode": "L252NW",
                 "polling_station_id": "AA",
-                "council": "",
+                "council": "X01000001",
                 "slug": "d",
                 "uprn": "00004",
             },
         ]
 
-        address_set = AddressSet(MockLogger())
+        address_list = AddressList(MockLogger())
         for el in in_list:
-            address_set.add(el)
+            address_list.append(el)
 
         addressbase = {
             "00001": {
@@ -427,10 +424,10 @@ class AddressSetTest(TestCase):
             # 00004 is not in here
         }
 
-        address_set.elements = address_set.remove_invalid_uprns(addressbase)
+        address_list.remove_invalid_uprns(addressbase)
 
         # 00003 and 00004 should still be in the set
-        self.assertEqual(4, len(address_set.elements))
+        self.assertEqual(4, len(address_list.elements))
         # but those records should now have a blank uprn
-        for el in address_set.elements:
-            assert el.uprn in ["00001", "00002", ""]
+        for el in address_list.elements:
+            assert el["uprn"] in ["00001", "00002", ""]

--- a/polling_stations/apps/data_collection/tests/test_address_list.py
+++ b/polling_stations/apps/data_collection/tests/test_address_list.py
@@ -62,7 +62,7 @@ class AddressListTest(TestCase):
 
         self.assertEqual(expected, address_list.elements)
 
-    def test_remove_ambiguous_addresses_exactmatch(self):
+    def test_remove_ambiguous_addresses_by_address_exactmatch(self):
         in_list = [
             {
                 "address": "Haringey Park, London",
@@ -97,7 +97,98 @@ class AddressListTest(TestCase):
 
         self.assertEqual([], address_list.elements)
 
-    def test_remove_ambiguous_addresses_fuzzymatch(self):
+    def test_remove_ambiguous_addresses_by_uprn_nomatches(self):
+        in_list = [
+            {
+                "address": "1 Haringey Park, London",
+                "postcode": "N89JG",
+                "polling_station_id": "AA",
+                "council": "X01000001",
+                "slug": "1-haringey-park-london-n89jg-aa",
+                "uprn": "1001",
+            },
+            {
+                "address": "2 Haringey Park, London",
+                "postcode": "N89JG",
+                "polling_station_id": "AB",
+                "council": "X01000001",
+                "slug": "2-haringey-park-london-n89jg-ab",
+                "uprn": "1002",
+            },
+            {
+                "address": "3 Haringey Park, London",
+                "postcode": "N89JG",
+                "polling_station_id": "AB",
+                "council": "X01000001",
+                "slug": "3-haringey-park-london-n89jg-ab",
+                "uprn": "1003",
+            },
+        ]
+
+        # Everything has a unique UPRN
+        # so we shouldn't remove anything
+        expected = in_list
+
+        address_list = AddressList(MockLogger())
+        for el in in_list:
+            address_list.append(el)
+        address_list.remove_ambiguous_addresses_by_uprn()
+
+        self.assertEqual(expected, address_list.elements)
+
+    def test_remove_ambiguous_addresses_by_uprn_withmatches(self):
+        in_list = [
+            {
+                "address": "1 Haringey Park, London",
+                "postcode": "N89JG",
+                "polling_station_id": "AA",
+                "council": "X01000001",
+                "slug": "1-haringey-park-london-n89jg-aa",
+                "uprn": "1001",
+            },
+            {
+                "address": "2 Haringey Park, London",
+                "postcode": "N89JG",
+                "polling_station_id": "AB",
+                "council": "X01000001",
+                "slug": "2-haringey-park-london-n89jg-ab",
+                "uprn": "1001",
+            },
+            {
+                "address": "3 Haringey Park, London",
+                "postcode": "N89JG",
+                "polling_station_id": "AB",
+                "council": "X01000001",
+                "slug": "3-haringey-park-london-n89jg-ab",
+                "uprn": "1003",
+            },
+            {
+                "address": "4 Haringey Park, London",
+                "postcode": "N89JH",
+                "polling_station_id": "AC",
+                "council": "X01000001",
+                "slug": "4-haringey-park-london-n89jh-ac",
+                "uprn": "1004",
+            },
+        ]
+
+        """
+        1 Haringey Park, London and
+        2 Haringey Park, London
+        both have the same UPRN (1001) but they map to different stations
+        so we should remove all the N89JG addresses, leaving only
+        4 Haringey Park, London
+        """
+        expected = [in_list[3]]
+
+        address_list = AddressList(MockLogger())
+        for el in in_list:
+            address_list.append(el)
+        address_list.remove_ambiguous_addresses_by_uprn()
+
+        self.assertEqual(expected, address_list.elements)
+
+    def test_remove_ambiguous_addresses_by_address_fuzzymatch(self):
         """
         The addresses:
         - 5-6 Mickleton Dr, Southport, PR82QX
@@ -187,7 +278,7 @@ class AddressListTest(TestCase):
 
         self.assertEqual(expected, address_list.elements)
 
-    def test_remove_ambiguous_addresses_some_stations_match(self):
+    def test_remove_ambiguous_addresses_by_address_some_stations_match(self):
         # if one polling station doesn't match, we should remove all of them
         in_list = [
             {
@@ -232,7 +323,7 @@ class AddressListTest(TestCase):
         address_list.remove_ambiguous_addresses_by_address()
         self.assertEqual([], address_list.elements)
 
-    def test_remove_ambiguous_addresses_whole_postcode(self):
+    def test_remove_ambiguous_addresses_by_address_whole_postcode(self):
         # if we've got one ambiguous address,
         # we should remove all addresse with the same postcode
         in_list = [
@@ -278,7 +369,7 @@ class AddressListTest(TestCase):
         address_list.remove_ambiguous_addresses_by_address()
         self.assertEqual([], address_list.elements)
 
-    def test_remove_ambiguous_addresses_no_issues(self):
+    def test_remove_ambiguous_addresses_by_address_no_issues(self):
         # if there are no ambiguous addresses,
         # we shouldn't do anything
 


### PR DESCRIPTION
Sorry - this PR bundles together more changes into 1 PR than is really ideal.

Broad categories of stuff happening here:

## 1. Refactor AddressSet

Closes #1205

Instead of

- storing data as a set of namedtuples
- converting to a list of dicts
- changing the data
- changing it back to a set of namedtuples

every time we want to change something, just store it as a list of dicts all the way through the process. This should make things a bit more readable as well as improving performance.

## 2. Check for duplicate UPRNs on import

Closes #1329

Predictably, this is not completely clear-cut - a UPRN duplicate isn't necessarily a hard error. Sometimes we get multiple addresses with the same UPRN and its not actually a problem (or not one that we care about, at least). An example of this is sometimes we might see 2A High Street and 2B High Street with the same UPRN (which is the parent/type D UPRN for 2 High Street), or a property (incorrectly) has next door's UPRN, but we don't care because all the addresses and postcodes are correct and everyone with that postcode maps to the same polling station so we don't use the UPRN. Also this obviously varies between councils, EMS suppliers, etc.

Having played with it a bit, I think the situation where this generally indicates a problem is if we've got 2 different addresses with the same UPRN and they have the same postcode but map to 2 different polling stations, so I've gone with that (enforcing the same postcode requirement by calling `remove_ambiguous_addresses_by_uprn()` after `remove_invalid_uprns()`. If we've got duplicate UPRNs and they have mismatching postcodes, we deal with that in `remove_invalid_uprns()` and if they have the same postcode and map to the same polling station, then we probably don't care but we do report it afterwards so we can check them manually.

I think in general, I do also want to have another look at `remove_invalid_uprns()` but I think I'm going to leave that for another PR but assume we'll retain the assumption that by the time we get to `remove_ambiguous_addresses_by_uprn()` we will have already (somehow) resolved postcode/UPRN disagreements.

## 3. Picture-check postcodes on ResidentialAddress import

Closes #1321

This performs a regex check on every postcode to ensure its valid before we import it. If it isn't, discard it (it won't be reachable from the front-end anyway) and log it (if we know its happened, we might be able to correct it).