### PR TITLE
Import East Suffolk

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_east_suffolk.py
+++ b/polling_stations/apps/data_importers/management/commands/import_east_suffolk.py
@@ -1,69 +1,23 @@
-from django.contrib.gis.geos import Point
 from data_importers.management.commands import BaseDemocracyCountsCsvImporter
 
 
 class Command(BaseDemocracyCountsCsvImporter):
-    council_id = "E07000244"
-    addresses_name = "parl.2019-12-12/Version 1/districts-merged.csv"
-    stations_name = "parl.2019-12-12/Version 1/stations-merged.csv"
-    elections = ["parl.2019-12-12"]
-    allow_station_point_from_postcode = False
+    council_id = "ESK"
+    addresses_name = (
+        "2021-03-31T14:17:43.933405/East Suffolk Council Area - Polling Districts.csv"
+    )
+    stations_name = "2021-03-31T14:17:43.933405/East Suffolk Council Area - Polling Stations - v2.csv"
+    elections = ["2021-05-06"]
 
     def station_record_to_dict(self, record):
-
-        # St Philips Church
-        # user issue report #112
-        if record.stationcode == "181":
-            rec = super().station_record_to_dict(record)
-            rec["location"] = Point(1.335067, 51.962539, srid=4326)
-            return rec
-
-        # Village Hall Barsham
-        # user issue report #118
-        if record.stationcode in ["8", "8X"]:
-            rec = super().station_record_to_dict(record)
-            rec["location"] = Point(1.522623, 52.450787, srid=4326)
-            return rec
+        if record.stationcode in ("12", "12X", "12XX", "12XXX"):
+            # Shadingfield Village Hall
+            record = record._replace(postcode="NR34 8DH")
 
         return super().station_record_to_dict(record)
 
     def address_record_to_dict(self, record):
-        rec = super().address_record_to_dict(record)
-        uprn = record.uprn.strip().lstrip("0")
+        if record.postcode in ["NR35 1BZ", "IP12 2SY", "NR32 4ER"]:
+            return None  # split
 
-        if uprn in ["10090648769"]:
-            return None
-
-        if uprn in [
-            "10013328792",  # NR347DQ -> NR347DJ : Pinetrees, Park Drive, Beccles
-            "10012981034",  # NR349TU -> NR349PU : 8 St Andrews Road, Beccles
-            "10013331693",  # NR351BZ -> NR351BY : The Annexe, 67 Lower Olland Street, Bungay
-            "10012979638",  # IP200PN -> IP200PR : Greenside Farm, The Green, South Elmham St Margaret, Harleston
-            "10012979623",  # IP200PN -> IP200PR : Holly Tree Cottage, The Green, South Elmham St Margaret, Harleston
-            "10012982450",  # NR348HZ -> NR348NF : Brook Farm, Halesworth Road, Redisham, Beccles
-            "100091400931",  # NR348LR -> NR348LA : Corner Cottage, Cromwell Road, Ringsfield, Beccles
-            "100091401913",  # NR348LY -> NR348LN : Dove Cottage, Redisham Road, Ringsfield, Beccles
-            "10012977169",  # NR324WW -> NR324GF : 3 Townsend Way, Oulton, Lowestoft
-            "10012977132",  # NR324WX -> NR324GD : 4 Dawson Mews, Oulton, Lowestoft
-            "10012977135",  # NR324WX -> NR324GD : 10 Dawson Mews, Oulton, Lowestoft
-            "10013329842",  # NR348ET -> NR348ER : The Cartshed At Stoven Hall, Southwold Road, Stoven, Beccles
-            "10012976656",  # NR322AN -> NR322AX : 1 Zanetta Court, Trafalgar Street, Lowestoft
-            "100091406249",  # NR325PL -> NR325AU : Flowerlands, Flixton Road, Blundeston, Lowestoft
-            "10012982806",  # NR325PQ -> NR325LB : Whitehouse Cottage, Rackhams Corner, Blundeston, Lowestoft
-            "10012979226",  # NR323BH -> NR323BW : 19 Hobart Way, Oulton, Lowestoft
-            "10013326043",  # NR324UF -> NR324XJ : 11 Field Grange, Oulton, Lowestoft
-            "10013326045",  # NR324UF -> NR324XJ : 17 Field Grange, Oulton, Lowestoft
-            "100091408467",  # IP186SD -> IP186SB : Craigmyle House, St Felix School, Halesworth Road, Reydon, Southwold
-            "10012979693",  # NR348BQ -> NR348BG : Cherry Tree Cottage, Clay Common Lane, Uggeshall, Beccles
-            "100091394639",  # IP171QW -> IP171RY : Friston Lodge, Farnham Road, Snape, Saxmundham
-            "100091392652",  # IP100AZ -> IP100BB : Dairy Farm, Brightwell Street, Brightwell, Ipswich
-            "100091399513",  # IP122SY -> IP122JY : 2 White Cross Farm, Snape Road, Tunstall, Woodbridge
-        ]:
-            rec["accept_suggestion"] = True
-
-        if uprn in [
-            "10013604974"  # IP124PQ -> IP121BW : Boat Ray, Martlesham Creek Boatyard, Church Lane, Martlesham, Woodbridge
-        ]:
-            rec["accept_suggestion"] = False
-
-        return rec
+        return super().address_record_to_dict(record)


### PR DESCRIPTION
Notes:

* Wide postcodes NR348ET and IP117RZ are because a property has the wrong address in council data and AddressBase, but it's not going to mislead a user
* Checked polling stations 115 and 56/57/58.

```
Importing data for East Suffolk Council...
----------------------------------
Contextual Data:
Total UPRNs in AddressBase: 134,935
Total Dwellings from 2011 Census: 0
----------------------------------
Addresses: Found 106,049 rows in input file
----------------------------------
WARNING: Polling station 115 is in Ipswich Borough Council (IPS) but target council is East Suffolk Council (ESK) - manual check recommended

WARNING: Polling stations 'St Peters Church Hall St Peters Road' and 'Salvation Army Church & Community Centre 9 Carlton Road' are at approximately the same location, but have different postcodes:
qgis filter exp: "internal_council_id" IN ('58','56')
WARNING: Polling stations 'St Peters Church Hall St Peters Road' and 'Salvation Army Church & Community Centre 9 Carlton Road' are at approximately the same location, but have different postcodes:
qgis filter exp: "internal_council_id" IN ('58','57')
==================================
        DATA QUALITY REPORT
==================================

STATIONS IMPORTED                : 259
----------------------------------
 - with point                    : 259
 - without point                 : 0
 - with address                  : 259
 - without address               : 0


UPRNS ASSIGNED STATION ID        : 105690
 - As % of uprns in addressbase  : 78.3%
 - As % of rows in council csv   : 99.7%
----------------------------------
   - valid station id refs       : 105690
   - invalid station id refs     : 0
----------------------------------
```