### PR TITLE
WIP remove local auth workarounds

### DIFF
--- a/polling_stations/apps/councils/management/commands/import_councils.py
+++ b/polling_stations/apps/councils/management/commands/import_councils.py
@@ -192,6 +192,12 @@ class Command(BaseCommand):
             elif council_id == "S12000048":
                 # Perth & Kinross
                 data = self.get_from_yvm("S12000024")
+            elif council_id == "S12000049":
+                # Glasgow
+                data = self.get_from_yvm("S12000046")
+            elif council_id == "S12000050":
+                # North Lanarkshire
+                data = self.get_from_yvm("S12000044")
             elif council_id in TEMP_CONTACT_DETAILS:
                 self.stdout.write("No contact details available from YVM")
                 return TEMP_CONTACT_DETAILS[council_id]
@@ -238,7 +244,7 @@ class Command(BaseCommand):
         councils = []
         self.stdout.write("Downloading ONS boundaries from %s..." % (boundaries_url))
         councils = councils + self.get_councils(
-            boundaries_url, id_field="lad18cd", name_field="lad18nm"
+            boundaries_url, id_field="lad19cd", name_field="lad19nm"
         )
 
         councils = self.pre_process_councils(councils)

--- a/polling_stations/apps/councils/tests/test_council_importer.py
+++ b/polling_stations/apps/councils/tests/test_council_importer.py
@@ -25,9 +25,9 @@ class MockCouncilsImporter(Command):
                     "type": "Feature",
                     "properties": {
                         "objectid": 1,
-                        "lad18cd": auth["code"],
-                        "lad18nm": auth["name"],
-                        "lad14nmw": " ",
+                        "lad19cd": auth["code"],
+                        "lad19nm": auth["name"],
+                        "lad19nmw": " ",
                         "st_areashape": 123,
                         "st_lengthshape": 4564,
                     },

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -6,33 +6,6 @@ BOUNDARIES_URL = (
 )
 
 
-# The data we need won't all be
-# updated before May 2019
-# so this will help us to bodge it
-OLD_TO_NEW_MAP = {
-    # Fife
-    "S12000015": "S12000047",
-    # Perth & Kinross
-    "S12000024": "S12000048",
-    # Somerset West & Taunton
-    "E07000190": "E07000246",
-    "E07000191": "E07000246",
-    # Bournemouth, Christchurch & Poole
-    "E06000028": "E06000058",
-    "E06000029": "E06000058",
-    "E07000048": "E06000058",
-    # Dorset
-    "E07000049": "E06000059",
-    "E07000050": "E06000059",
-    "E07000051": "E06000059",
-    "E07000052": "E06000059",
-    "E07000053": "E06000059",
-    # East Suffolk
-    "E07000205": "E07000244",
-    "E07000206": "E07000244",
-    # West Suffolk
-    "E07000201": "E07000245",
-    "E07000204": "E07000245",
-}
+OLD_TO_NEW_MAP = {}
 
-NEW_COUNCILS = ["E07000246", "E06000058", "E06000059", "E07000244", "E07000245"]
+NEW_COUNCILS = []

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -2,7 +2,7 @@
 
 YVM_LA_URL = "https://www.yourvotematters.co.uk/_design/nested-content/results-page2/search-voting-locations-by-districtcode?queries_distcode_query="  # noqa
 BOUNDARIES_URL = (
-    "https://opendata.arcgis.com/datasets/b2d5f4f8e9eb469bb22af910bdc1de22_1.geojson"
+    "https://opendata.arcgis.com/datasets/2b95585accc4437b97d766f31c5568cb_0.geojson"
 )
 
 


### PR DESCRIPTION
Not ready for merge yet - the one missing piece of the puzzle for this is an updated ONSUD release (June 2019 release is still not up to date with all these changes), although the May ONSPD is. Query open with ONS Geography about this.

Closes #1698
Refs #1630
Refs https://trello.com/c/4JIFou7P
Refs https://trello.com/c/piIbUuL2
Refs https://trello.com/c/OCFJAUBn
Refs https://github.com/DemocracyClub/polling_deploy/issues/179

Co-ordinate this with changes to the deploy repo updating ONSPD, ONSUD and update:

https://github.com/DemocracyClub/polling_deploy/blob/4b9d01c2fbad3c8fa28265977342430e484a74f7/vars.yml#L12
to
https://ons-cache.s3.amazonaws.com/Local_Authority_Districts_April_2019_Boundaries_UK_BFE.geojson

I'm leaving all the code in place that uses `OLD_TO_NEW_MAP` and `NEW_COUNCILS` as we'll need theis feature again for Buckinghamshire in May 2020 ( https://www.buckscc.gov.uk/services/council-and-democracy/our-plans/unitary/ ) and Northamptonshire in 2021 ( https://www3.northamptonshire.gov.uk/councilservices/council-and-democracy/transparency/Pages/unitary-councils.aspx )