### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/polling_stations/apps/data_collection/data_types.py
+++ b/polling_stations/apps/data_collection/data_types.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 
 from django.conf import settings
 from django.forms import ValidationError
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from localflavor.gb.forms import GBPostcodeField
 
 from addressbase.models import Blacklist, get_uprn_hash_table
@@ -383,7 +383,7 @@ class AddressList:
                     self.logger.log_message(
                         logging.INFO,
                         "Correcting postcode based on UPRN and fuzzy match.\nInput Record:\n%s\nAddressbase record:\n%s\nMatch quality: %s\n",
-                        variable=(record, addressbase_record, match_quality),
+                        variable=(record, addressbase_record, round(match_quality)),
                     )
                     record["postcode"] = addressbase_record["postcode"]
                 elif match_quality <= 50:
@@ -440,7 +440,7 @@ class AddressList:
                             record["address"],
                             record,
                             addressbase_record,
-                            match_quality,
+                            round(match_quality),
                         ),
                     )
                     record["uprn"] = ""

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,12 +9,11 @@ djangorestframework==3.11.0
 djangorestframework-gis==0.15
 django-cors-headers==3.2.1
 fastkml==0.11
-fuzzywuzzy==0.18.0
+rapidfuzz==0.2.2
 lxml==4.5.0
 marshmallow==3.5.1
 psycopg2-binary==2.8.4
 pyshp==2.1.0
-python-levenshtein==0.12.0
 raven==6.10.0
 requests==2.23.0
 retry==0.9.2

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ skipsdist = True
 3.6 = py36
 
 [testenv]
+; download the latest pip, setuptools and wheel when creating the venv
+download = true
 passenv = *
 deps = -r{toxinidir}/requirements/testing.txt
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.