### PR TITLE
Europarl home page text

### DIFF
--- a/polling_stations/apps/data_finder/features/index.feature
+++ b/polling_stations/apps/data_finder/features/index.feature
@@ -24,7 +24,6 @@ Feature: Check Postcodes
     Then I submit the only form
     Then The browser's URL should contain "/address/5/"
     And I should see "Contact Foo Council"
-    And I should see "We don't have data for your area."
     And No errors were thrown
 
     Scenario: Check postcode without address picker
@@ -46,7 +45,6 @@ Feature: Check Postcodes
     Then I select "My address is not in the list" from "address"
     Then I submit the only form
     Then I should see "Contact Foo Council"
-    And I should see "We don't have data for your area."
     And No errors were thrown
 
     Scenario: Check multiple councils

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -1,4 +1,5 @@
 import abc
+from datetime import datetime
 
 from django.conf import settings
 from django.contrib.gis.geos import Point
@@ -6,7 +7,7 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404
 from django.views.generic import FormView, TemplateView
-from django.utils import translation
+from django.utils import translation, timezone
 
 from councils.models import Council
 from data_finder.models import LoggedPostcode
@@ -76,6 +77,18 @@ class LanguageMixin(object):
 class HomeView(WhiteLabelTemplateOverrideMixin, FormView):
     form_class = PostcodeLookupForm
     template_name = "home.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        eu_polls_open = timezone.make_aware(
+            datetime.strptime("2019-05-23 7", "%Y-%m-%d %H")
+        )
+        eu_polls_close = timezone.make_aware(
+            datetime.strptime("2019-05-23 22", "%Y-%m-%d %H")
+        )
+        now = timezone.now()
+        context["show_polls_open"] = eu_polls_open < now and eu_polls_close > now
+        return context
 
     def form_valid(self, form):
 

--- a/polling_stations/templates/fragments/polling_station_unknown.html
+++ b/polling_stations/templates/fragments/polling_station_unknown.html
@@ -3,7 +3,6 @@
 <h2>{% blocktrans with council.name as council_name %}Contact {{ council_name }}{% endblocktrans %}</h2>
 
 {% blocktrans %}
-  <p>We don't have data for your area.</p>
   <p>
     Your polling station address should be printed on your polling card, which is delivered by post before an election.
   </p>
@@ -12,7 +11,7 @@
   <p>
     {% if council.phone %}
       {% blocktrans with council.phone as council_phone and council.name as council_name %}
-        Or, you need to contact your local council.
+        Or if you don't have a poll card, you need to contact your local council.
         You can call {{ council_name }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong>
       {% endblocktrans %}
     {% else %}

--- a/polling_stations/templates/fragments/you_dont_need_poll_card.html
+++ b/polling_stations/templates/fragments/you_dont_need_poll_card.html
@@ -13,7 +13,7 @@
         {% blocktrans %}
         <h3>You don't need your poll card to vote</h3>
         <p>
-          If you are registered to vote but you don't have your poll card, you
+          If you are registered to vote, but you don't have your poll card, you
           can go to the polling station and give them your name and address.
         </p>
         {% endblocktrans %}

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -30,4 +30,23 @@
     </form>
 </section>
 
+{% if show_polls_open %}
+<div class="card centered-card">
+  <h2>European Parliament elections</h2>
+  <p>Polling stations are open from 7am to 10pm today.</p>
+
+  <p>You don't need your poll card to vote.</p>
+
+  <p>You must vote at your assigned polling station.</p>
+
+  <p>
+    If you are registered to vote, but you don't have your poll card, you
+    can go to the polling station and give them your name and address.
+  </p>
+
+  <p>You don't need any other form of ID, except in Northern Ireland, where you must bring photo ID.</p>
+
+</div>
+{% endif %}
+
 {% endblock content %}

--- a/polling_stations/templates/multiple_councils.html
+++ b/polling_stations/templates/multiple_councils.html
@@ -10,8 +10,6 @@
   <h2>{% blocktrans %}Contact Your Council{% endblocktrans %}</h2>
 
   {% blocktrans with council.phone as council_phone %}
-  <p>We don't have data for your area.</p>
-
   <p>Your polling station address should be printed on your polling card, which is delivered by post before an election.</p>
   <p>Or, you need to contact your council. Residents in {{ postcode }} may be in one of the following council areas:</p>
   {% endblocktrans %}


### PR DESCRIPTION
![Screenshot 2019-05-21 19 20 05](https://user-images.githubusercontent.com/242329/58120582-73211100-7bfd-11e9-81f0-656edccb0bf2.png)

After making this change, I'm not any more convinced it's useful. One to chat about on the call tomorrow.

As I'd done the work of adding a card that only shows up when polls are open, I thought I'd PR it anyway.

4e229eb changes the "we don't know" page a bit – I think it's slightly better wording than before (e.g not using "data"). Not going to care too much if I'm wrong though. Another thing to ~bike shed~ talk about tomorrow.