### PR TITLE
add NEXT_CHARISMATIC_ELECTION_DATE setting

### DIFF
--- a/polling_stations/settings/testing.py
+++ b/polling_stations/settings/testing.py
@@ -1,6 +1,7 @@
 from .base import *  # noqa
 
 EVERY_ELECTION["CHECK"] = True  # noqa
+NEXT_CHARISMATIC_ELECTION_DATE = None
 DISABLE_GA = True  # don't log to Google Analytics when we are running tests
 
 INSTALLED_APPS = list(INSTALLED_APPS)  # noqa


### PR DESCRIPTION
This will allow us to set `NEXT_CHARISMATIC_ELECTION_DATE = "2019-05-02"` in the settings on the deploy repo to temporarily ignore any elections that may or may not be happening on 2019-05-23 until we're ready to shift focus and deal with them.