### PR TITLE
don't email us about 503 from status_check

### DIFF
--- a/polling_stations/apps/pollingstations/filters.py
+++ b/polling_stations/apps/pollingstations/filters.py
@@ -1,0 +1,12 @@
+import logging
+
+
+class StatusCheckFilter(logging.Filter):
+    def filter(self, record):
+        if (
+            record.status_code == 503
+            and hasattr(record, "request")
+            and "status_check" in record.request.path
+        ):
+            return False
+        return True

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -180,11 +180,14 @@ SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+    "filters": {
+        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
+        "ignore_status_checks": {"()": "pollingstations.filters.StatusCheckFilter"},
+    },
     "handlers": {
         "mail_admins": {
             "level": "ERROR",
-            "filters": ["require_debug_false"],
+            "filters": ["require_debug_false", "ignore_status_checks"],
             "class": "django.utils.log.AdminEmailHandler",
         },
         "null": {"class": "logging.NullHandler"},


### PR DESCRIPTION
I always forget about this until we're trying to deploy an image, but whenever we do this, we get spammed with a bunch of emails saying `[Django] ERROR (internal IP): Service Unavailable: /status_check/` while the server initializes.
I've never worked out why sentry doesn't swallow this particular error, but its annoying.
This filter should drop this specific log event but pass all others.