### PR TITLE
ignore static in base .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 .sass-cache
 COMPILED/
+polling_stations/static
 
 # C extensions
 *.so


### PR DESCRIPTION
if we clear `/static`, we lose the local `.gitignore`