### PR TITLE
improve contact info for Scottish councils

### DIFF
--- a/polling_stations/apps/councils/data/scotland.csv
+++ b/polling_stations/apps/councils/data/scotland.csv
@@ -1,0 +1,33 @@
+gss,council_name,email,phone,web
+S12000005,Clackmannanshire Council,elections@clacks.gov.uk,01259 450000,https://www.clacks.gov.uk/council/elections/
+S12000006,Dumfries and Galloway Council,ier@dumgal.gov.uk,01387 260627,https://www.dumgal.gov.uk/elections
+S12000008,East Ayrshire Council,electionoffice@east-ayrshire.gov.uk,01563 576555,https://www.east-ayrshire.gov.uk/CouncilAndGovernment/ElectionsAndVoting/ElectionsandVoting.aspx
+S12000010,East Lothian Council,elections@eastlothian.gov.uk,01620 820183,https://www.eastlothian.gov.uk/info/210600/elections_and_voting
+S12000011,East Renfrewshire Council,electionoffice@eastrenfrewshire.gov.uk,0300 300 0150,https://eastrenfrewshire.gov.uk/elections-and-voting
+S12000013,Comhairle nan Eilean Siar,elections@cne-siar.gov.uk,01851 822613,https://cne-siar.gov.uk/your-council/elections-and-voting/
+S12000014,Falkirk Council,elections@falkirk.gov.uk,01324 506070,https://www.falkirk.gov.uk/services/council-democracy/elections-voting/
+S12000017,Highland Council,election@highland.gov.uk,01349 886657,https://www.highland.gov.uk/info/799/elections_and_voting
+S12000018,Inverclyde Council,elections@inverclyde.gov.uk,01475 712126,https://www.inverclyde.gov.uk/law-and-licensing/democracy-and-elections
+S12000019,Midlothian Council,enquiries@midlothian.gov.uk,0131 344 2500,https://www.midlothian.gov.uk/news/799/elections_and_voting
+S12000020,Moray Council,election.enquiries@moray.gov.uk,01343 563334,http://www.moray.gov.uk/elections
+S12000021,North Ayrshire Council,elections@north-ayrshire.gov.uk,01292 612221,https://north-ayrshire.cmis.uk.com/north-ayrshire/VotingElections.aspx
+S12000023,Orkney Islands Council,electionoffice@orkney.gov.uk,01856 873535,http://www.orkney.gov.uk/Council/C/elections.htm
+S12000026,Scottish Borders Council,ero@scotborders.gov.uk,01835 825005,https://www.scotborders.gov.uk/info/20057/elections_and_voting/199/elections
+S12000027,Shetland Islands Council,returning.officer@shetland.gov.uk,01595 744066,https://www.shetland.gov.uk/elections/
+S12000028,South Ayrshire Council,customerservices@south-ayrshire.gov.uk,01292 612221,https://www.south-ayrshire.gov.uk/elections/
+S12000029,South Lanarkshire Council,elections@southlanarkshire.gov.uk,0303 123 1019,https://www.southlanarkshire.gov.uk/info/200237/elections
+S12000030,Stirling Council,elections@stirling.gov.uk,01786 233095,https://www.stirling.gov.uk/council-democracy/politicians-elections-democracy/elections-voting/
+S12000033,Aberdeen City Council,elections@aberdeencity.gov.uk,01224 523521,https://www.aberdeencity.gov.uk/services/council-and-democracy/elections-and-voting
+S12000034,Aberdeenshire Council,elections@aberdeenshire.gov.uk,01224 068400,https://aberdeenshire.gov.uk/council-and-democracy/elections/
+S12000035,Argyll and Bute Council,Elections@argyll-bute.gov.uk,01546 603264,https://www.argyll-bute.gov.uk/elections
+S12000036,City of Edinburgh Council,elections@edinburgh.gov.uk,0131 200 2315,https://www.edinburgh.gov.uk/info/20033/elections_and_voting
+S12000038,Renfrewshire Council,ero@renfrewshire-vjb.gov.uk,0300 300 0150,http://www.renfrewshire.gov.uk/elections
+S12000039,West Dunbartonshire Council,elections@west-dunbarton.gov.uk,0800 980 0471,https://www.west-dunbarton.gov.uk/council/voting-and-elections/
+S12000040,West Lothian Council,elections@westlothian.gov.uk,01506 281651,https://www.westlothian.gov.uk/aboutmyvote
+S12000041,Angus Council,elections@angus.gov.uk,01307 499910,https://www.angus.gov.uk/council_and_democracy/elections_and_voting
+S12000042,Dundee City Council,ero@dundeecity.gov.uk,01382 434444,https://www.dundeecity.gov.uk/
+S12000045,East Dunbartonshire Council,ero-edc@dab-vjb.gov.uk,0141 562 1200,https://www.eastdunbarton.gov.uk/council/elections-voting
+S12000047,Fife Council,voters.roll@fife.gov.uk,01592 583111,https://www.fifedirect.org.uk/index.cfm
+S12000048,Perth & Kinross Council,elections@pkc.gov.uk,01738 475004,https://www.pkc.gov.uk/elections
+S12000046,Glasgow City Council,voters.roll@fs.glasgow.gov.uk,0141 287 4444,https://www.glasgow.gov.uk/elections
+S12000044,North Lanarkshire Council,electionoffice@northlan.gov.uk,01698 302119,https://www.northlanarkshire.gov.uk/index.aspx?articleid=1269

--- a/polling_stations/apps/councils/management/commands/import_councils.py
+++ b/polling_stations/apps/councils/management/commands/import_councils.py
@@ -168,11 +168,6 @@ class Command(BaseCommand):
 
         return councils
 
-    def _save_council(self, council):
-        # write council object to ALL databases
-        for db in settings.DATABASES.keys():
-            council.save(using=db)
-
     def clean_url(self, url):
         if not url.startswith(("http://", "https://")):
             # Assume http everywhere will redirect to https if it is there.
@@ -262,6 +257,6 @@ class Command(BaseCommand):
             council.address = info["address"]
             council.postcode = info["postcode"]
 
-            self._save_council(council)
+            council.save()
 
         self.stdout.write("..done")

--- a/polling_stations/apps/councils/management/commands/update_scotland.py
+++ b/polling_stations/apps/councils/management/commands/update_scotland.py
@@ -1,0 +1,21 @@
+import csv
+import os
+from collections import namedtuple
+from django.core.management.base import BaseCommand
+from councils.models import Council
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        filename = os.path.abspath("./polling_stations/apps/councils/data/scotland.csv")
+        with open(filename) as infile:
+            reader = csv.reader(infile)
+            Row = namedtuple("Row", next(reader))
+            for row in map(Row._make, reader):
+                c = Council.objects.get(pk=row.gss)
+                c.email = row.email
+                c.phone = row.phone
+                c.website = row.web
+                c.address = ""
+                c.postcode = ""
+                c.save()


### PR DESCRIPTION
This is tech debt we'll need to review post-May, but lets look at it again in the context of the EC's move to numiko. We'll probably have to rewrite the whole councils import then anyway.

refs  #969

Note: when you merge this, call `./manage.py update_scotland` after importing councils in the deploy scripts