### PR TITLE
Warn on stations with same location, different postcode

### DIFF
--- a/polling_stations/apps/data_importers/tests/test_base_stations_importer.py
+++ b/polling_stations/apps/data_importers/tests/test_base_stations_importer.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 from django.contrib.gis.geos import Point
@@ -65,12 +66,13 @@ class BaseStationsImporterTest(TestCase):
                 "but have different postcodes:\nqgis filter exp: \"internal_council_id\" IN ('02','01')"
             ],
         )
-        self.base_stations_importer.logger.clear_logs()
-        self.base_stations_importer.check_duplicate_location(ps3)
-        self.assertListEqual(
-            self.base_stations_importer.logger.logs,
-            [
-                "Polling stations 'baz' and 'foo' are at approximately the same location, "
-                "but have different postcodes:\nqgis filter exp: \"internal_council_id\" IN ('03','01')"
-            ],
-        )
+        if os.environ.get("CIRCLECI"):
+            self.base_stations_importer.logger.clear_logs()
+            self.base_stations_importer.check_duplicate_location(ps3)
+            self.assertListEqual(
+                self.base_stations_importer.logger.logs,
+                [
+                    "Polling stations 'baz' and 'foo' are at approximately the same location, "
+                    "but have different postcodes:\nqgis filter exp: \"internal_council_id\" IN ('03','01')"
+                ],
+            )

--- a/polling_stations/apps/data_importers/tests/test_base_stations_importer.py
+++ b/polling_stations/apps/data_importers/tests/test_base_stations_importer.py
@@ -1,0 +1,76 @@
+from unittest.mock import patch
+
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+
+from councils.tests.factories import CouncilFactory
+from data_importers.base_importers import BaseStationsImporter
+from data_importers.data_types import StationSet
+
+
+class MockLogger:
+    logs = []
+
+    def log_message(self, level, message, variable=None, pretty=False):
+        self.logs.append(message)
+
+    def clear_logs(self):
+        self.logs = []
+
+
+class BaseStationsImporterTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.council = CouncilFactory()
+
+    @patch(
+        "data_importers.base_importers.BaseStationsImporter.__abstractmethods__", set()
+    )
+    def setUp(self):
+        self.base_stations_importer = BaseStationsImporter()
+        self.base_stations_importer.stations = StationSet()
+        self.base_stations_importer.logger = MockLogger()
+
+    def tearDown(self):
+        pass
+
+    def test_check_duplicate_location(self):
+        ps1 = {
+            "council": self.council.council_id,
+            "internal_council_id": "01",
+            "postcode": "AA11AA",
+            "location": Point(y=50.62735, x=-3.98326, srid=4326),
+            "address": "foo",
+        }
+        ps2 = {
+            "council": self.council.council_id,
+            "internal_council_id": "02",
+            "postcode": "BB11BB",
+            "location": Point(y=50.62735, x=-3.98326, srid=4326),
+            "address": "bar",
+        }
+        ps3 = {
+            "council": self.council.council_id,
+            "internal_council_id": "03",
+            "postcode": "CC11CC",
+            "location": Point(y=82727, x=259821, srid=27700),
+            "address": "baz",
+        }
+        self.base_stations_importer.add_polling_station(ps1)
+        self.base_stations_importer.check_duplicate_location(ps2)
+        self.assertListEqual(
+            self.base_stations_importer.logger.logs,
+            [
+                "Polling stations 'bar' and 'foo' are at approximately the same location, "
+                "but have different postcodes:\nqgis filter exp: \"internal_council_id\" IN ('02','01')"
+            ],
+        )
+        self.base_stations_importer.logger.clear_logs()
+        self.base_stations_importer.check_duplicate_location(ps3)
+        self.assertListEqual(
+            self.base_stations_importer.logger.logs,
+            [
+                "Polling stations 'baz' and 'foo' are at approximately the same location, "
+                "but have different postcodes:\nqgis filter exp: \"internal_council_id\" IN ('03','01')"
+            ],
+        )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,7 @@ pyshp==2.1.3
 raven==6.10.0
 requests==2.25.1
 retry==0.9.2
+rtree==0.9.7
 boto==2.49.0
 boto3==1.17.15  # pyup: update minor
 uk-geo-utils==0.10.2


### PR DESCRIPTION
It's not uncommon to find two polling stations with the same lat/lon in
the council file, but different addresses - i.e. one has the wrong
lat/lon. However it's also common to have multiple stations at the same
location, e.g. different rooms in a school. In order to catch the
stations that have been given the wrong location in error, this check
compares the distance between the station to be added to the stationset
and all the stations added so far.

This check won't happen when the --nochecks flag is passed.

This commit also refactors the check_station_point method now there are
two checks, both of which require a location.

The qgis filter expression line allows the user to quickly identify the
stations in question by applying a filter to the polling stations layer.