### PR TITLE
fix fail-on-template-vars errors

### DIFF
--- a/polling_stations/apps/bug_reports/forms.py
+++ b/polling_stations/apps/bug_reports/forms.py
@@ -12,3 +12,5 @@ class BugReportForm(forms.ModelForm):
     )
     source_url = forms.CharField(widget=forms.HiddenInput(), required=False)
     source = forms.CharField(widget=forms.HiddenInput(), required=False)
+    required_css_class = "required"
+    error_css_class = "error"

--- a/polling_stations/apps/data_finder/forms.py
+++ b/polling_stations/apps/data_finder/forms.py
@@ -5,6 +5,9 @@ from localflavor.gb.forms import GBPostcodeField
 
 class PostcodeLookupForm(forms.Form):
     postcode = GBPostcodeField(label="Enter your postcode")
+    required_css_class = "required"
+    error_css_class = "error"
+
 
 
 class AddressSelectForm(forms.Form):

--- a/polling_stations/apps/data_finder/forms.py
+++ b/polling_stations/apps/data_finder/forms.py
@@ -9,7 +9,6 @@ class PostcodeLookupForm(forms.Form):
     error_css_class = "error"
 
 
-
 class AddressSelectForm(forms.Form):
     address = forms.ChoiceField(
         choices=(),

--- a/polling_stations/apps/pollingstations/context_processors.py
+++ b/polling_stations/apps/pollingstations/context_processors.py
@@ -10,3 +10,7 @@ def global_settings(request):
         "RAVEN_CONFIG": getattr(settings, "RAVEN_CONFIG", None),
         "SERVER_ENVIRONMENT": getattr(settings, "SERVER_ENVIRONMENT", None),
     }
+
+
+def canonical_url(request):
+    return {"CANONICAL_URL": getattr(settings, "CANONICAL_URL", '')}

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -120,6 +120,7 @@ TEMPLATES = [
                 "bug_reports.context_processors.bug_report_form",
                 "pollingstations.context_processors.google_analytics",
                 "pollingstations.context_processors.global_settings",
+                "pollingstations.context_processors.canonical_url",
                 "whitelabel.context_processors.base_template",
             ],
         },
@@ -301,3 +302,5 @@ if DEBUG:
 # importing test settings file if necessary (TODO chould be done better)
 if len(sys.argv) > 1 and sys.argv[1] in ["test", "harvest"]:
     from .testing import *  # noqa
+
+CANONICAL_URL= ''

--- a/polling_stations/settings/testing.py
+++ b/polling_stations/settings/testing.py
@@ -13,3 +13,5 @@ MIGRATION_MODULES = {app: None for app in INSTALLED_APPS if "django" not in app}
 
 MAPZEN_API_KEY = ""
 GOOGLE_API_KEYS = []
+
+SILENCED_SYSTEM_CHECKS = ["templates.E002"]


### PR DESCRIPTION
Fixes nearly all errors from running `pytest --fail-on-template-vars` as requested in issue #2802.

**string_if_invalid**
when setting `pytest --fail-on-template-vars`, pytest-django overwrites the template option `string_if_invalid` to an exception. This causes a lot of errors of the form 
`'string_if_invalid' in TEMPLATES OPTIONS must be a string but got: ...` [33e3abf](https://github.com/DemocracyClub/UK-Polling-Stations/commit/33e3abf30ec97c3b6fef28f9588ecfdadca7eb1d) removes this error by not running the system check `templates.E002` when testing.

**required_css_class**
The `dc_base_theme` repository's `field.html` [template](https://github.com/DemocracyClub/dc_base_theme/blob/master/dc_theme/templates/dc_forms/field.html) expects the form to have a `required_css_class` property. [eb15152](https://github.com/DemocracyClub/UK-Polling-Stations/commit/eb15152e93197546ab79b871b90e38a239880712) and [6a98de9](https://github.com/DemocracyClub/UK-Polling-Stations/commit/6a98de974ead4a0ed1ea6fc187ef50f3eede4769) add those properties to the relevant forms. It may be that a better solution is to remove the expectation of that property from the template.

**CANONICAL_URL**
The `base_full.html` template expects `CANONICAL_URL` in its context. [0af9439](https://github.com/DemocracyClub/UK-Polling-Stations/commit/0af9439b57aed713f65e38d78c902f183e219254) creates a context_processor to add `CANONICAL_URL` to context. [9330d48](https://github.com/DemocracyClub/UK-Polling-Stations/commit/9330d483d9effd1ce164e6c03fb0db41dd9ee93b) adds this context processor to the list of context processors and adds the setting variable `CANONICAL_URL` to `base_settings.py`. This will need to be overridden in production.

**Undefined template variable 'media'**
The outstanding error is `Failed: Undefined template variable 'media' in '.../site-packages/pipeline/templates/pipeline/css.html'`.


