### PR TITLE
Preserve particular query parameters across RoutingHelper redirects

### DIFF
--- a/polling_stations/apps/addressbase/tests/test_addressbase.py
+++ b/polling_stations/apps/addressbase/tests/test_addressbase.py
@@ -126,8 +126,7 @@ class PostcodeBoundaryFixerTestCase(TestCase):
         # Before the fix, we wrongly assume that we know the polling station
         postcode = "KW15 88TF"
         rh = RoutingHelper(postcode)
-        endpoint = rh.get_endpoint()
-        self.assertEqual("postcode_view", endpoint.view)
+        self.assertEqual("postcode_view", rh.view)
 
         # Fix the addresses outside of the districts
         fixer = EdgeCaseFixer("X01000001", MockLogger())
@@ -136,8 +135,7 @@ class PostcodeBoundaryFixerTestCase(TestCase):
 
         # Now we should get offered an address lookup
         rh = RoutingHelper(postcode)
-        endpoint = rh.get_endpoint()
-        self.assertEqual("address_select_view", endpoint.view)
+        self.assertEqual("address_select_view", rh.view)
 
     def test_make_addresses_cross_borders(self):
         """

--- a/polling_stations/apps/data_finder/helpers/routing.py
+++ b/polling_stations/apps/data_finder/helpers/routing.py
@@ -86,10 +86,9 @@ class RoutingHelper:
 
     @cached_property
     def kwargs(self):
-        if self.route_type in ("multiple_councils", "multiple_addresses", "postcode"):
-            return {"postcode": self.postcode}
-        if self.route_type in {"single_address"}:
+        if self.route_type == "single_address":
             return {"address_slug": self.addresses[0].slug}
+        return {"postcode": self.postcode}
 
     def get_canonical_url(self, request, preserve_query=True):
         """Returns a canonical URL to route to, preserving any important query parameters"""

--- a/polling_stations/apps/data_finder/tests/test_routing_helper.py
+++ b/polling_stations/apps/data_finder/tests/test_routing_helper.py
@@ -1,3 +1,6 @@
+from unittest import mock
+
+from django.http import QueryDict
 from django.test import TestCase
 from addressbase.models import Blacklist
 from data_finder.helpers import RoutingHelper
@@ -57,3 +60,21 @@ class RoutingHelperTest(TestCase):
         rh = RoutingHelper("dd11dd")
         endpoint = rh.get_endpoint()
         self.assertEqual("multiple_councils_view", endpoint.view)
+
+    def test_canonical_url(self):
+        rh = RoutingHelper("AA11AA")
+        request = mock.Mock()
+        request.GET = QueryDict("utm_source=foo&something=other")
+        # Could be either slug
+        self.assertRegexpMatches(
+            rh.get_canonical_url(request), "/address/[12]/\?utm_source=foo"
+        )
+
+    def test_canonical_url_without_preserve(self):
+        rh = RoutingHelper("AA11AA")
+        request = mock.Mock()
+        request.GET = QueryDict("utm_source=foo&something=other")
+        # Could be either slug
+        self.assertRegexpMatches(
+            rh.get_canonical_url(request, preserve_query=False), "/address/[12]/"
+        )

--- a/polling_stations/apps/data_finder/tests/test_routing_helper.py
+++ b/polling_stations/apps/data_finder/tests/test_routing_helper.py
@@ -12,25 +12,21 @@ class RoutingHelperTest(TestCase):
 
     def test_address_view(self):
         rh = RoutingHelper("AA11AA")
-        endpoint = rh.get_endpoint()
-        self.assertEqual("address_view", endpoint.view)
+        self.assertEqual("address_view", rh.view)
 
     def test_address_select_view(self):
         rh = RoutingHelper("BB11BB")
-        endpoint = rh.get_endpoint()
-        self.assertEqual("address_select_view", endpoint.view)
+        self.assertEqual("address_select_view", rh.view)
 
     def test_postcode_view(self):
         rh = RoutingHelper("CC11CC")
-        endpoint = rh.get_endpoint()
-        self.assertEqual("postcode_view", endpoint.view)
+        self.assertEqual("postcode_view", rh.view)
 
     def test_multiple_councils_view(self):
         # check we are directed to multiple_councils_view if
         # postcode is attached to multiple councils in the blacklist
         rh = RoutingHelper("DD11DD")
-        endpoint = rh.get_endpoint()
-        self.assertEqual("multiple_councils_view", endpoint.view)
+        self.assertEqual("multiple_councils_view", rh.view)
 
     def test_multiple_councils_view_override(self):
         # insert blacklist records for postcodes matching other conditions
@@ -43,23 +39,19 @@ class RoutingHelperTest(TestCase):
 
         # check the blacklist overrides all other conditions
         rh = RoutingHelper("AA11AA")
-        endpoint = rh.get_endpoint()
-        self.assertEqual("multiple_councils_view", endpoint.view)
+        self.assertEqual("multiple_councils_view", rh.view)
 
         rh = RoutingHelper("BB11BB")
-        endpoint = rh.get_endpoint()
-        self.assertEqual("multiple_councils_view", endpoint.view)
+        self.assertEqual("multiple_councils_view", rh.view)
 
         rh = RoutingHelper("CC11CC")
-        endpoint = rh.get_endpoint()
-        self.assertEqual("multiple_councils_view", endpoint.view)
+        self.assertEqual("multiple_councils_view", rh.view)
 
     def test_multiple_councils_lowercase_postcode(self):
         # check we are directed to multiple_councils_view if
         # postcode is attached to multiple councils in the blacklist
         rh = RoutingHelper("dd11dd")
-        endpoint = rh.get_endpoint()
-        self.assertEqual("multiple_councils_view", endpoint.view)
+        self.assertEqual("multiple_councils_view", rh.view)
 
     def test_canonical_url(self):
         rh = RoutingHelper("AA11AA")

--- a/polling_stations/apps/data_finder/tests/test_routing_helper.py
+++ b/polling_stations/apps/data_finder/tests/test_routing_helper.py
@@ -58,7 +58,7 @@ class RoutingHelperTest(TestCase):
         request = mock.Mock()
         request.GET = QueryDict("utm_source=foo&something=other")
         # Could be either slug
-        self.assertRegexpMatches(
+        self.assertRegex(
             rh.get_canonical_url(request), "/address/[12]/\?utm_source=foo"
         )
 
@@ -67,6 +67,6 @@ class RoutingHelperTest(TestCase):
         request = mock.Mock()
         request.GET = QueryDict("utm_source=foo&something=other")
         # Could be either slug
-        self.assertRegexpMatches(
+        self.assertRegex(
             rh.get_canonical_url(request, preserve_query=False), "/address/[12]/"
         )

--- a/polling_stations/apps/data_finder/tests/test_views.py
+++ b/polling_stations/apps/data_finder/tests/test_views.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+
+
+class HomeViewTestCase(TestCase):
+    fixtures = ["test_routing.json"]
+
+    def test_get(self):
+        response = self.client.get("/")
+        self.assertEqual(200, response.status_code)
+
+    def test_redirect(self):
+        response = self.client.post(
+            r"/?utm_source=foo&something=other", {"postcode": "AA11AA"}, follow=False
+        )
+        self.assertEqual(302, response.status_code)
+        # The query string isn't preserved, because they've come from the home page, and it could be either slug
+        # for the postcode given (hence the [12])
+        self.assertRegexpMatches(response["Location"], "/address/[12]/")
+
+
+class PostCodeViewTestCase(TestCase):
+    fixtures = ["test_routing.json"]
+
+    def test_redirect_if_should_be_other_view(self):
+        # This should go to the address picker, because it's split over multiple polling districts
+        response = self.client.get(
+            "/postcode/BB11BB/?utm_source=foo&something=other", follow=False
+        )
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(response["Location"], "/address_select/BB11BB/?utm_source=foo")
+
+
+class MultipleCouncilsViewTestCase(TestCase):
+    fixtures = ["test_routing.json"]
+
+    def test_redirect_if_should_be_other_view(self):
+        # This should go to the address page, because it's actually entirely within one council and polling district
+        response = self.client.get(
+            "/multiple_councils/AA11AA/?utm_source=foo&something=other", follow=False
+        )
+        self.assertEqual(302, response.status_code)
+        self.assertRegexpMatches(
+            response["Location"], r"/address/[12]/\?utm_source=foo"
+        )

--- a/polling_stations/apps/data_finder/tests/test_views.py
+++ b/polling_stations/apps/data_finder/tests/test_views.py
@@ -15,7 +15,7 @@ class HomeViewTestCase(TestCase):
         self.assertEqual(302, response.status_code)
         # The query string isn't preserved, because they've come from the home page, and it could be either slug
         # for the postcode given (hence the [12])
-        self.assertRegexpMatches(response["Location"], "/address/[12]/")
+        self.assertRegex(response["Location"], "/address/[12]/")
 
 
 class PostCodeViewTestCase(TestCase):
@@ -39,6 +39,4 @@ class MultipleCouncilsViewTestCase(TestCase):
             "/multiple_councils/AA11AA/?utm_source=foo&something=other", follow=False
         )
         self.assertEqual(302, response.status_code)
-        self.assertRegexpMatches(
-            response["Location"], r"/address/[12]/\?utm_source=foo"
-        )
+        self.assertRegex(response["Location"], r"/address/[12]/\?utm_source=foo")

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -92,8 +92,8 @@ class HomeView(WhiteLabelTemplateOverrideMixin, FormView):
         postcode = Postcode(form.cleaned_data["postcode"])
 
         rh = RoutingHelper(postcode)
-        endpoint = rh.get_endpoint()
-        self.success_url = reverse(endpoint.view, kwargs=endpoint.kwargs)
+        # Don't preserve query, as the user has already been to an HTML page
+        self.success_url = rh.get_canonical_url(self.request, preserve_query=False)
 
         return super(HomeView, self).form_valid(form)
 
@@ -190,9 +190,8 @@ class PostcodeView(BasePollingStationView):
             return HttpResponseRedirect(reverse("home"))
 
         rh = RoutingHelper(self.kwargs["postcode"])
-        endpoint = rh.get_endpoint()
-        if endpoint.view != "postcode_view":
-            return HttpResponseRedirect(reverse(endpoint.view, kwargs=endpoint.kwargs))
+        if rh.view != "postcode_view":
+            return HttpResponseRedirect(rh.get_canonical_url(request))
         else:
             # we are already in postcode_view
             self.postcode = Postcode(kwargs["postcode"])
@@ -326,9 +325,8 @@ class MultipleCouncilsView(TemplateView, LogLookUpMixin, LanguageMixin):
     def get(self, request, *args, **kwargs):
         self.postcode = Postcode(self.kwargs["postcode"])
         rh = RoutingHelper(self.postcode)
-        endpoint = rh.get_endpoint()
-        if endpoint.view != "multiple_councils_view":
-            return HttpResponseRedirect(reverse(endpoint.view, kwargs=endpoint.kwargs))
+        if rh.view != "multiple_councils_view":
+            return HttpResponseRedirect(rh.get_canonical_url(request))
 
         self.council_ids = rh.councils
         context = self.get_context_data(**kwargs)


### PR DESCRIPTION
This pulls redirect URL generation into RoutingHelper so that it can optionally preserve utm_* query parameters.

This then obviates the need for `.get_endpoint()`, which has been removed.

Resolves #1368.