### PR TITLE
jsescape translation when including in a JS string

### DIFF
--- a/polling_stations/templates/fragments/feedback_js.html
+++ b/polling_stations/templates/fragments/feedback_js.html
@@ -19,7 +19,7 @@
 
       $("#feedback_form .comments_container").hide();
       $('<input type="radio" name="found_useful" value="PROBLEM" required data-toggle="button" id="report_problem" />'+
-        '<label class="link-button" for="report_problem">{% trans "Report a problem with this page" %}</label>'
+        '<label class="link-button" for="report_problem">{% trans "Report a problem with this page" as report_a_problem_text %}{{ report_a_problem_text|escapejs }}</label>'
       ).insertAfter("#feedback_choices_container");
 
       $('#feedback_form input[name=found_useful]').click(function() {


### PR DESCRIPTION
Our Welsh translation contains an `'`, which would otherwise break the string quotes.