### PR TITLE
add a SHOW_MAPS setting

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from data_finder.views import LogLookUpMixin
 from data_finder.helpers import (
@@ -109,6 +110,9 @@ class ResidentialAddressViewSet(ViewSet, LogLookUpMixin):
         except PostcodeError:
             location = None
         ret["postcode_location"] = location
+        SHOW_MAPS = getattr(settings, "SHOW_MAPS", True)
+        if not SHOW_MAPS:
+            ret["postcode_location"] = None
 
         ret["polling_station_known"] = False
         ret["polling_station"] = None

--- a/polling_stations/apps/api/pollingstations.py
+++ b/polling_stations/apps/api/pollingstations.py
@@ -6,7 +6,11 @@ from rest_framework.serializers import (
     SerializerMethodField,
 )
 from rest_framework.viewsets import GenericViewSet
-from rest_framework_gis.serializers import GeoFeatureModelSerializer
+from rest_framework_gis.serializers import (
+    GeoFeatureModelSerializer,
+    GeometrySerializerMethodField,
+)
+from django.conf import settings
 from django.utils.http import urlencode
 from pollingstations.models import PollingStation
 from .mixins import PollingEntityMixin
@@ -49,6 +53,7 @@ class PollingStationGeoSerializer(PollingStationSerializer, GeoFeatureModelSeria
     id = SerializerMethodField("generate_id")
     urls = SerializerMethodField("generate_urls")
     council = SerializerMethodField("generate_council")
+    location = GeometrySerializerMethodField("generate_location")
 
     def generate_council(self, record):
         return reverse(
@@ -59,6 +64,12 @@ class PollingStationGeoSerializer(PollingStationSerializer, GeoFeatureModelSeria
 
     def generate_id(self, record):
         return "%s.%s" % (record.council_id, record.internal_council_id)
+
+    def generate_location(self, record):
+        SHOW_MAPS = getattr(settings, "SHOW_MAPS", True)
+        if not SHOW_MAPS:
+            return None
+        return record.location
 
     class Meta:
         model = PollingStation

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -1,6 +1,7 @@
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from data_finder.views import LogLookUpMixin
 from data_finder.helpers import (
@@ -81,6 +82,9 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
             location = None
 
         ret["postcode_location"] = location
+        SHOW_MAPS = getattr(settings, "SHOW_MAPS", True)
+        if not SHOW_MAPS:
+            ret["postcode_location"] = None
 
         # council object
         if rh.route_type == "multiple_councils" or not loc:

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -152,6 +152,9 @@ class BasePollingStationView(
 
         self.council = self.get_council(loc)
         self.station = self.get_station()
+        SHOW_MAPS = getattr(settings, "SHOW_MAPS", True)
+        if not SHOW_MAPS and self.station:
+            self.station.location = None
         self.directions = self.get_directions()
 
         ee = self.get_ee_wrapper()

--- a/polling_stations/settings/testing.py
+++ b/polling_stations/settings/testing.py
@@ -3,6 +3,7 @@ from .base import *  # noqa
 EVERY_ELECTION["CHECK"] = True  # noqa
 NEXT_CHARISMATIC_ELECTION_DATE = None
 DISABLE_GA = True  # don't log to Google Analytics when we are running tests
+SHOW_MAPS = True
 
 INSTALLED_APPS = list(INSTALLED_APPS)  # noqa
 INSTALLED_APPS.append("aloe_django")


### PR DESCRIPTION
We've talked a bit about whether in the event of a snap election we could increase coverage and still provide a useful service but eliminate one of the major sources of errors/checking by just showing polling station address, but no map/directions etc. This is what some of our major data consumers do (e.g: the Electoral Commission). We may have a chance to find out in the near future.

This PR gives us a global setting we can use to just stop serving maps via the front-end or any point/location data via the API. My thinking with this approach is that its still useful to import/store points in the DB and be able to use them in dev/QGIS for checking purposes, but just not serve maps to users.

The downside with this approach is its a sledgehammer, not a scalpel. We can't turn it on for some councils but off for others, for example.