### PR TITLE
Tidy ups to catch split postcodes

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_adur.py
+++ b/polling_stations/apps/data_importers/management/commands/import_adur.py
@@ -7,3 +7,9 @@ class Command(BaseXpressDemocracyClubCsvImporter):
     stations_name = "2021-02-15T11:20:20.221841/ADCDemocracy_Club__06May2021.tsv"
     elections = ["2021-05-06"]
     csv_delimiter = "\t"
+
+    def address_record_to_dict(self, record):
+        if record.addressline6 == "BN43 6DF":
+            return None
+
+        return super().address_record_to_dict(record)

--- a/polling_stations/apps/data_importers/management/commands/import_dacorum.py
+++ b/polling_stations/apps/data_importers/management/commands/import_dacorum.py
@@ -27,4 +27,6 @@ class Command(BaseXpressDemocracyClubCsvImporter):
         ]:
             return None
 
+        if record.addressline6 in ["HP2 4AP", "HP2 6JN"]:
+            return None
         return rec

--- a/polling_stations/apps/data_importers/management/commands/import_fareham.py
+++ b/polling_stations/apps/data_importers/management/commands/import_fareham.py
@@ -26,7 +26,10 @@ class Command(BaseXpressDemocracyClubCsvImporter):
         rec = super().address_record_to_dict(record)
 
         if record.post_code in [
-            "SO31 7BJ",  # Spilt postcode
+            "SO31 7BJ",
+            "PO16 7LR",
+            "SO31 6BH",
+            "PO14 4QS",
         ]:
             return None
 

--- a/polling_stations/apps/data_importers/management/commands/import_worthing.py
+++ b/polling_stations/apps/data_importers/management/commands/import_worthing.py
@@ -16,3 +16,8 @@ class Command(BaseXpressDemocracyClubCsvImporter):
             record = record._replace(polling_place_northing="102975")
 
         return super().station_record_to_dict(record)
+
+    def address_record_to_dict(self, record):
+        if record.addressline6 == "BN11 3FP":
+            return None
+        return super().address_record_to_dict(record)


### PR DESCRIPTION
https://github.com/DemocracyClub/UK-Polling-Stations/pull/3048
Added a check for postcodes that are split in council data but won't be
in our data after import. The easiest fix is to not assign any postcodes
to those addresses.