### PR TITLE
Spatial hub imports

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -720,8 +720,8 @@ class BaseScotlandSpatialHubImporter(
     """
 
     srid = 27700
-    districts_name = "euro.2019-05-23/Polling-Districts/pub_poldi.shp"
-    stations_name = "euro.2019-05-23/Polling-Places/pub_polpl.shp"
+    districts_name = "europarl.2019-05-23/Polling-Districts/pub_poldi.shp"
+    stations_name = "europarl.2019-05-23/Polling-Places/pub_polpl.shp"
     data_prefix = "Scotland-May-2019"
     run_in_series = True
     shp_encoding = "latin-1"

--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -46,8 +46,15 @@ class CsvMixin:
     csv_encoding = "utf-8"
     csv_delimiter = ","
 
-    def get_file_options(self):
-        return {"encoding": self.csv_encoding, "delimiter": self.csv_delimiter}
+    def get_csv_options(self):
+        return {"csv_encoding": self.csv_encoding, "csv_delimiter": self.csv_delimiter}
+
+
+class ShpMixin:
+    shp_encoding = "utf-8"
+
+    def get_shp_options(self):
+        return {"shp_encoding": self.shp_encoding}
 
 
 class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
@@ -112,10 +119,12 @@ class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
         return Council.objects.get(pk=council_id)
 
     def get_data(self, filetype, filename):
-        if hasattr(self, "get_file_options"):
-            options = self.get_file_options()
-        else:
-            options = {}
+        options = {}
+        if hasattr(self, "get_csv_options"):
+            options.update(self.get_csv_options())
+        if hasattr(self, "get_shp_options"):
+            options.update(self.get_shp_options())
+
         helper = FileHelperFactory.create(filetype, filename, options)
         return helper.get_features()
 
@@ -646,7 +655,9 @@ class BaseStationsAddressesImporter(BaseStationsImporter, BaseAddressesImporter)
         self.stations.save()
 
 
-class BaseCsvStationsShpDistrictsImporter(BaseStationsDistrictsImporter, CsvMixin):
+class BaseCsvStationsShpDistrictsImporter(
+    BaseStationsDistrictsImporter, CsvMixin, ShpMixin
+):
     """
     Stations in CSV format
     Districts in SHP format
@@ -656,7 +667,7 @@ class BaseCsvStationsShpDistrictsImporter(BaseStationsDistrictsImporter, CsvMixi
     districts_filetype = "shp"
 
 
-class BaseShpStationsShpDistrictsImporter(BaseStationsDistrictsImporter):
+class BaseShpStationsShpDistrictsImporter(BaseStationsDistrictsImporter, ShpMixin):
     """
     Stations in SHP format
     Districts in SHP format
@@ -713,6 +724,7 @@ class BaseScotlandSpatialHubImporter(
     stations_name = "euro.2019-05-23/Polling-Places/pub_polpl.shp"
     data_prefix = "Scotland-May-2019"
     run_in_series = True
+    shp_encoding = "latin-1"
 
     @property
     @abc.abstractmethod
@@ -737,10 +749,7 @@ class BaseScotlandSpatialHubImporter(
         return self.base_folder_path
 
     def parse_string(self, text):
-        try:
-            return text.strip().decode("windows-1252")
-        except AttributeError:
-            return text.strip()
+        return text.strip()
 
     def district_record_to_dict(self, record):
         council_name = self.parse_string(record[2])
@@ -781,7 +790,9 @@ class BaseCsvStationsCsvAddressesImporter(BaseStationsAddressesImporter, CsvMixi
     addresses_filetype = "csv"
 
 
-class BaseShpStationsCsvAddressesImporter(BaseStationsAddressesImporter, CsvMixin):
+class BaseShpStationsCsvAddressesImporter(
+    BaseStationsAddressesImporter, CsvMixin, ShpMixin
+):
     """
     Stations in SHP format
     Addresses in CSV format
@@ -844,7 +855,7 @@ class BaseApiKmlStationsKmlDistrictsImporter(BaseGenericApiImporter):
     districts_filetype = "kml"
 
 
-class BaseApiShpZipStationsShpZipDistrictsImporter(BaseGenericApiImporter):
+class BaseApiShpZipStationsShpZipDistrictsImporter(BaseGenericApiImporter, ShpMixin):
     """
     Stations in Zipped SHP format
     Districts in Zipped SHP format
@@ -854,7 +865,9 @@ class BaseApiShpZipStationsShpZipDistrictsImporter(BaseGenericApiImporter):
     districts_filetype = "shp.zip"
 
 
-class BaseApiCsvStationsShpZipDistrictsImporter(BaseGenericApiImporter, CsvMixin):
+class BaseApiCsvStationsShpZipDistrictsImporter(
+    BaseGenericApiImporter, CsvMixin, ShpMixin
+):
     """
     Stations in CSV format
     Districts in Zipped SHP format

--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -709,9 +709,9 @@ class BaseScotlandSpatialHubImporter(
     """
 
     srid = 27700
-    districts_name = "parl.2017-06-08/polling_districts_20170526.shp"
-    stations_name = "parl.2017-06-08/polling_places_20170526.shp"
-    data_prefix = "Scotland May 2017"
+    districts_name = "euro.2019-05-23/Polling-Districts/pub_poldi.shp"
+    stations_name = "euro.2019-05-23/Polling-Places/pub_polpl.shp"
+    data_prefix = "Scotland-May-2019"
     run_in_series = True
 
     @property
@@ -743,7 +743,7 @@ class BaseScotlandSpatialHubImporter(
             return text.strip()
 
     def district_record_to_dict(self, record):
-        council_name = self.parse_string(record[3])
+        council_name = self.parse_string(record[2])
         if council_name != self.council_name:
             return None
 
@@ -758,15 +758,15 @@ class BaseScotlandSpatialHubImporter(
         return {"internal_council_id": code, "name": name, "polling_station_id": code}
 
     def station_record_to_dict(self, record):
-        council_name = self.parse_string(record[3])
+        council_name = self.parse_string(record[2])
         if council_name != self.council_name:
             return None
 
-        code = self.parse_string(record[1])
+        code = self.parse_string(record[0])
         if not code:
             return None
 
-        address = self.parse_string(record[0])
+        address = self.parse_string(record[3])
 
         return {"internal_council_id": code, "postcode": "", "address": address}
 

--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -723,7 +723,6 @@ class BaseScotlandSpatialHubImporter(
     districts_name = "europarl.2019-05-23/Polling-Districts/pub_poldi.shp"
     stations_name = "europarl.2019-05-23/Polling-Places/pub_polpl.shp"
     data_prefix = "Scotland-May-2019"
-    run_in_series = True
     shp_encoding = "latin-1"
 
     @property

--- a/polling_stations/apps/data_collection/filehelpers.py
+++ b/polling_stations/apps/data_collection/filehelpers.py
@@ -74,9 +74,10 @@ Helper class for reading geographic data from ESRI SHP files
 
 
 class ShpHelper:
-    def __init__(self, filepath, zip=False):
+    def __init__(self, filepath, zip=False, encoding="utf-8"):
         self.filepath = filepath
         self.zip = zip
+        self.encoding = encoding
 
     def get_features(self):
         # If our shapefile is in a zip, extract it
@@ -91,10 +92,10 @@ class ShpHelper:
                 raise ValueError("Found %i shapefiles in archive" % len(shp_files))
             shp_file = shp_files[0]
 
-            sf = shapefile.Reader(shp_file)
+            sf = shapefile.Reader(shp_file, encoding=self.encoding)
             return sf.shapeRecords()
         else:
-            sf = shapefile.Reader(self.filepath)
+            sf = shapefile.Reader(self.filepath, encoding=self.encoding)
             return sf.shapeRecords()
 
 
@@ -167,9 +168,9 @@ class FileHelperFactory:
     @staticmethod
     def create(filetype, filepath, options):
         if filetype == "shp":
-            return ShpHelper(filepath)
+            return ShpHelper(filepath, zip=False, encoding=options["shp_encoding"])
         elif filetype == "shp.zip":
-            return ShpHelper(filepath, zip=True)
+            return ShpHelper(filepath, zip=True, encoding=options["shp_encoding"])
         elif filetype == "kml":
             return KmlHelper(filepath)
         elif filetype == "geojson":
@@ -177,6 +178,8 @@ class FileHelperFactory:
         elif filetype == "json":
             return JsonHelper(filepath)
         elif filetype == "csv":
-            return CsvHelper(filepath, options["encoding"], options["delimiter"])
+            return CsvHelper(
+                filepath, options["csv_encoding"], options["csv_delimiter"]
+            )
         else:
             raise ValueError("Unexpected file type: %s" % (filetype))

--- a/polling_stations/apps/data_collection/management/commands/import_aberdeen.py
+++ b/polling_stations/apps/data_collection/management/commands/import_aberdeen.py
@@ -10,11 +10,11 @@ due to incomplete/poor quality data
 class Command(BaseScotlandSpatialHubImporter):
     council_id = "S12000033"
     council_name = "Aberdeen City"
-    elections = ["local.aberdeen-city.2017-05-04", "parl.2017-06-08"]
+    elections = ["europarl.2019-05-23"]
 
     def station_record_to_dict(self, record):
         # exclude duplicate/ambiguous codes
-        if record[1] in ["DG0205", "DG0206", "CS1008"]:
+        if record[0] in ["DG0205", "DG0206", "CS1008"]:
             return None
 
         return super().station_record_to_dict(record)


### PR DESCRIPTION
Here's an initial bash at updating the `ScotlandSpatialHubImporter` class. It seems to behave as expected with a couple of scripts, I've attached the Aberdeen one as an example - the duplicate stations in district issue is unchanged from 2017.  
It would be good to get feedback on 71fb6f9  - I'm not sure if the `encoding` kwarg that I've added to the `ShpHelper` class is the best way to go as it's not obvious to me where one would set it in an import script. However it may be an expedient hack that gets us through to June. 