### PR TITLE
Add covid keep safe message

### DIFF
--- a/polling_stations/templates/fragments/keep_safe.html
+++ b/polling_stations/templates/fragments/keep_safe.html
@@ -1,15 +1,15 @@
 {% load i18n_with_welsh %}
-  <div class="card centered-card">
+  <div class="card">
     <h2>{% trans "Keeping you and fellow voters safe!" %}</h2>
       <p>{% trans "Local election teams will be doing everything they can to ensure voting in person on polling day is safe for everyone. This means there will be safety measures in place at polling stations to prevent the spread of COVID-19, many of which you’ll be very familiar with! " %}</p>
 
       <ul>
-        <li>{% trans "There will be a limit to the number of people allowed in a polling station at any given time to allow for social distancing." %}</li>
-        <li>{% trans "Please remember your face covering- you will need this to enter the polling station and will be expected to wear it throughout." %}</li>
-        <li>{% trans "Make sure to sanitise your hands before and after voting. In many places, sanitiser will be available but it may be a good idea to carry your own!" %}</li>
+        <li>{% trans "There will be a limit to the number of people allowed in a polling station at any given time to allow for <strong>social distancing</strong>." %}</li>
+        <li>{% trans "Please remember your <strong>face covering</strong> - you will need this to enter the polling station and will be expected to wear it throughout." %}</li>
+        <li>{% trans "Make sure to <strong>sanitise your hands</strong> before and after voting. In many places, sanitiser will be available but it may be a good idea to carry your own!" %}</li>
         <li>{% trans "Some polling stations will supply clean pencils for voters but it may be best to bring your own with you." %}</li>
         <li>{% trans "Polling Stations will be cleaned regularly by polling staff. You may need to wait while a booth is sanitised before you enter." %}</li>
-        <li>{% trans "Polling Station staff may be working behind safety screens- this doesn’t mean you can’t ask for assistance if you require it!" %}</li>
+        <li>{% trans "Polling Station staff may be working behind safety screens - this doesn’t mean you can’t <strong>ask for assistance if you require it!</strong>" %}</li>
       </ul>
-      <p>{% trans "With these new safety measures in place, it may take a little bit longer to vote than usual. Remember that if you are in the queue to vote before 10pm, you will still be able to vote even when polls ‘officially close’." %}</p>
+      <p>{% trans "With these new safety measures in place, it may take a little bit longer to vote than usual. Remember that if you are in the queue to vote before 10pm, you will still be able to vote even when polls officially close." %}</p>
   </div>

--- a/polling_stations/templates/fragments/keep_safe.html
+++ b/polling_stations/templates/fragments/keep_safe.html
@@ -1,0 +1,15 @@
+{% load i18n_with_welsh %}
+  <div class="card centered-card">
+    <h2>{% trans "Keeping you and fellow voters safe!" %}</h2>
+      <p>{% trans "Local election teams will be doing everything they can to ensure voting in person on polling day is safe for everyone. This means there will be safety measures in place at polling stations to prevent the spread of COVID-19, many of which you’ll be very familiar with! " %}</p>
+
+      <ul>
+        <li>{% trans "There will be a limit to the number of people allowed in a polling station at any given time to allow for social distancing." %}</li>
+        <li>{% trans "Please remember your face covering- you will need this to enter the polling station and will be expected to wear it throughout." %}</li>
+        <li>{% trans "Make sure to sanitise your hands before and after voting. In many places, sanitiser will be available but it may be a good idea to carry your own!" %}</li>
+        <li>{% trans "Some polling stations will supply clean pencils for voters but it may be best to bring your own with you." %}</li>
+        <li>{% trans "Polling Stations will be cleaned regularly by polling staff. You may need to wait while a booth is sanitised before you enter." %}</li>
+        <li>{% trans "Polling Station staff may be working behind safety screens- this doesn’t mean you can’t ask for assistance if you require it!" %}</li>
+      </ul>
+      <p>{% trans "With these new safety measures in place, it may take a little bit longer to vote than usual. Remember that if you are in the queue to vote before 10pm, you will still be able to vote even when polls ‘officially close’." %}</p>
+  </div>

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -52,6 +52,7 @@
 
             <p>{% trans "In England, Wales and Scotland, you don't need any form of ID. In Northern Ireland, you must bring photo ID." %}</p>
         </div>
+        {% include "fragments/keep_safe.html" %}
     {% endif %}
 
 {% endblock content %}


### PR DESCRIPTION
This seems like it might be too many words, interested to hear other's thoughts. As it's below the scroll bar on most screens I don't really mind including it though. I'd be nervous of putting it on the results page as it wouldn't get read at the bottom, and any higher and it would push other stuff way down.

Overview shot of home page: 
![Screenshot from 2021-04-29 15-36-31](https://user-images.githubusercontent.com/20044500/116568832-bbc0c900-a900-11eb-9f6e-1dd5e30f319b.png)

This is what the card looks like:
![Screenshot from 2021-04-29 15-35-13](https://user-images.githubusercontent.com/20044500/116568741-a481db80-a900-11eb-8692-5ce918af7ab6.png)


