### PR TITLE
Import Portsmouth (closes #3333)

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_portsmouth.py
+++ b/polling_stations/apps/data_importers/management/commands/import_portsmouth.py
@@ -3,38 +3,34 @@ from data_importers.management.commands import BaseXpressDemocracyClubCsvImporte
 
 
 class Command(BaseXpressDemocracyClubCsvImporter):
-    council_id = "E06000044"
-    addresses_name = "parl.2019-12-12/Version 1/Democracy_Club__12December2019port.tsv"
-    stations_name = "parl.2019-12-12/Version 1/Democracy_Club__12December2019port.tsv"
-    elections = ["parl.2019-12-12"]
+    council_id = "POR"
+    addresses_name = (
+        "2021-03-24T11:20:37.542789/Portsmouth Democracy_Club__06May2021.tsv"
+    )
+    stations_name = (
+        "2021-03-24T11:20:37.542789/Portsmouth Democracy_Club__06May2021.tsv"
+    )
+    elections = ["2021-05-06"]
     csv_delimiter = "\t"
-    allow_station_point_from_postcode = False
 
     def address_record_to_dict(self, record):
+        if record.addressline6 in ["PO5 2BT", "PO4 0LF", "PO2 8LR"]:
+            return None  # split
         rec = super().address_record_to_dict(record)
-        uprn = record.property_urn.strip().lstrip("0")
-
-        if record.addressline6 == "PO4 099":
-            rec["postcode"] = "PO4 0PL"
-
-        if uprn in ["1775078308", "1775002824", "1775002823"]:
-            rec = super().address_record_to_dict(record)
-            rec["accept_suggestion"] = True
-            return rec
-
-        if uprn in ["1775100211", "1775125846"]:
-            return None
-
         return rec
 
     def station_record_to_dict(self, record):
+        # Christ Church Church Hall
+        if record.polling_place_id == "4918":
+            record = record._replace(polling_place_uprn="1775049305")
+
         rec = super().station_record_to_dict(record)
 
         # St Margaret's Parish Centre
-        if rec["internal_council_id"] == "4319":
+        if rec["internal_council_id"] == "4730":
             rec["location"] = Point(-1.067090, 50.786643, srid=4326)
         # Eastney Methodist Church
-        if rec["internal_council_id"] == "4331":
+        if rec["internal_council_id"] == "4743":
             rec["location"] = Point(-1.059545, 50.7866578, srid=4326)
 
         return rec


### PR DESCRIPTION
I added a bit extra to the warnings to contextualise the warnings:

> WARNING: Using UPRN 1775070654 for station ID 4693, but 'PO1 2EZ' != 'PO1 2HH'
> WARNING:   'Cathedral House (Becket Hall), St Thomas`s Street, Portsmouth' vs 'HALL CATHEDRAL HOUSE 63-68 ST THOMAS'S STREET, PORTSMOUTH
> WARNING: Using UPRN 1775073763 for station ID 4704, but 'PO5 4QA' != 'PO5 1EE'
> WARNING:   'King's Church, Somers Road, Southsea' vs 'THE KINGS CHURCH & CENTRE, SOMERS ROAD, SOUTHSEA
> WARNING: Using UPRN 1775037297 for station ID 4722, but 'PO4 0AS' != 'PO4 0AG'
> WARNING:   'Francis Lodge, Fernhurst Junior School, Heidelberg Road, Southsea' vs 'FRANCIS LODGE HEIDELBERG ROAD, SOUTHSEA
> WARNING: Using UPRN 1775106969 for station ID 4730, but 'PO4 9DD' != 'PO4 8AY'
> WARNING:   'St Margaret's Parish Centre, Highland Road, Southsea' vs 'ST. MARGARETS PARISH HALL, HIGHLAND ROAD, SOUTHSEA
> WARNING: Using UPRN 1775099449 for station ID 4743, but 'PO4 9NH' != 'PO4 9NJ'
> WARNING:   'Eastney Methodist Church, Highland Road, Southsea' vs 'EASTNEY METHODIST CHURCH, HIGHLAND ROAD, SOUTHSEA
> WARNING: Using UPRN 1775012468 for station ID 4877, but 'PO6 3PY' != 'PO6 3QY'
> WARNING:   'Hillside and Wymering Centre, Cheltenham Road, Portsmouth' vs 'HILLSIDE AND WYMERING CENTRE CHELTENHAM ROAD, PORTSMOUTH
> WARNING: Polling station 4862 is in Fareham Borough Council (FAR) but target council is Portsmouth City Council (POR) - manual check recommended
>
> WARNING: Using UPRN 1775054690 for station ID 4896, but 'PO6 3NL' != 'PO6 3NH'
> WARNING:   'St Peter & St Paul Hall, Old Wymering Lane, Wymering' vs 'WYMERING PARISH CHURCH, CHURCH HALL, OLD WYMERING LANE, PORTSMOUTH

As the addresses between the polling station data and AddressBase pretty
much match up, I'm going to leave these.

The St Margaret's and Eastney Methodist Church location fixes are doing
no harm, so can stay, but with updated IDs.