### PR TITLE
change "we don't know of any upcoming elections" wording

### DIFF
--- a/polling_stations/templates/fragments/no_election.html
+++ b/polling_stations/templates/fragments/no_election.html
@@ -5,17 +5,18 @@
   {% include "fragments/cancelled_election.html" %}
 {% else %}
   <h2>We don't know of any upcoming elections in your area</h2>
-  {% if council.phone %}
-    {% blocktrans with council.name as council_name and council.phone as council_phone %}
+  {% if council.phone and council.website %}
+    {% blocktrans with council.name as council_name and council.phone as council_phone and council.website as council_website %}
     <p>
-      We're not aware of any upcoming elections in your area. If you think there may be elections in your area, please call your council to check.
-      You can contact {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong>
+      There are no district council or mayoral elections in your area. There may be parish, town or community council elections in some areas.
+      Check your local <a href="{{ council_website }}">council website</a> for more information, or contact {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong>.
     </p>
     {% endblocktrans %}
   {% else %}
     {% blocktrans with council.name as council_name %}
     <p>
-      We're not aware of any upcoming elections in your area. If you think there may be elections in your area, please call {{ council_name }} to check.
+        There are no district council or mayoral elections in your area. There may be parish, town or community council elections in some areas.
+        If you think there may be elections in your area, call {{ council_name }} to check.
     </p>
     {% endblocktrans %}
   {% endif %}


### PR DESCRIPTION
closes #1541
This gives us some wording to bikeshed. I've attempted to balance the needs of 3 groups here:

* Providing useful information to members of the public
* Councils who do have parish elections happening in areas that don't have district ward elections and want us not to tell their users "you don't have an election"
* Councils who do have parish elections and don't want loads of people phoning them up to ask if they have an election or not.

![Screenshot at 2019-03-19 15-00-29](https://user-images.githubusercontent.com/6025893/54617601-76f7b200-4a59-11e9-9112-257991188a89.png)

For now, lets concern ourselves with the 'happy path'. There is also an edge case where there are several councils where we don't hold very good contact info, but I'm hoping to fix that at the start of April when the new councils become "official".

There is also an edge case for users in NI where the relevant thing to contact is EONI not the local council, but I'm going to ignore that one for now because this content is now 2nd May-specific and everyone in NI has an election on 2nd May, but we probably also need a NI-version of this content when we re-generic-ify this content again.