### PR TITLE
remove local auth workarounds

### DIFF
--- a/polling_stations/apps/addressbase/helpers.py
+++ b/polling_stations/apps/addressbase/helpers.py
@@ -1,6 +1,5 @@
 import logging
 from collections import namedtuple
-from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry
 from django.db import connection
 from councils.models import Council
@@ -72,8 +71,6 @@ class EdgeCaseFixer:
             council_id = c.council_id
         else:
             council_id = address.council_id
-            if council_id in settings.OLD_TO_NEW_MAP:
-                council_id = settings.OLD_TO_NEW_MAP[council_id]
 
         if council_id != self.target_council_id:
             # treat addresses in other council areas as district not found

--- a/polling_stations/apps/addressbase/management/commands/create_blacklist.py
+++ b/polling_stations/apps/addressbase/management/commands/create_blacklist.py
@@ -1,5 +1,4 @@
 from django.db import connection
-from django.conf import settings
 from django.core.management.base import BaseCommand
 from addressbase.models import Blacklist
 
@@ -40,17 +39,7 @@ class Command(BaseCommand):
             [postcode],
         )
         councils = self.cursor.fetchall()
-
-        # merge/de-dupe any new councils not in uprn to council lookup
-        gss_codes = [council[0] for council in councils]
-        gss_codes = [
-            settings.OLD_TO_NEW_MAP[code] if code in settings.OLD_TO_NEW_MAP else code
-            for code in gss_codes
-        ]
-        gss_codes = list(set(gss_codes))
-        if len(gss_codes) == 1:
-            return []
-        return gss_codes
+        return [council[0] for council in councils]
 
     def handle(self, *args, **kwargs):
         self.cursor = connection.cursor()

--- a/polling_stations/apps/addressbase/models.py
+++ b/polling_stations/apps/addressbase/models.py
@@ -48,7 +48,7 @@ class Blacklist(models.Model):
         unique_together = ("postcode", "lad")
 
 
-def get_uprn_hash_table(council_ids):
+def get_uprn_hash_table(council_id):
     # get all the UPRNs in target local auth
     # NB we miss ~25 over the country because lighthouses etc.
     cursor = connection.cursor()
@@ -61,9 +61,9 @@ def get_uprn_hash_table(council_ids):
             a.location
         FROM addressbase_address a
         JOIN addressbase_uprntocouncil u ON a.uprn=u.uprn
-        WHERE u.lad IN %s;
+        WHERE u.lad=%s;
         """,
-        [council_ids],
+        [council_id],
     )
     # return result a hash table keyed by UPRN
     return {

--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -506,7 +506,7 @@ class AddressList:
     def save(self, batch_size, fuzzy_match, match_threshold):
 
         self.remove_ambiguous_addresses_by_address()
-        addressbase_data = get_uprn_hash_table(self.council_ids)
+        addressbase_data = get_uprn_hash_table(self.council_id)
         self.handle_invalid_uprns(addressbase_data, fuzzy_match, match_threshold)
         self.attach_doorstep_gridrefs(addressbase_data)
         self.remove_addresses_outside_target_auth()

--- a/polling_stations/apps/data_finder/helpers/geocoders.py
+++ b/polling_stations/apps/data_finder/helpers/geocoders.py
@@ -64,30 +64,9 @@ class OnspdGeocoderAdapter(BaseGeocoder):
         return geocoder
 
 
-class PatchedABGeocoder(AddressBaseGeocoder):
-    def get_code(self, code_type, *args, **kwargs):
-        try:
-            code = super().get_code(code_type, *args, **kwargs)
-        except MultipleCodesException:
-            if code_type != "lad":
-                raise
-            gss_codes = set([getattr(u, "lad") for u in self._uprns])
-            gss_codes = [
-                settings.OLD_TO_NEW_MAP[code]
-                if code in settings.OLD_TO_NEW_MAP
-                else code
-                for code in gss_codes
-            ]
-            gss_codes = list(set(gss_codes))
-            if len(gss_codes) > 1:
-                raise
-            return gss_codes[0]
-        return code
-
-
 class AddressBaseGeocoderAdapter(BaseGeocoder):
     def geocode(self):
-        geocoder = PatchedABGeocoder(self.postcode)
+        geocoder = AddressBaseGeocoder(self.postcode)
         geocoder.centroid
 
         try:

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -1,9 +1,7 @@
 # settings for councils scraper
 
 YVM_LA_URL = "https://www.yourvotematters.co.uk/_design/nested-content/results-page2/search-voting-locations-by-districtcode?queries_distcode_query="  # noqa
-BOUNDARIES_URL = (
-    "https://opendata.arcgis.com/datasets/2b95585accc4437b97d766f31c5568cb_0.geojson"
-)
+BOUNDARIES_URL = "https://ons-cache.s3.amazonaws.com/Local_Authority_Districts_April_2019_Boundaries_UK_BFE.geojson"
 
 
 # The data we need won't all be

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -4,37 +4,6 @@ YVM_LA_URL = "https://www.yourvotematters.co.uk/_design/nested-content/results-p
 BOUNDARIES_URL = "https://ons-cache.s3.amazonaws.com/Local_Authority_Districts_April_2019_Boundaries_UK_BFE.geojson"
 
 
-# The data we need won't all be
-# updated before May 2019
-# so this will help us to bodge it
-OLD_TO_NEW_MAP = {
-    # Fife
-    "S12000015": "S12000047",
-    # Perth & Kinross
-    "S12000024": "S12000048",
-    # Glasgow
-    "S12000046": "S12000049",
-    # North Lanarkshire
-    "S12000044": "S12000050",
-    # Somerset West & Taunton
-    "E07000190": "E07000246",
-    "E07000191": "E07000246",
-    # Bournemouth, Christchurch & Poole
-    "E06000028": "E06000058",
-    "E06000029": "E06000058",
-    "E07000048": "E06000058",
-    # Dorset
-    "E07000049": "E06000059",
-    "E07000050": "E06000059",
-    "E07000051": "E06000059",
-    "E07000052": "E06000059",
-    "E07000053": "E06000059",
-    # East Suffolk
-    "E07000205": "E07000244",
-    "E07000206": "E07000244",
-    # West Suffolk
-    "E07000201": "E07000245",
-    "E07000204": "E07000245",
-}
+OLD_TO_NEW_MAP = {}
 
-NEW_COUNCILS = ["E07000246", "E06000058", "E06000059", "E07000244", "E07000245"]
+NEW_COUNCILS = []


### PR DESCRIPTION
Now that we're using the latest ONSPD and we've got rid of ONSUD completely, everything we rely on is using the new codes/boundaries for all these areas.

Refs #1630
Refs https://trello.com/c/4JIFou7P
Refs https://trello.com/c/piIbUuL2
Refs https://trello.com/c/OCFJAUBn

I'm leaving any code in place that uses `OLD_TO_NEW_MAP` and `NEW_COUNCILS` which refs the councils table or ONSPD as we may need this feature again for Buckinghamshire in May 2020 and Northamptonshire in 2021.

I'm removing any code which assumes that the ONSUD exists or could not be up-to-date on the basis that we'll apply modifications to the councils table then generate a uprntocouncil table which reflects those changes, so it will always be as up-to-date as the councils table.
