### PR TITLE
Add ONSPD postcode centroid to dashboard.

### DIFF
--- a/polling_stations/apps/dashboard/templates/dashboard/postcode.html
+++ b/polling_stations/apps/dashboard/templates/dashboard/postcode.html
@@ -61,6 +61,7 @@
                     map.fitBounds(layer.getBounds(), {padding: [30, 30]});
                 })
             });
+
         })();
     </script>
 {% endblock in_page_javascript %}

--- a/polling_stations/apps/dashboard/templates/dashboard/postcode.html
+++ b/polling_stations/apps/dashboard/templates/dashboard/postcode.html
@@ -21,7 +21,8 @@
 
             var typeIcons = {
                 'pollingstation': 'fa-check-square',
-                'residentialaddress': 'fa-home'
+                'residentialaddress': 'fa-home',
+                'onspd': 'fa-flag'
             };
 
             tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -32,6 +33,7 @@
             map = L.map('area_map', {
                 layers: [tiles]
             });
+
             fetch('{% url "dashboard:postcode-geojson" postcode %}').then((response) => {
                 response.json().then((json) => {
                     layer = L.geoJSON(json, {


### PR DESCRIPTION
This might be useful when there's a split postcode. I haven't totally decide about this as we don't want the bar for throwing away a single property from a postcode (as opposed to the whole postcode) to be high (i.e. it's obviously really wrong). So I'm not sure this makes it an easier call, but it is an extra bit of information. 