### PR TITLE
add every election THRESHOLD_DAYS setting

### DIFF
--- a/polling_stations/apps/data_finder/helpers/every_election.py
+++ b/polling_stations/apps/data_finder/helpers/every_election.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import requests
 from django.conf import settings
 from uk_geo_utils.helpers import Postcode
@@ -161,7 +161,14 @@ class EveryElectionWrapper:
             return True
 
         if len(self.ballots) > 0 and not self.all_ballots_cancelled:
-            return True
+            if not settings.EVERY_ELECTION["THRESHOLD_DAYS"]:
+                return True
+            if (
+                datetime.strptime(self._get_next_election_date(), "%Y-%m-%d")
+                - timedelta(days=settings.EVERY_ELECTION["THRESHOLD_DAYS"])
+                <= datetime.now()
+            ):
+                return True
         return False
 
     def get_explanations(self):

--- a/polling_stations/settings/constants/elections.py
+++ b/polling_stations/settings/constants/elections.py
@@ -10,9 +10,11 @@ Set CHECK to False to return the value of HAS_ELECTION instead
 
 This is mostly useful in development when we want
 to see results even if there is no election happening
-"""
-EVERY_ELECTION = {"CHECK": True, "HAS_ELECTION": True}
 
-ELECTION_BLACKLIST = [
-    "local.epping-forest.moreton-and-fyfield.by.2018-05-03"  # uncontested
-]
+THRESHOLD_DAYS allows us to ignore elections which are
+more than N days in the future when determining has_election.
+Set to None or zero to ignore
+"""
+EVERY_ELECTION = {"CHECK": True, "HAS_ELECTION": True, "THRESHOLD_DAYS": 90}
+
+ELECTION_BLACKLIST = []

--- a/polling_stations/settings/testing.py
+++ b/polling_stations/settings/testing.py
@@ -1,6 +1,7 @@
 from .base import *  # noqa
 
 EVERY_ELECTION["CHECK"] = True  # noqa
+EVERY_ELECTION["THRESHOLD_DAYS"] = None  # noqa
 NEXT_CHARISMATIC_ELECTION_DATE = None
 DISABLE_GA = True  # don't log to Google Analytics when we are running tests
 


### PR DESCRIPTION
This is a bit obscure, but the problem I'm trying to solve here is: We would like to start creating ids for elections in May next year, but as soon as we do that, we shift to saying "we don't know" instead of "no upcoming elections" in all the areas where we do that. This allows us to set a number of days (opening gambit: 90 days) beyond which we'll ignore upcoming elections (in the front-end, for the purpose of serving a polling station result).
That means we can start creating IDs for elections we know are going to happen in May next year but ignore them in WDIV until nearer the time.