### PR TITLE
Deal with duplicate elements in addresslist

### DIFF
--- a/polling_stations/apps/data_importers/data_types.py
+++ b/polling_stations/apps/data_importers/data_types.py
@@ -314,6 +314,7 @@ class AddressList(AssignPollingStationsMixin):
         self.elements = [e for e in self.elements if e["uprn"] in addressbase_data]
 
     def remove_records_that_dont_match_addressbase(self, addressbase_data):
+        to_remove = []
         for input_record in self.elements:
             addressbase_record = addressbase_data[input_record["uprn"].lstrip("0")]
 
@@ -323,7 +324,8 @@ class AddressList(AssignPollingStationsMixin):
             ):
                 continue
             else:
-                self.elements.remove(input_record)
+                to_remove.append(input_record)
+        self.elements = [e for e in self.elements if e not in to_remove]
 
     def remove_records_missing_uprns(self):
         self.elements = [e for e in self.elements if e.get("uprn", None)]

--- a/polling_stations/apps/data_importers/tests/test_address_list.py
+++ b/polling_stations/apps/data_importers/tests/test_address_list.py
@@ -372,6 +372,50 @@ class AddressListTest(TestCase):
         address_list.remove_records_that_dont_match_addressbase(addressbase_data)
         self.assertEqual(expected, address_list.elements)
 
+    def test_remove_records_that_dont_match_addressbase_with_duplicates(self):
+        in_list = [
+            {
+                "polling_station_id": "01",
+                "address": "foo 1",
+                "postcode": "AA1 2BB",
+                "council": "AAA",
+                "uprn": "10",
+            },
+            {
+                "polling_station_id": "01",
+                "address": "foo 2",
+                "postcode": "AA1 2BB",
+                "council": "AAA",
+                "uprn": "20",
+            },
+            {
+                "polling_station_id": "01",
+                "address": "foo 2",
+                "postcode": "AA1 2BB",
+                "council": "AAA",
+                "uprn": "20",
+            },
+        ]
+        addressbase_data = {
+            "10": {"postcode": "AA1 2BB"},
+            "20": {"postcode": "AA1 2CC"},
+        }
+        expected = [
+            {
+                "polling_station_id": "01",
+                "address": "foo 1",
+                "postcode": "AA1 2BB",
+                "council": "AAA",
+                "uprn": "10",
+            },
+        ]
+
+        address_list = AddressList(MockLogger())
+        for el in in_list:
+            address_list.append(el)
+        address_list.remove_records_that_dont_match_addressbase(addressbase_data)
+        self.assertEqual(expected, address_list.elements)
+
     def test_get_council_split_postcodes(self):
         in_list = [
             {


### PR DESCRIPTION
The check against addressbase was mutating the list it was iterating
over, meaning duplicate elements weren't all getting deleted, and then
uprns were getting assigned pollingstations, where we weren't confident
of the match.