### PR TITLE
Tidying show_polls_open

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: UK-Polling-Stations\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-06 20:32+0100\n"
+"POT-Creation-Date: 2021-04-08 14:13+0100\n"
 "PO-Revision-Date: 2016-03-16 21:36+0000\n"
 "Last-Translator: Gareth Morlais\n"
 "Language-Team: Welsh (United Kingdom) (http://www.transifex.com/democracy-"
@@ -535,7 +535,7 @@ msgstr ""
 
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:12
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:30
-#: polling_stations/templates/home.html:38
+#: polling_stations/templates/home.html:47
 msgid "You must vote at your assigned polling station."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgid "You don't need your poll card to vote"
 msgstr ""
 
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:21
-#: polling_stations/templates/home.html:41
+#: polling_stations/templates/home.html:50
 msgid ""
 "If you are registered to vote, but you don't have your poll card, you can go "
 "to the polling station and give them your name and address."
@@ -567,18 +567,29 @@ msgid "Read more about voting in Great Britain"
 msgstr ""
 
 #: polling_stations/templates/home.html:33
-msgid "6 May 2021 Elections"
-msgstr ""
-
-#: polling_stations/templates/home.html:34
-msgid "Polling stations are open from 7am to 10pm <strong>today</strong>."
+#, python-format
+msgid "%(election_date)s Elections"
 msgstr ""
 
 #: polling_stations/templates/home.html:36
+msgid "Polling stations are open from 7am to 10pm <strong>today</strong>."
+msgstr ""
+
+#: polling_stations/templates/home.html:39
+#, python-format
+msgctxt ""
+"day_of_week  and election_date are localised, e.g. 'Dydd Lau' and '6 Mai "
+"2021'. If it's awkward, leave out the day of the week."
+msgid ""
+"Polling stations are open from 7am to 10pm on <strong>%(day_of_week)s "
+"%(election_date)s</strong>."
+msgstr ""
+
+#: polling_stations/templates/home.html:45
 msgid "You don't need your poll card to vote."
 msgstr ""
 
-#: polling_stations/templates/home.html:44
+#: polling_stations/templates/home.html:53
 msgid ""
 "In England, Wales and Scotland, you don't need any form of ID. In Northern "
 "Ireland, you must bring photo ID."

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-06 20:32+0100\n"
+"POT-Creation-Date: 2021-04-08 14:13+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -459,7 +459,7 @@ msgstr ""
 
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:12
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:30
-#: polling_stations/templates/home.html:38
+#: polling_stations/templates/home.html:47
 msgid "You must vote at your assigned polling station."
 msgstr ""
 
@@ -468,7 +468,7 @@ msgid "You don't need your poll card to vote"
 msgstr ""
 
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:21
-#: polling_stations/templates/home.html:41
+#: polling_stations/templates/home.html:50
 msgid ""
 "If you are registered to vote, but you don't have your poll card, you can go "
 "to the polling station and give them your name and address."
@@ -491,18 +491,29 @@ msgid "Read more about voting in Great Britain"
 msgstr ""
 
 #: polling_stations/templates/home.html:33
-msgid "6 May 2021 Elections"
-msgstr ""
-
-#: polling_stations/templates/home.html:34
-msgid "Polling stations are open from 7am to 10pm <strong>today</strong>."
+#, python-format
+msgid "%(election_date)s Elections"
 msgstr ""
 
 #: polling_stations/templates/home.html:36
+msgid "Polling stations are open from 7am to 10pm <strong>today</strong>."
+msgstr ""
+
+#: polling_stations/templates/home.html:39
+#, python-format
+msgctxt ""
+"day_of_week  and election_date are localised, e.g. 'Dydd Lau' and '6 Mai "
+"2021'. If it's awkward, leave out the day of the week."
+msgid ""
+"Polling stations are open from 7am to 10pm on <strong>%(day_of_week)s "
+"%(election_date)s</strong>."
+msgstr ""
+
+#: polling_stations/templates/home.html:45
 msgid "You don't need your poll card to vote."
 msgstr ""
 
-#: polling_stations/templates/home.html:44
+#: polling_stations/templates/home.html:53
 msgid ""
 "In England, Wales and Scotland, you don't need any form of ID. In Northern "
 "Ireland, you must bring photo ID."

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -86,18 +86,25 @@ class HomeView(WhiteLabelTemplateOverrideMixin, FormView):
         https://github.com/DemocracyClub/UK-Polling-Stations/pull/2037/files#diff-78a9fc588889ef751c68b530b1af1e80
         https://github.com/DemocracyClub/UK-Polling-Stations/issues/2051
         """
-        polls_open = timezone.make_aware(
-            datetime.strptime("2019-12-12 7", "%Y-%m-%d %H")
-        )
-        polls_close = timezone.make_aware(
-            datetime.strptime("2019-12-12 22", "%Y-%m-%d %H")
-        )
-        now = timezone.now()
 
-        context["show_polls_open"] = polls_close > now
-        context["poll_date"] = "on Thursday 12 December"
-        if polls_open < now and polls_close > now:
-            context["poll_date"] = "today"
+        election_date = getattr(settings, "NEXT_CHARISMATIC_ELECTION_DATE", None)
+        if election_date:
+            election_date: datetime = timezone.make_aware(
+                datetime.strptime(election_date, "%Y-%m-%d")
+            )
+            polls_close = election_date.replace(hour=22)
+
+            now = timezone.now()
+
+            context.update(
+                {
+                    "election_date": election_date,
+                    "election_date_is_today": election_date.date() == now.date(),
+                    "show_polls_open_card": now < polls_close,
+                }
+            )
+        else:
+            context["show_polls_open_card"] = False
 
         return context
 

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -28,10 +28,19 @@
         </form>
     </section>
 
-    {% if show_polls_open %}
+    {% if show_polls_open_card %}
         <div class="card centered-card">
-            <h2>{% trans "6 May 2021 Elections" %}</h2>
-            <p>{% trans "Polling stations are open from 7am to 10pm <strong>today</strong>." %}</p>
+            <h2>{% blocktrans with election_date=election_date|date:"DATE_FORMAT" context="Section heading for information about elections on that date. election_date is already localised, e.g. '6 Mai 2021'." %}{{ election_date }} Elections{% endblocktrans %}</h2>
+
+            {% if election_date_is_today %}
+                <p>{% trans "Polling stations are open from 7am to 10pm <strong>today</strong>." %}</p>
+            {% else %}
+                <p>
+                    {% blocktrans trimmed with election_date=election_date|date:"DATE_FORMAT" day_of_week=election_date|date:"l" context "day_of_week  and election_date are localised, e.g. 'Dydd Lau' and '6 Mai 2021'. If it's awkward, leave out the day of the week." %}
+                        Polling stations are open from 7am to 10pm on <strong>{{ day_of_week }} {{ election_date }}</strong>.
+                    {% endblocktrans %}
+                </p>
+            {% endif %}
 
             <p>{% trans "You don't need your poll card to vote." %}</p>
 


### PR DESCRIPTION
Shows the card until 10pm on polling day. Shows "today" instead of the date on polling day itself. All marked for translation, and uses localised date formats and day of week name.

Screenshots with a Welsh `Accept-Language`, but without Welsh translations available:

Polls open tomorrow:
![Screenshot from 2021-04-08 14-18-41](https://user-images.githubusercontent.com/238690/114033802-7ebf6480-9875-11eb-86e2-2010adbdb08e.png)

Polls open today:
![Screenshot from 2021-04-08 14-19-18](https://user-images.githubusercontent.com/238690/114033841-87b03600-9875-11eb-88fb-4943c2d66eb9.png)
