### PR TITLE
Handle addresses that aren't in a council

### DIFF
--- a/polling_stations/apps/addressbase/models.py
+++ b/polling_stations/apps/addressbase/models.py
@@ -9,6 +9,17 @@ from pollingstations.models import PollingStation
 
 
 class Address(AbstractAddress):
+    def get_council_from_others_in_postcode(self):
+        others = (
+            Address.objects.filter(postcode=self.postcode)
+            .exclude(uprntocouncil__isnull=True)
+            .distinct("uprntocouncil__lad")
+        )
+        if len(others) == 1:
+            return others[0].council
+        else:
+            return None
+
     @property
     def council_id(self):
         return self.council.council_id

--- a/polling_stations/apps/addressbase/tests/test_address.py
+++ b/polling_stations/apps/addressbase/tests/test_address.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+
+from addressbase.models import UprnToCouncil
+from addressbase.tests.factories import UprnToCouncilFactory
+from councils.tests.factories import CouncilFactory
+
+
+class TestAddressFactory(TestCase):
+    def test_get_council_from_others_in_postcode(self):
+        council_abc = CouncilFactory(pk="ABC", identifiers=["X01000000"])
+        UprnToCouncilFactory.create_batch(3, lad="X01000000", uprn__postcode="AA11AA")
+
+        uprns = UprnToCouncil.objects.all()
+        uprn = uprns[0]
+        address = uprn.uprn
+        uprn.delete()
+        self.assertEqual(address.get_council_from_others_in_postcode(), council_abc)
+
+    def test_get_council_from_others_in_postcode_ambiguous(self):
+        CouncilFactory(pk="ABC", identifiers=["X01000000"])
+        UprnToCouncilFactory.create_batch(2, lad="X01000000", uprn__postcode="AA11AA")
+        UprnToCouncilFactory.create_batch(2, lad="X01000002", uprn__postcode="AA11AA")
+        uprns = UprnToCouncil.objects.filter(lad="X01000000")
+        uprn = uprns[0]
+        address = uprn.uprn
+        uprn.delete()
+        self.assertIsNone(address.get_council_from_others_in_postcode())

--- a/polling_stations/apps/data_finder/helpers/routing.py
+++ b/polling_stations/apps/data_finder/helpers/routing.py
@@ -25,7 +25,7 @@ class RoutingHelper:
 
     @property
     def councils(self):
-        council_ids = {a.council_id for a in self.addresses}
+        council_ids = {a.council_id for a in self.addresses if a.council_id}
         if len(council_ids) == 1:
             return None
         else:


### PR DESCRIPTION
These are mostly piers, and there's only 20 odd of them.

These changes mean that we don't consider them when looking if a
postcode is split, and if all the other addresses in that postcode have
the same council we assume the pier (or lighthouse) is also in that
council.