### PR TITLE
move 'info on your candidates' card higher up

### DIFF
--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -68,6 +68,8 @@
       {% include "election_explainers.html" %}
     {% endif %}
 
+    {% include "fragments/info_on_your_candidates.html" %}
+
     {% if we_know_where_you_should_vote or custom %}
       {% if request.brand == 'democracyclub' and has_election and not error %}
         <div class="card">
@@ -82,8 +84,6 @@
     {% if council.address or council.postcode or council.phone or council.email %}
       {% include "fragments/contact_details.html" %}
     {% endif %}
-
-    {% include "fragments/info_on_your_candidates.html" %}
 
     {% if not error and request.brand == 'democracyclub' and not messages %}
       <div class="card">


### PR DESCRIPTION
Looking at the feedback, there are quite a few comments along the lines of:

> Looking for ward name so I can check list of candidates

> I want to know who is running and info about them.

> Would be nice to have a link to a list of candidates

> I thought it would tell me the names etc of the candidates.

> IT COULD HAVE ADDED WO IS STANDING

Clearly they are scrolling far enough down the page to find the "complain about this" card, but not as far as the "info on your candidates" card. This moves the "info on your candidates" card above the feedback form.