### PR TITLE
import Aberdeenshire

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_aberdeenshire.py
+++ b/polling_stations/apps/data_collection/management/commands/import_aberdeenshire.py
@@ -4,4 +4,4 @@ from data_collection.management.commands import BaseScotlandSpatialHubImporter
 class Command(BaseScotlandSpatialHubImporter):
     council_id = "S12000034"
     council_name = "Aberdeenshire"
-    elections = ["local.aberdeenshire.2017-05-04", "parl.2017-06-08"]
+    elections = ["europarl.2019-05-23"]

--- a/polling_stations/apps/data_collection/management/commands/import_aberdeenshire.py
+++ b/polling_stations/apps/data_collection/management/commands/import_aberdeenshire.py
@@ -5,3 +5,11 @@ class Command(BaseScotlandSpatialHubImporter):
     council_id = "S12000034"
     council_name = "Aberdeenshire"
     elections = ["europarl.2019-05-23"]
+
+    def station_record_to_dict(self, record):
+        rec = super().station_record_to_dict(record)
+        if record[0] == "EG1202":  # District file and Stations file disagree on station
+            return None
+        if record[0] == "EG1106":  # District file and Stations file disagree on station
+            return None
+        return rec

--- a/polling_stations/apps/data_collection/management/commands/misc_fixes.py
+++ b/polling_stations/apps/data_collection/management/commands/misc_fixes.py
@@ -188,6 +188,7 @@ class Command(BaseCommand):
             "130073905",
             "130073906",
             "130099688",
+            "151651178",
         ]
         addresses = Address.objects.filter(pk__in=bad_uprns)
         for address in addresses:


### PR DESCRIPTION
Extracted from #1996 You should be able to push to this branch.

This is one which includes the station name in both the districts file and the stations file. I had a quick look over this and noticed there is at least one where they disagree.

District `EG1202`
- districts file says its "FINTRAY PUBLIC HALL"
- stations file says its "Axis Centre"

This is an annoying inconsistency because we don't know really which of the 2 contradicting data points to rely on. Can you revisit this one and have a look at whether there are any other cases of this. If its just the one, can we exclude this and say "we don't know" for this district. If its lots of them, lets re-evaluate it.