### PR TITLE
Add use postcode centroids flag

### DIFF
--- a/polling_stations/apps/data_collection/base_importers.py
+++ b/polling_stations/apps/data_collection/base_importers.py
@@ -73,6 +73,7 @@ class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
     logger = None
     batch_size = None
     imports_districts = False
+    use_postcode_centroids = False
 
     def write_info(self, message):
         if self.verbosity > 0:
@@ -106,6 +107,15 @@ class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
         parser.add_argument(
             "--nochecks",
             help="<Optional> Do not perform validation checks or display context information",
+            action="store_true",
+            required=False,
+            default=False,
+        )
+
+        parser.add_argument(
+            "-p",
+            "--use-postcode-centroids",
+            help="<optional> Use postcode centroids to derive a location for polling stations",
             action="store_true",
             required=False,
             default=False,
@@ -202,6 +212,7 @@ class BaseImporter(BaseCommand, PostProcessingMixin, metaclass=abc.ABCMeta):
         self.logger = LogHelper(self.verbosity)
         self.batch_size = kwargs.get("batch_size")
         self.validation_checks = not (kwargs.get("nochecks"))
+        self.allow_station_point_from_postcode = kwargs.get("use_postcode_centroids")
 
         if self.council_id is None:
             self.council_id = args[0]

--- a/polling_stations/apps/data_collection/ems_importers.py
+++ b/polling_stations/apps/data_collection/ems_importers.py
@@ -34,7 +34,6 @@ class BaseXpressCsvImporter(BaseCsvStationsCsvAddressesImporter, metaclass=abc.A
 
     # Set this to false in an import script if we want to only set a station
     # point based on UPRN or co-ordinates (even if we've got a valid postcode)
-    allow_station_point_from_postcode = True
 
     @property
     @abc.abstractmethod
@@ -333,7 +332,6 @@ class BaseHalaroseCsvImporter(
         "pollingstationaddress_5",
     ]
     residential_uprn_field = "uprn"
-    allow_station_point_from_postcode = True
 
     def get_station_hash(self, record):
         return "-".join(
@@ -468,7 +466,6 @@ class BaseDemocracyCountsCsvImporter(
     postcode_field = "postcode"
     station_id_field = "stationcode"
     residential_uprn_field = "uprn"
-    allow_station_point_from_postcode = True
 
     def address_record_to_dict(self, record):
 

--- a/polling_stations/apps/data_collection/management/commands/import.py
+++ b/polling_stations/apps/data_collection/management/commands/import.py
@@ -142,9 +142,19 @@ class Command(BaseCommand):
 
         commands_series = []
         commands_parallel = []
-        opts = {"noclean": False, "nochecks": True, "verbosity": 1}
+        opts = {
+            "noclean": False,
+            "nochecks": True,
+            "verbosity": 1,
+            "use_postcode_centroids": False,
+        }
         if kwargs["multiprocessing"]:
-            opts = {"noclean": False, "nochecks": True, "verbosity": 0}
+            opts = {
+                "noclean": False,
+                "nochecks": True,
+                "verbosity": 0,
+                "use_postcode_centroids": False,
+            }
 
         # loop over all the import scripts
         # and build up a list of management commands to run


### PR DESCRIPTION
We generally don't want this behavior in production because it introduced more
problems than it solved - "The church is at the other end of the street!" etc.
However when checking that polling districts and their stations look plausible
it is really useful. So add the flag:
	$ manage.py import_place -p
and the postcode centroids will be used to create station points.

I haven't added tests because as far as I can tell the other flags aren't. Can do if it would be valuable.