### PR TITLE
Add option to update council contact details

### DIFF
--- a/polling_stations/apps/councils/tests/test_council_importer.py
+++ b/polling_stations/apps/councils/tests/test_council_importer.py
@@ -52,6 +52,13 @@ class TestCouncilImporter(TestCase):
         # suppress output
         out = StringIO()
         cmd.stdout = out
-        cmd.handle(**{"teardown": False, "alt_url": None, "contact_type": "vjbs"})
+        cmd.handle(
+            **{
+                "teardown": False,
+                "alt_url": None,
+                "contact_type": "vjbs",
+                "update_contact_details": False,
+            }
+        )
 
         assert Council.objects.count() == 6


### PR DESCRIPTION
This is useful for running as an ad-hoc command when a single council
contact detail changes, but also paves the way for consuming contact
details from a 3rd party API on a cron job.