### PR TITLE
Import Craven (closes #2423)

### DIFF
--- a/polling_stations/apps/data_collection/management/commands/import_craven.py
+++ b/polling_stations/apps/data_collection/management/commands/import_craven.py
@@ -5,31 +5,39 @@ from data_collection.management.commands import (
 
 class Command(BaseXpressDCCsvInconsistentPostcodesImporter):
     council_id = "E07000163"
-    addresses_name = "europarl.2019-05-23/Version 1/Democracy_Club__23May2019craven.tsv"
-    stations_name = "europarl.2019-05-23/Version 1/Democracy_Club__23May2019craven.tsv"
-    elections = ["europarl.2019-05-23"]
+    addresses_name = (
+        "parl.2019-12-12/Version 1/Democracy_Club__12December2019craven.tsv"
+    )
+    stations_name = "parl.2019-12-12/Version 1/Democracy_Club__12December2019craven.tsv"
+    elections = ["parl.2019-12-12"]
     csv_delimiter = "\t"
     csv_encoding = "windows-1252"
+    allow_station_point_from_postcode = False
 
     def address_record_to_dict(self, record):
-        rec = super().address_record_to_dict(record)
         uprn = record.property_urn.strip().lstrip("0")
 
-        if uprn == "10012775321":
-            rec["postcode"] = "BD20 8HL"
+        if record.addressline6 in ("LS29 0EU", "LS29 0RQ", "LA2 8PR"):
+            # Postcode centroid across council boundary
+            return None
+
+        if record.addressline6 == "BD20 8HO":
+            record = record._replace(addressline6="BD20 8HL")
+
+        if (record.addressline1, record.addressline2) == ("26 High Street", "Gargrave"):
+            # Previously associated UPRN was for misaddressed-in-AddressBase-to-include-'Gargrave' 26 High Street in
+            # Skipton proper.
+            record = record._replace(property_urn="10007560825")
+
+        rec = super().address_record_to_dict(record)
 
         if uprn in [
-            "100050352517",  # BD233RB -> BD231JZ : 26 High Street, Gargrave, Skipton
-            "10092993238",  # BD207RH -> BD207AR : 1 Prospect Street, Crosshills, Keighley
+            "10007566505",  # BD235EL -> BD235AD : Badger Hill House, Station Road, Threshfield, Skipton
+            "10007564535",  # BD236DA -> BD236BU : Rosemary Cottage, Main Street, Appletreewick, Skipton
             "10007564837",  # LA27DQ -> LA27DH : Bowker House Farm, Mewith Lane, Bentham, Lancaster
-        ]:
-            rec["accept_suggestion"] = True
-
-        if uprn in [
-            "10013144569",  # BD236RD -> BD231FL : The Flat, 1 Main Street, Embsay, Skipton
-            "10013144322",  # BD233LP -> BD236NF : Heber Cottage, East Marton, Skipton
-            "10013146501",  # LA28PR -> LA27DH : Mearbeck Farmhouse, White Pit Lane, Tatham, Wray, Lancaster
-            "10013148994",  # BD232EW -> BD233EW : 1 Carletonside Fold, Skipton
+            "100052044713",  # LA63HJ -> LA27HL : Greta Villa, 22 Main Street, Ingleton, Carnforth
+            "100050346180",  # BD209AZ -> BD207LD : 1 South View, Farnhill, Keighley
+            "10007559698",  # BD249PH -> BD240EH : The Old Schoolhouse, Stainforth, Settle
         ]:
             rec["accept_suggestion"] = False
 


### PR DESCRIPTION
100050347440 is wrongly geocoded to be in High Bentham, but is actually in Low
Bentham and has the right postcode, so is fine to leave as is.