### PR TITLE
Get CI passing again after external changes to test ecosystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - sudo cp src/drafter.h /usr/include/drafter/drafter.h
   - cd ..
   - rm -rf drafter-v3.2.7/
-  - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/77.0.3865.40/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo chown root:root ./chromedriver
   - sudo chmod 755 ./chromedriver

--- a/polling_stations/apps/data_collection/management/commands/import_stevenage.py
+++ b/polling_stations/apps/data_collection/management/commands/import_stevenage.py
@@ -8,11 +8,11 @@ from uk_geo_utils.geocoders import AddressBaseGeocoder, AddressBaseException
 class Command(BaseCsvStationsCsvAddressesImporter):
     council_id = "E07000243"
     addresses_name = (
-        "local.2018-05-03/Version 1/DemocracyClub Stevenage PD removed.csv"
-    )  # from idox
+        "local.2018-05-03/Version 1/DemocracyClub Stevenage PD removed.csv"  # from idox
+    )
     stations_name = (
-        "local.2018-05-03/Version 1/stations.csv"
-    )  # extracted from PDF by hand
+        "local.2018-05-03/Version 1/stations.csv"  # extracted from PDF by hand
+    )
     elections = []
 
     def format_address(self, instr):


### PR DESCRIPTION
I assume black's opinions have changed on the syntactic construct in `import_stevenage.py` have changed since a previous version of black.

chromium-browser has also been updated in our CI test dist (xenial), so this brings in a newer version of chromedriver to match.

Once this is in, other PRs will start passing again.