### PR TITLE
Revert "be smarter if residential UPRN and postcode don't match"

### DIFF
--- a/polling_stations/apps/data_collection/tests/test_address_list.py
+++ b/polling_stations/apps/data_collection/tests/test_address_list.py
@@ -456,7 +456,7 @@ class AddressListTest(TestCase):
             if el["uprn"] == "00004":
                 self.assertEqual(None, el.get("location", None))
 
-    def test_remove_invalid_uprns_autofix_postcode(self):
+    def test_remove_invalid_uprns(self):
         in_list = [
             {
                 "address": "1 Abbeyvale Dr, Liverpool",
@@ -476,65 +476,7 @@ class AddressListTest(TestCase):
             },
             {
                 "address": "3 Abbeyvale Dr, Liverpool",
-                "postcode": "L252XX",
-                "polling_station_id": "AB",
-                "council": "X01000001",
-                "slug": "c",
-                "uprn": "00003",
-            },
-        ]
-
-        address_list = AddressList(MockLogger())
-        for el in in_list:
-            address_list.append(el)
-
-        addressbase = {
-            "00001": {
                 "postcode": "L252NW",
-                "address": "1 Abbeyvale Dr, Liverpool",
-                "location": "SRID=4326;POINT(-0.9288492 53.3119342)",
-            },
-            "00002": {
-                "postcode": "L252NW",
-                "address": "2 Abbeyvale Dr, Liverpool",
-                "location": "SRID=4326;POINT(-0.9288480 53.3119345)",
-            },
-            "00003": {
-                "postcode": "L252NW",  # this postcode doesn't match with the input record
-                "address": "3 Abbeyvale Dr, Liverpool",
-                "location": "SRID=4326;POINT(-0.9288400 53.3119332)",
-            },
-        }
-
-        address_list.handle_invalid_uprns(addressbase)
-
-        # all the records should still be in the set
-        self.assertEqual(3, len(address_list.elements))
-        # We should have auto-corrected L252XX to L252NW
-        for el in address_list.elements:
-            self.assertEqual(el["postcode"], "L252NW")
-
-    def test_remove_invalid_uprns_remove_uprn(self):
-        in_list = [
-            {
-                "address": "1 Abbeyvale Dr, Liverpool",
-                "postcode": "L252NW",
-                "polling_station_id": "AA",
-                "council": "X01000001",
-                "slug": "a",
-                "uprn": "00001",
-            },
-            {
-                "address": "2 Abbeyvale Dr, Liverpool",
-                "postcode": "L252NW",
-                "polling_station_id": "AA",
-                "council": "X01000001",
-                "slug": "b",
-                "uprn": "00002",
-            },
-            {
-                "address": "3 Abbeyvale Street, Liverpool",
-                "postcode": "L252XX",
                 "polling_station_id": "AB",
                 "council": "X01000001",
                 "slug": "c",
@@ -566,14 +508,14 @@ class AddressListTest(TestCase):
                 "location": "SRID=4326;POINT(-0.9288480 53.3119345)",
             },
             "00003": {
-                "postcode": "L252NW",  # this postcode doesn't match with the input record
-                "address": "3 Abbeyvale Dr, Liverpool",  # and neither does this address
+                "postcode": "L252XX",  # this postcode doesn't match with the input record
+                "address": "2 Abbeyvale Dr, Liverpool",
                 "location": "SRID=4326;POINT(-0.9288400 53.3119332)",
             }
             # 00004 is not in here
         }
 
-        address_list.handle_invalid_uprns(addressbase)
+        address_list.remove_invalid_uprns(addressbase)
 
         # 00003 and 00004 should still be in the set
         self.assertEqual(4, len(address_list.elements))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,11 +9,9 @@ djangorestframework==3.9.1
 djangorestframework-gis==0.14
 django-cors-headers==2.4.0
 fastkml==0.11
-fuzzywuzzy==0.17.0
 lxml==4.3.1
 psycopg2-binary==2.7.7
 pyshp==2.0.1
-python-levenshtein==0.12.0
 raven==6.10.0
 requests==2.21.0
 retry==0.9.2


### PR DESCRIPTION
This reverts commit 1fbc213cba7f573933085376e3c770994f72f047.

Having spent a bit of time with 2 of us working with this, I've decided to back it out for now. I think there is merit in the approach, but in this exact form, although we're fixing some issues, we're also _introducing_ new errors and doing it in a way that is hard to undo. Needs more thought/testing