### PR TITLE
be smarter if residential UPRN and postcode don't match (part 2)

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -623,6 +623,10 @@ class BaseStationsDistrictsImporter(BaseStationsImporter, BaseDistrictsImporter)
 
 
 class BaseStationsAddressesImporter(BaseStationsImporter, BaseAddressesImporter):
+
+    fuzzy_match = True
+    match_threshold = 100
+
     def pre_import(self):
         raise NotImplementedError
 
@@ -638,7 +642,7 @@ class BaseStationsAddressesImporter(BaseStationsImporter, BaseAddressesImporter)
         self.addresses = AddressList(self.logger)
         self.import_residential_addresses()
         self.import_polling_stations()
-        self.addresses.save(self.batch_size)
+        self.addresses.save(self.batch_size, self.fuzzy_match, self.match_threshold)
         self.stations.save()
 
 

--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -253,7 +253,7 @@ class BaseStationsImporter(BaseImporter, metaclass=abc.ABCMeta):
                 if council.council_id != self.council_id:
                     self.logger.log_message(
                         logging.WARNING,
-                        "Polling station %s is in %s (%s) but target council is %s (%s) - manual check recommended",
+                        "Polling station %s is in %s (%s) but target council is %s (%s) - manual check recommended\n",
                         variable=(
                             station_record["internal_council_id"],
                             council.name,
@@ -265,7 +265,7 @@ class BaseStationsImporter(BaseImporter, metaclass=abc.ABCMeta):
             except Council.DoesNotExist:
                 self.logger.log_message(
                     logging.WARNING,
-                    "Polling station %s is not covered by any council area - manual check recommended",
+                    "Polling station %s is not covered by any council area - manual check recommended\n",
                     variable=(station_record["internal_council_id"]),
                 )
 
@@ -569,6 +569,7 @@ class BaseAddressesImporter(BaseImporter, metaclass=abc.ABCMeta):
         self.write_info(
             "Addresses: Found {:,} rows in input file".format(len(addresses))
         )
+        self.write_info("----------------------------------")
         for address in addresses:
             address_info = self.address_record_to_dict(address)
 

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -151,7 +151,7 @@ class AddressList:
             except ValidationError:
                 self.logger.log_message(
                     logging.WARNING,
-                    "Discarding record with invalid postcode:\n%s",
+                    "Discarding record with invalid postcode:\n%s\n",
                     variable=address,
                     pretty=True,
                 )
@@ -429,7 +429,7 @@ class AddressList:
                     loglevel = logging.WARNING
                 self.logger.log_message(
                     loglevel,
-                    "Discarding record: Postcode centroid is outside target local authority:\n%s",
+                    "Discarding record: Postcode centroid is outside target local authority:\n%s\n",
                     variable=record,
                     pretty=True,
                 )

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 
 from django.db import connection
 from django.forms import ValidationError
+from fuzzywuzzy import fuzz
 from localflavor.gb.forms import GBPostcodeField
 
 from addressbase.models import Blacklist
@@ -164,7 +165,7 @@ class AddressList:
             )
 
     def get_address_lookup(self):
-        # for each address, build a lookup of address -> list of station ids
+        # for each address, build a lookup of address -> set of station ids
         address_lookup = {}
         for record in self.elements:
             address_slug = Slugger.slugify(
@@ -179,7 +180,7 @@ class AddressList:
         return address_lookup
 
     def get_uprn_lookup(self):
-        # for each address, build a lookup of uprn -> list of station ids
+        # for each address, build a lookup of uprn -> set of station ids
         uprn_lookup = {}
         for record in self.elements:
             uprn = record["uprn"]
@@ -191,6 +192,18 @@ class AddressList:
                 uprn_lookup[uprn] = set([record["polling_station_id"]])
 
         return uprn_lookup
+
+    def get_postcode_lookup(self):
+        # for each address, build a lookup of address -> set of station ids
+        postcode_lookup = {}
+        for record in self.elements:
+            postcode = record["postcode"]
+            if postcode in postcode_lookup:
+                postcode_lookup[postcode].add(record["polling_station_id"])
+            else:
+                postcode_lookup[postcode] = set([record["polling_station_id"]])
+
+        return postcode_lookup
 
     def get_ambiguous_postcodes(self, lookup, key):
         # build a set of postcodes containing
@@ -215,7 +228,7 @@ class AddressList:
         """
         Note this function assumes that UPRNs and postcodes match
         this means we either need to ensure this function is called
-        _after_ remove_invalid_uprns() (which is what we're doing now)
+        _after_ handle_invalid_uprns() (which is what we're doing now)
         or we'd need to switch it to index the dict on (UPRN, Postcode)
         """
         uprn_lookup = self.get_uprn_lookup()
@@ -254,8 +267,15 @@ class AddressList:
             if record["uprn"] in addressbase_data:
                 record["location"] = addressbase_data[record["uprn"]]["location"]
 
-    def remove_invalid_uprns(self, addressbase_data):
+    def handle_invalid_uprns(self, addressbase_data, fuzzy_match, match_threshold):
+        postcode_lookup = self.get_postcode_lookup()
+
+        def is_split_postcode(postcode):
+            return postcode in postcode_lookup and len(postcode_lookup[postcode]) > 1
+
         for record in self.elements:
+            if not record["uprn"]:
+                continue
 
             # if the UPRN attached to the input record isn't present
             # in the data we fetched from AddressBase, discard the UPRN
@@ -268,17 +288,66 @@ class AddressList:
                 record["uprn"] = ""
                 continue
 
-            # if the UPRN attached to the input record is present
-            # in the data we fetched from AddressBase, but the postcode
-            # on the input record doesn't match the postcode on the
-            # record from AddressBase, discard the UPRN
-            if record["postcode"] != addressbase_data[record["uprn"]]["postcode"]:
-                self.logger.log_message(
-                    logging.INFO,
-                    "Removing UPRN due to postcode mismatch.\nInput Record:\n%s\nAddressbase record:\n%s",
-                    variable=(record, addressbase_data[record["uprn"]]),
+            addressbase_record = addressbase_data[record["uprn"]]
+            if record["postcode"] != addressbase_record["postcode"]:
+                # The UPRN attached to the input record is present
+                # in the data we fetched from AddressBase, but the postcode
+                # on the input record doesn't match the postcode on the
+                # record from AddressBase
+
+                if not fuzzy_match:
+                    self.logger.log_message(
+                        logging.INFO,
+                        "Removing UPRN due to postcode mismatch.\nInput Record:\n%s\nAddressbase record:\n%s",
+                        variable=(record, addressbase_data[record["uprn"]]),
+                    )
+                    record["uprn"] = ""
+                    continue
+
+                match_quality = fuzz.partial_ratio(
+                    record["address"].lower().replace(",", ""),
+                    addressbase_record["address"].lower().replace(",", ""),
                 )
-                record["uprn"] = ""
+
+                if match_quality >= match_threshold:
+                    # If [input record address] and [addressbase record address]
+                    # are match_threshold% the same, assume the postcode on
+                    # [input record] is wrong and fix [input record]
+                    # with the postcode from addressbase
+                    self.logger.log_message(
+                        logging.INFO,
+                        "Correcting postcode based on UPRN and fuzzy match.\nInput Record:\n%s\nAddressbase record:\n%s\nMatch quality: %s\n",
+                        variable=(record, addressbase_record, match_quality),
+                    )
+                    record["postcode"] = addressbase_record["postcode"]
+                else:
+                    if (
+                        is_split_postcode(record["postcode"])
+                        or is_split_postcode(addressbase_record["postcode"])
+                        or (
+                            record["postcode"] in postcode_lookup
+                            and addressbase_record["postcode"] in postcode_lookup
+                            and postcode_lookup[record["postcode"]]
+                            != postcode_lookup[addressbase_record["postcode"]]
+                        )
+                    ):
+                        # this needs manual review
+                        loglevel = logging.WARNING
+                    else:
+                        # if neither postcode it split or if moving the address
+                        # from one district to the other would make no difference
+                        # this _probably_ doesn't matter
+                        loglevel = logging.INFO
+
+                    # If [input record address] and [addressbase record address]
+                    # are less than match_threshold% the same, assume the UPRN on
+                    # [input record] is wrong and remove the UPRN from [input record]
+                    self.logger.log_message(
+                        loglevel,
+                        "Removing UPRN due to postcode mismatch.\nInput Record:\n%s\nAddressbase record:\n%s\nMatch quality: %s\n",
+                        variable=(record, addressbase_record, match_quality),
+                    )
+                    record["uprn"] = ""
 
     def get_uprns_from_addressbase(self):
         # get all the UPRNs in target local auth
@@ -308,7 +377,7 @@ class AddressList:
         Remove any addresses with a postcode which appears in our input data
         but where the postcode centroid is outside the target local auth.
 
-        As long as we're calling this after remove_invalid_uprns()
+        As long as we're calling this after handle_invalid_uprns()
         We can take a massive shortcut for performance here
         and only look at input records where the uprn is empty
         because by definition (see get_uprns_from_addressbase() )
@@ -391,11 +460,11 @@ class AddressList:
                     ),
                 )
 
-    def save(self, batch_size):
+    def save(self, batch_size, fuzzy_match, match_threshold):
 
         self.remove_ambiguous_addresses_by_address()
         addressbase_data = self.get_uprns_from_addressbase()
-        self.remove_invalid_uprns(addressbase_data)
+        self.handle_invalid_uprns(addressbase_data, fuzzy_match, match_threshold)
         self.attach_doorstep_gridrefs(addressbase_data)
         self.remove_addresses_outside_target_auth()
         self.remove_ambiguous_addresses_by_uprn()

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -309,7 +309,10 @@ class AddressList:
                     addressbase_record["address"].lower().replace(",", ""),
                 )
 
-                if match_quality >= match_threshold:
+                accept_suggestion = record.get(
+                    "accept_suggestion", (match_quality >= match_threshold)
+                )
+                if accept_suggestion:
                     # If [input record address] and [addressbase record address]
                     # are match_threshold% the same, assume the postcode on
                     # [input record] is wrong and fix [input record]
@@ -333,8 +336,14 @@ class AddressList:
                     ):
                         # this needs manual review
                         loglevel = logging.WARNING
-                        bad_postcodes.add(record["postcode"])
-                        bad_postcodes.add(addressbase_record["postcode"])
+
+                        if record.get("accept_suggestion", True):
+                            bad_postcodes.add(record["postcode"])
+                            bad_postcodes.add(addressbase_record["postcode"])
+                        # if we _explicitly_ set
+                        # record["accept_suggestion"] = False
+                        # in the import script, don't delete anything
+
                     else:
                         # if neither postcode it split or if moving the address
                         # from one district to the other would make no difference

--- a/polling_stations/apps/data_collection/management/commands/import_ashfield.py
+++ b/polling_stations/apps/data_collection/management/commands/import_ashfield.py
@@ -15,24 +15,9 @@ class Command(BaseXpressDemocracyClubCsvImporter):
     def address_record_to_dict(self, record):
         uprn = record.property_urn.strip().lstrip("0")
 
-        if uprn == "10001344107":
+        if uprn in ["100031234554", "100031241226", "10001342248", "10070852165"]:
             rec = super().address_record_to_dict(record)
-            rec["postcode"] = "NG15 8JA"
-            return rec
-
-        if uprn == "10001337112":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "NG17 4FU"
-            return rec
-
-        if uprn == "10001342248":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "NG17 1FU"
-            return rec
-
-        if uprn == "10070852165":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "NG17 8HS"
+            rec["accept_suggestion"] = True
             return rec
 
         return super().address_record_to_dict(record)

--- a/polling_stations/apps/data_collection/management/commands/import_basingstoke.py
+++ b/polling_stations/apps/data_collection/management/commands/import_basingstoke.py
@@ -15,12 +15,9 @@ class Command(BaseXpressDemocracyClubCsvImporter):
     def address_record_to_dict(self, record):
         uprn = record.property_urn.strip().lstrip("0")
 
-        if uprn == "10008483736":
+        if uprn in ["100062463351"]:
             rec = super().address_record_to_dict(record)
-            rec["postcode"] = "RG19 8LB"
+            rec["accept_suggestion"] = True
             return rec
-
-        if record.addressline6.strip() == "RG24 7AY":
-            return None
 
         return super().address_record_to_dict(record)

--- a/polling_stations/apps/data_collection/management/commands/import_derbyshire_dales.py
+++ b/polling_stations/apps/data_collection/management/commands/import_derbyshire_dales.py
@@ -8,4 +8,10 @@ class Command(BaseDemocracyCountsCsvImporter):
     elections = ["local.2019-05-02"]
 
     def address_record_to_dict(self, record):
-        return super().address_record_to_dict(record)
+        rec = super().address_record_to_dict(record)
+        uprn = record.uprn.strip().lstrip("0")
+
+        if uprn in ["10010331972", "10010331834", "10070090689"]:
+            rec["accept_suggestion"] = True
+
+        return rec

--- a/polling_stations/apps/data_collection/management/commands/import_fylde.py
+++ b/polling_stations/apps/data_collection/management/commands/import_fylde.py
@@ -6,6 +6,7 @@ class Command(BaseXpressDemocracyClubCsvImporter):
     addresses_name = "local.2019-05-02/Version 1/Fylde-Democracy_Club__02May2019.csv"
     stations_name = "local.2019-05-02/Version 1/Fylde-Democracy_Club__02May2019.csv"
     elections = ["local.2019-05-02"]
+    match_threshold = 98
 
     def address_record_to_dict(self, record):
         uprn = record.property_urn.strip().lstrip("0")
@@ -23,6 +24,20 @@ class Command(BaseXpressDemocracyClubCsvImporter):
         if uprn == "200001128516":
             rec = super().address_record_to_dict(record)
             rec["postcode"] = "FY6 9BU"
+            return rec
+
+        if uprn in [
+            "10013591588",
+            "100010405565",
+            "100012620334",
+            "100010399571",
+            "100012619511",
+            "100012620275",
+            "100012618650",
+            "100010401469",
+        ]:
+            rec = super().address_record_to_dict(record)
+            rec["accept_suggestion"] = True
             return rec
 
         return super().address_record_to_dict(record)

--- a/polling_stations/apps/data_collection/management/commands/import_hartlepool.py
+++ b/polling_stations/apps/data_collection/management/commands/import_hartlepool.py
@@ -33,13 +33,13 @@ class Command(BaseXpressDemocracyClubCsvImporter):
         }
 
         # corrections
-        if postcode == "TS22 5QE":
-            ret["postcode"] = "TS22 5FY"
-        if postcode == "TS25 2HE":
+        if postcode in ["TS25 2HE", "TS24 0HJ"]:
             return None
-        if uprn == "10090070423":
-            ret["postcode"] = "TS25 2DY"
-        if uprn == "10090070227":
-            ret["postcode"] = "TS25 2BF"
+
+        if uprn in ["10090068484", "10009734034", "100110786034"]:
+            ret["accept_suggestion"] = True
+
+        if uprn in ["100110673453", "100110673049"]:
+            ret["accept_suggestion"] = False
 
         return ret

--- a/polling_stations/apps/data_collection/management/commands/import_ipswich.py
+++ b/polling_stations/apps/data_collection/management/commands/import_ipswich.py
@@ -6,3 +6,13 @@ class Command(BaseXpressDemocracyClubCsvImporter):
     addresses_name = "local.2019-05-02/Version 1/Democracy_Club__02May2019 Ipswich.CSV"
     stations_name = "local.2019-05-02/Version 1/Democracy_Club__02May2019 Ipswich.CSV"
     elections = ["local.2019-05-02"]
+
+    def address_record_to_dict(self, record):
+        uprn = record.property_urn.strip().lstrip("0")
+
+        if uprn in ["100091636692", "10093555116", "100091482960"]:
+            rec = super().address_record_to_dict(record)
+            rec["accept_suggestion"] = True
+            return rec
+
+        return super().address_record_to_dict(record)

--- a/polling_stations/apps/data_collection/management/commands/import_manchester.py
+++ b/polling_stations/apps/data_collection/management/commands/import_manchester.py
@@ -48,4 +48,14 @@ class Command(BaseXpressDCCsvInconsistentPostcodesImporter):
         ):
             rec["postcode"] = "M14 5EU"
 
+        # invalid postcodes
+        if record.addressline6.strip() == "M13 OFN":
+            rec["postcode"] = "M13 0FN"
+
+        if record.addressline6.strip() == "M11 IJJ":
+            rec["postcode"] = "M11 1JJ"
+
+        if record.addressline6.strip() == "M22 OJA":
+            rec["postcode"] = "M22 0JA"
+
         return rec

--- a/polling_stations/apps/data_collection/management/commands/import_portsmouth.py
+++ b/polling_stations/apps/data_collection/management/commands/import_portsmouth.py
@@ -13,16 +13,15 @@ class Command(BaseXpressDemocracyClubCsvImporter):
 
     def address_record_to_dict(self, record):
         rec = super().address_record_to_dict(record)
+        uprn = record.property_urn.strip().lstrip("0")
 
         if record.addressline6 == "PO4 099":
             rec["postcode"] = "PO4 0PL"
 
-        if record.property_urn.strip().lstrip("0") in [
-            "1775122942",
-            "1775122943",
-            "1775122944",
-        ]:
-            rec["postcode"] = "PO5 2BZ"
+        if uprn in ["1775078308", "1775035998", "1775002824", "1775002823"]:
+            rec = super().address_record_to_dict(record)
+            rec["accept_suggestion"] = True
+            return rec
 
         return rec
 

--- a/polling_stations/apps/data_collection/management/commands/import_redcar_cleveland.py
+++ b/polling_stations/apps/data_collection/management/commands/import_redcar_cleveland.py
@@ -9,26 +9,21 @@ class Command(BaseXpressDemocracyClubCsvImporter):
     csv_delimiter = "\t"
 
     def address_record_to_dict(self, record):
+        rec = super().address_record_to_dict(record)
         uprn = record.property_urn.strip().lstrip("0")
 
-        if uprn == "100110675731":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "TS134EA"
-            return rec
+        if uprn in [
+            "10034518861",
+            "100110675731",
+            "200002523561",
+            "10023902772",
+            "10023902773",
+            "200002523768",
+            "200002523076",
+        ]:
+            rec["accept_suggestion"] = True
 
-        if uprn == "10034518861":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "TS79LF"
-            return rec
+        if uprn in ["10023906550"]:
+            rec["accept_suggestion"] = False
 
-        if uprn == "10023906866":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "TS9 6QR"
-            return rec
-
-        if uprn == "10034529574":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "TS11 7HP"
-            return rec
-
-        return super().address_record_to_dict(record)
+        return rec

--- a/polling_stations/apps/data_collection/management/commands/import_south_norfolk.py
+++ b/polling_stations/apps/data_collection/management/commands/import_south_norfolk.py
@@ -10,14 +10,22 @@ class Command(BaseXpressDemocracyClubCsvImporter):
 
     def address_record_to_dict(self, record):
         rec = super().address_record_to_dict(record)
+        uprn = record.property_urn.strip().lstrip("0")
 
-        if record.property_urn.strip().lstrip("0") == "2630166893":
-            rec["postcode"] = "NR9 3JP"
+        if uprn in [
+            "2630159192",
+            "2630101566",
+            "2630106361",
+            "2630164300",
+            "2630122694",
+        ]:
+            rec = super().address_record_to_dict(record)
+            rec["accept_suggestion"] = True
+            return rec
 
-        if record.property_urn.strip().lstrip("0") == "2630159192":
-            rec["postcode"] = "NR35 2QR"
-
-        if record.property_urn.strip().lstrip("0") == "2630153843":
+        if uprn == "2630153843":
             rec["postcode"] = "NR14 6RJ"
+            rec["accept_suggestion"] = False
+            return rec
 
         return rec

--- a/polling_stations/apps/data_collection/management/commands/import_spelthorne.py
+++ b/polling_stations/apps/data_collection/management/commands/import_spelthorne.py
@@ -10,12 +10,14 @@ class Command(BaseHalaroseCsvImporter):
         "local.2019-05-02/Version 1/polling_station_export Spelthorne-2019-02-07.csv"
     )
     elections = ["local.2019-05-02"]
+    match_threshold = 98
 
     def address_record_to_dict(self, record):
+        uprn = record.uprn.strip().lstrip("0")
 
-        if record.houseid == "43674":
+        if uprn in ["33040703", "33040704", "33048602", "33051119"]:
             rec = super().address_record_to_dict(record)
-            rec["postcode"] = "TW15 2SH"
+            rec["accept_suggestion"] = True
             return rec
 
         return super().address_record_to_dict(record)

--- a/polling_stations/apps/data_collection/management/commands/import_wokingham.py
+++ b/polling_stations/apps/data_collection/management/commands/import_wokingham.py
@@ -7,14 +7,19 @@ class Command(BaseXpressDemocracyClubCsvImporter):
     stations_name = "local.2019-05-02/Version 1/Democracy_Club__02May2019Woke.CSV"
     elections = ["local.2019-05-02"]
     csv_delimiter = ","
+    fuzzy_match = False
 
     def address_record_to_dict(self, record):
         rec = super().address_record_to_dict(record)
+        uprn = record.property_urn.strip().lstrip("0")
 
         if record.addressline6 in ["RG7 1ZE", "RG7 1ZG"]:
             rec["postcode"] = "RG7 1FQ"
 
-        if record.property_urn.strip().lstrip("0") == "14005649":
-            rec["postcode"] = "RG2 9QG"
+        if uprn in ["14020309"]:
+            rec["accept_suggestion"] = True
+
+        if uprn in ["14059977"]:
+            rec["accept_suggestion"] = False
 
         return rec

--- a/polling_stations/apps/data_collection/management/commands/import_wychavon.py
+++ b/polling_stations/apps/data_collection/management/commands/import_wychavon.py
@@ -3,52 +3,19 @@ from data_collection.management.commands import BaseXpressDemocracyClubCsvImport
 
 class Command(BaseXpressDemocracyClubCsvImporter):
     council_id = "E07000238"
-    addresses_name = (
-        "local.2019-05-02/Version 1/Democracy_Club__02May2019 Wychavon-fixed.tsv"
-    )
-    stations_name = (
-        "local.2019-05-02/Version 1/Democracy_Club__02May2019 Wychavon-fixed.tsv"
-    )
+    addresses_name = "local.2019-05-02/Version 2/Democracy_Club__02May2019Wyc2.tsv"
+    stations_name = "local.2019-05-02/Version 2/Democracy_Club__02May2019Wyc2.tsv"
     elections = ["local.2019-05-02"]
     csv_delimiter = "\t"
 
     def address_record_to_dict(self, record):
+        rec = super().address_record_to_dict(record)
         uprn = record.property_urn.strip().lstrip("0")
 
-        if uprn == "10013945401":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "GL20 7HB"
-            return rec
+        if uprn in ["100120707960", "100120707957", "100120716820"]:
+            rec["accept_suggestion"] = True
 
-        if uprn == "100120716819":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "WR7 4PP"
-            return rec
+        if uprn in ["10013941784"]:
+            rec["accept_suggestion"] = False
 
-        if uprn == "100120698775":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "WR11 7PT"
-            return rec
-
-        if uprn == "100120709729":
-            rec = super().address_record_to_dict(record)
-            rec["postcode"] = "WR11 7YH"
-            return rec
-
-        return super().address_record_to_dict(record)
-
-    def station_record_to_dict(self, record):
-
-        """
-        File supplied contained obviously inaccurate point
-        remove it and fall back to geocoding
-        """
-        if record.polling_place_id == "5075":
-            record = record._replace(polling_place_easting="0")
-            record = record._replace(polling_place_northing="0")
-
-        if record.polling_place_id == "4927":
-            record = record._replace(polling_place_easting="0")
-            record = record._replace(polling_place_northing="0")
-
-        return super().station_record_to_dict(record)
+        return rec

--- a/polling_stations/apps/data_collection/tests/test_address_list.py
+++ b/polling_stations/apps/data_collection/tests/test_address_list.py
@@ -456,7 +456,7 @@ class AddressListTest(TestCase):
             if el["uprn"] == "00004":
                 self.assertEqual(None, el.get("location", None))
 
-    def test_remove_invalid_uprns(self):
+    def test_remove_invalid_uprns_autofix_postcode(self):
         in_list = [
             {
                 "address": "1 Abbeyvale Dr, Liverpool",
@@ -476,7 +476,65 @@ class AddressListTest(TestCase):
             },
             {
                 "address": "3 Abbeyvale Dr, Liverpool",
+                "postcode": "L252XX",
+                "polling_station_id": "AB",
+                "council": "X01000001",
+                "slug": "c",
+                "uprn": "00003",
+            },
+        ]
+
+        address_list = AddressList(MockLogger())
+        for el in in_list:
+            address_list.append(el)
+
+        addressbase = {
+            "00001": {
                 "postcode": "L252NW",
+                "address": "1 Abbeyvale Dr, Liverpool",
+                "location": "SRID=4326;POINT(-0.9288492 53.3119342)",
+            },
+            "00002": {
+                "postcode": "L252NW",
+                "address": "2 Abbeyvale Dr, Liverpool",
+                "location": "SRID=4326;POINT(-0.9288480 53.3119345)",
+            },
+            "00003": {
+                "postcode": "L252NW",  # this postcode doesn't match with the input record
+                "address": "3 Abbeyvale Dr, Liverpool",
+                "location": "SRID=4326;POINT(-0.9288400 53.3119332)",
+            },
+        }
+
+        address_list.handle_invalid_uprns(addressbase, True, 100)
+
+        # all the records should still be in the set
+        self.assertEqual(3, len(address_list.elements))
+        # We should have auto-corrected L252XX to L252NW
+        for el in address_list.elements:
+            self.assertEqual(el["postcode"], "L252NW")
+
+    def test_remove_invalid_uprns_remove_uprn(self):
+        in_list = [
+            {
+                "address": "1 Abbeyvale Dr, Liverpool",
+                "postcode": "L252NW",
+                "polling_station_id": "AA",
+                "council": "X01000001",
+                "slug": "a",
+                "uprn": "00001",
+            },
+            {
+                "address": "2 Abbeyvale Dr, Liverpool",
+                "postcode": "L252NW",
+                "polling_station_id": "AA",
+                "council": "X01000001",
+                "slug": "b",
+                "uprn": "00002",
+            },
+            {
+                "address": "3 Abbeyvale Street, Liverpool",
+                "postcode": "L252XX",
                 "polling_station_id": "AB",
                 "council": "X01000001",
                 "slug": "c",
@@ -508,14 +566,14 @@ class AddressListTest(TestCase):
                 "location": "SRID=4326;POINT(-0.9288480 53.3119345)",
             },
             "00003": {
-                "postcode": "L252XX",  # this postcode doesn't match with the input record
-                "address": "2 Abbeyvale Dr, Liverpool",
+                "postcode": "L252NW",  # this postcode doesn't match with the input record
+                "address": "3 Abbeyvale Dr, Liverpool",  # and neither does this address
                 "location": "SRID=4326;POINT(-0.9288400 53.3119332)",
             }
             # 00004 is not in here
         }
 
-        address_list.remove_invalid_uprns(addressbase)
+        address_list.handle_invalid_uprns(addressbase, True, 100)
 
         # 00003 and 00004 should still be in the set
         self.assertEqual(4, len(address_list.elements))

--- a/polling_stations/apps/data_collection/tests/test_address_list.py
+++ b/polling_stations/apps/data_collection/tests/test_address_list.py
@@ -514,7 +514,7 @@ class AddressListTest(TestCase):
         for el in address_list.elements:
             self.assertEqual(el["postcode"], "L252NW")
 
-    def test_remove_invalid_uprns_remove_uprn(self):
+    def test_remove_invalid_uprns_delete(self):
         in_list = [
             {
                 "address": "1 Abbeyvale Dr, Liverpool",
@@ -542,11 +542,19 @@ class AddressListTest(TestCase):
             },
             {
                 "address": "4 Abbeyvale Dr, Liverpool",
-                "postcode": "L252NW",
+                "postcode": "L252XX",
                 "polling_station_id": "AA",
                 "council": "X01000001",
                 "slug": "d",
                 "uprn": "00004",
+            },
+            {
+                "address": "5 Abbeyvale Dr, Liverpool",
+                "postcode": "L252XY",
+                "polling_station_id": "AA",
+                "council": "X01000001",
+                "slug": "e",
+                "uprn": "00005",
             },
         ]
 
@@ -569,14 +577,12 @@ class AddressListTest(TestCase):
                 "postcode": "L252NW",  # this postcode doesn't match with the input record
                 "address": "3 Abbeyvale Dr, Liverpool",  # and neither does this address
                 "location": "SRID=4326;POINT(-0.9288400 53.3119332)",
-            }
-            # 00004 is not in here
+            },
         }
 
         address_list.handle_invalid_uprns(addressbase, True, 100)
 
-        # 00003 and 00004 should still be in the set
-        self.assertEqual(4, len(address_list.elements))
-        # but those records should now have a blank uprn
-        for el in address_list.elements:
-            assert el["uprn"] in ["00001", "00002", ""]
+        # this should delete all the L252NW and L252XX properties
+        # but leave L252XY intact
+        self.assertEqual(1, len(address_list.elements))
+        self.assertEqual(address_list.elements[0]["postcode"], "L252XY")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,9 +9,11 @@ djangorestframework==3.9.1
 djangorestframework-gis==0.14
 django-cors-headers==2.4.0
 fastkml==0.11
+fuzzywuzzy==0.17.0
 lxml==4.3.1
 psycopg2-binary==2.7.7
 pyshp==2.1.0
+python-levenshtein==0.12.0
 raven==6.10.0
 requests==2.21.0
 retry==0.9.2


### PR DESCRIPTION
Closes #1330

Lets see if we can make a slightly better job of this. I _think_ this is an improvement.

**Key changes:**

* Strip commas before fuzzy matching
* Set default match threshold to 100
* Allow match threshold to be configured on each import script instead of set globally
* Allow fuzzy matching to be turned off if needed
* If we can't fuzzy match, delete any (problematic) leftovers

**Review notes:**

* Still doing this as a post-process:
  * Input to `address_record_to_dict()` should match CSV
  * There are some things we need to know which require iterating the whole thing
  * How do we deal with a single-record correction or exclusion?
* `INFO`s vs `WARNING`s
* ~Is `delete_unmatched_postcodes` setting useful/necessary? Would it be better as a `--flag`~

**TODO:**

* ~Test the changes against all existing import scripts~

@symroe - feel free to have opinions about this, but I think the next thing I want to do with this is review the assumptions with @GeoWill next week and we'll see how it goes/tweak it before we merge.