### PR TITLE
Translation fixes 2021 04 29

### DIFF
--- a/polling_stations/apps/bug_reports/models.py
+++ b/polling_stations/apps/bug_reports/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
+from django.utils.translation import gettext_lazy as _
 
 
 STATUS_CHOICES = (("OPEN", "Open"), ("RESOLVED", "Resolved"))
@@ -10,13 +11,15 @@ REPORT_TYPES = (("OTHER", "Other"),)
 class BugReport(TimeStampedModel):
     description = models.TextField(
         blank=False,
-        verbose_name="Provide information about the problem to help us improve our service:",
+        verbose_name=_(
+            "Provide information about the problem to help us improve our service:"
+        ),
     )
     source_url = models.CharField(blank=True, max_length=800)
     status = models.CharField(blank=False, max_length=100, choices=STATUS_CHOICES)
     user_agent = models.TextField(blank=True)
     source = models.CharField(blank=True, max_length=100)
     email = models.EmailField(
-        blank=True, max_length=100, verbose_name="(Optional) Email address:"
+        blank=True, max_length=100, verbose_name=_("(Optional) Email address:")
     )
     report_type = models.CharField(blank=False, max_length=100, choices=REPORT_TYPES)

--- a/polling_stations/apps/bug_reports/templates/bug_reports/disclaimer.html
+++ b/polling_stations/apps/bug_reports/templates/bug_reports/disclaimer.html
@@ -1,5 +1,8 @@
+{% load i18n %}
 <p><small>
-  If you provide an email address, we may contact you to request more
-  information or notify you of improvements related to this report.
-  It will not be used for email marketing purposes.
+    {% blocktrans trimmed %}
+        If you provide an email address, we may contact you to request more
+        information or notify you of improvements related to this report.
+        It will not be used for email marketing purposes.
+    {% endblocktrans %}
 </small></p>

--- a/polling_stations/apps/data_finder/features/index.feature
+++ b/polling_stations/apps/data_finder/features/index.feature
@@ -10,7 +10,7 @@ Feature: Check Postcodes
     Then I submit the form with id "select-address-form"
     Then The browser's URL should contain "address/05"
     And I should see "Your polling station"
-    And I should see "Walking/driving directions"
+    And I should see "walking/driving directions"
     And No errors were thrown
 
     Scenario: Check postcode with address picker invalid station id
@@ -33,7 +33,7 @@ Feature: Check Postcodes
     Then I submit the form with id "find-polling-station-form"
     Then The browser's URL should contain "/address/10/"
     And I should see "Your polling station"
-    And I should see "Walking/driving directions"
+    And I should see "walking/driving directions"
     And No errors were thrown
 
     Scenario: Check my address not in list

--- a/polling_stations/apps/data_finder/tests/test_directions_helper.py
+++ b/polling_stations/apps/data_finder/tests/test_directions_helper.py
@@ -17,11 +17,11 @@ def mock_route_exception(self, start, end):
 
 
 def mock_route_google(self, start, end):
-    return Directions("1", "1", "walk", "foo", 5, "Google")
+    return Directions(352, 300, "walk", "foo", 5, "Google", start, end)
 
 
 def mock_route_mapbox(self, start, end):
-    return Directions("1", "1", "walk", "foo", 6, "Mapbox")
+    return Directions(352, 300, "walk", "foo", 6, "Mapbox", start, end)
 
 
 class DirectionsTest(TestCase):
@@ -79,3 +79,19 @@ class DirectionsTest(TestCase):
         d = DirectionsHelper()
         result = d.get_directions(start_location=self.a, end_location=self.b)
         self.assertEqual("Mapbox", result.source)
+
+    def test_unit_conversions(self):
+        directions = Directions(352, 300, "walk", "", 5, "Test", self.a, self.b)
+        self.assertEqual(6, directions.time_in_minutes)
+        self.assertEqual("0.2", "{:.1f}".format(directions.distance_in_miles))
+
+    def test_directions_urls(self):
+        directions = Directions(352, 300, "walk", "", 5, "Test", self.a, self.b)
+        self.assertEqual(
+            "https://www.google.com/maps/dir/51.5010,-0.1416/51.6010,-0.1417",
+            directions.google_maps_url,
+        )
+        self.assertEqual(
+            "https://www.cyclestreets.net/journey/51.5010,-0.1416/51.6010,-0.1417/",
+            directions.cyclestreets_url,
+        )

--- a/polling_stations/apps/data_finder/tests/test_google_directions.py
+++ b/polling_stations/apps/data_finder/tests/test_google_directions.py
@@ -16,7 +16,10 @@ class GoogleDirectionsClientValidMock(GoogleDirectionsClient):
             "routes": [
                 {
                     "legs": [
-                        {"duration": {"text": "4 mins"}, "distance": {"text": "0.2 mi"}}
+                        {
+                            "duration": {"text": "4 mins", "value": 352},
+                            "distance": {"text": "0.2 mi", "value": 300},
+                        }
                     ],
                     "overview_polyline": {"points": "foo\bar"},
                 }
@@ -38,8 +41,8 @@ class GoogleDirectionsClientTest(TestCase):
     def test_valid(self):
         g = GoogleDirectionsClientValidMock()
         result = g.get_route(self.a, self.b)
-        self.assertEqual("4 minute", result.time)
-        self.assertEqual("0.2 miles", result.dist)
+        self.assertEqual(352, result.time)
+        self.assertEqual(300, result.distance)
         self.assertEqual(json.dumps("foo\bar"), result.route)
         self.assertEqual(5, result.precision)
         self.assertEqual("Google", result.source)

--- a/polling_stations/apps/data_finder/tests/test_mapbox_directions.py
+++ b/polling_stations/apps/data_finder/tests/test_mapbox_directions.py
@@ -68,8 +68,8 @@ class GoogleDirectionsClientTest(TestCase):
     def test_valid(self):
         m = MapboxDirectionsClientValidMock()
         result = m.get_route(self.a, self.b)
-        self.assertEqual("46 minute", result.time)
-        self.assertEqual("9 miles", result.dist)
+        self.assertEqual(2727.832, result.time)
+        self.assertEqual(13276.476, result.distance)
         self.assertEqual(json.dumps("foo\bar"), result.route)
         self.assertEqual(5, result.precision)
         self.assertEqual("Mapbox", result.source)

--- a/polling_stations/apps/feedback/templates/feedback/feedback_form.html
+++ b/polling_stations/apps/feedback/templates/feedback/feedback_form.html
@@ -15,6 +15,6 @@
   <div class="comments_container">
     <p>{% trans "Can you tell us anything more?" %}</p>
     {{ feedback_form.comments }}
-    <button type="submit" class="button">Send feedback</button>
+    <button type="submit" class="button">{% trans "Send feedback" %}</button>
   </div>
 </form>

--- a/polling_stations/templates/base.html
+++ b/polling_stations/templates/base.html
@@ -38,7 +38,7 @@
             {% csrf_token %}
             <input name="next" type="hidden" value="{{ request.get_full_path }}">
             <ul>
-                <li id="language-label" aria-hidden="true">Language:</li>
+                <li id="language-label" aria-hidden="true">{% trans "Language:" %}</li>
                 {% get_current_language as LANGUAGE_CODE %}
                 {% get_available_languages as LANGUAGES %}
                 {% get_language_info_list for LANGUAGES as languages %}

--- a/polling_stations/templates/base_full.html
+++ b/polling_stations/templates/base_full.html
@@ -5,11 +5,11 @@
 {% block site_meta %}
   <title>
     {% block base_title %}
-    {% block page_title %}{% endblock page_title %} | {{ site_title }} by Democracy Club
+    {% block page_title %}{% endblock page_title %} | {% blocktrans %}{{ site_title }} by Democracy Club{% endblocktrans %}
     {% endblock base_title %}
   </title>
 
-  <meta name="description" content="{% block description %}Find out where to vote{% if NEXT_CHARISMATIC_ELECTION_DATE %} on {{ NEXT_CHARISMATIC_ELECTION_DATE|date:'F j Y' }}{% endif %}{% endblock %}">
+  <meta name="description" content="{% block description %}{% if NEXT_CHARISMATIC_ELECTION_DATE %}{% blocktrans with election_date=NEXT_CHARISMATIC_ELECTION_DATE|date:'F j Y' %}Find out where to vote on {{ election_date }}{% endblocktrans %}{% else %}{% trans "Find out where to vote" %}{% endif %}{% endblock %}">
   <meta name="keywords" content="{% block keywords %}Polling stations,Election,General Election,Local Election{% endblock %}">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -22,7 +22,7 @@
   <meta name="twitter:site" content="@democlub">
   <meta property="og:image" content="{{ CANONICAL_URL }}{% block og_image %}{% static "dc_theme/images/logo.png" %}{% endblock og_image %}">
   <meta property="og:title" content="{% block og_title %}{{ site_title }}{% endblock og_title %}">
-  <meta property="og:description" content="{% block og_description %}Find out where to vote{% if NEXT_CHARISMATIC_ELECTION_DATE %} on {{ NEXT_CHARISMATIC_ELECTION_DATE|date:'F j Y' }}{% endif %}{% endblock og_description %}">
+  <meta property="og:description" content="{% block og_description %}{% if NEXT_CHARISMATIC_ELECTION_DATE %}{% blocktrans with election_date=NEXT_CHARISMATIC_ELECTION_DATE|date:'F j Y' %}Find out where to vote on {{ election_date }}{% endblocktrans %}{% else %}{% trans "Find out where to vote" %}{% endif %}{% endblock og_description %}">
   {% if noindex %}
   <meta name="robots" content="noindex">
   {% endif %}

--- a/polling_stations/templates/fragments/polling_station_known.html
+++ b/polling_stations/templates/fragments/polling_station_known.html
@@ -17,12 +17,20 @@
 </div>
 
 {% if directions.time %}
-  <div id="directions">
-    <p>
-      {% blocktrans trimmed with directions.time as time and directions.dist as dist and directions.mode as mode %}
-        It's about {{ dist }} away or a {{ time }} {{ mode }} from {{ postcode }}.
-      {% endblocktrans %}
-    </p>
+    <div id="directions">
+        {% if directions.mode == "walk" %}
+            <p>
+                {% blocktrans trimmed with distance_in_miles=directions.distance_in_miles|floatformat:"1" time_in_minutes=directions.time_in_minutes %}
+                    It's about {{ distance_in_miles }} miles away or a {{ time_in_minutes }} minute walk from {{ postcode }}
+                {% endblocktrans %}
+            </p>
+        {% elif directions.mode == "drive" %}
+            <p>
+                {% blocktrans trimmed with distance_in_miles=directions.distance_in_miles|floatformat:"1" time_in_minutes=directions.time_in_minutes %}
+                    It's about {{ distance_in_miles }} miles away or a {{ time_in_minutes }} minute walk from {{ postcode }}
+                {% endblocktrans %}
+            </p>
+        {% endif %}
     Get
     <a href="https://www.google.com/maps/dir/{{ location.y }},{{ location.x }}/{{ station.location.y }},{{ station.location.x }}" target="_top">
       {% trans "Walking/driving directions from Google" %}

--- a/polling_stations/templates/fragments/polling_station_known.html
+++ b/polling_stations/templates/fragments/polling_station_known.html
@@ -21,24 +21,22 @@
         {% if directions.mode == "walk" %}
             <p>
                 {% blocktrans trimmed with distance_in_miles=directions.distance_in_miles|floatformat:"1" time_in_minutes=directions.time_in_minutes %}
-                    It's about {{ distance_in_miles }} miles away or a {{ time_in_minutes }} minute walk from {{ postcode }}
+                    It's about {{ distance_in_miles }} miles away or a {{ time_in_minutes }} minute walk from {{ postcode }}.
                 {% endblocktrans %}
             </p>
         {% elif directions.mode == "drive" %}
             <p>
                 {% blocktrans trimmed with distance_in_miles=directions.distance_in_miles|floatformat:"1" time_in_minutes=directions.time_in_minutes %}
-                    It's about {{ distance_in_miles }} miles away or a {{ time_in_minutes }} minute walk from {{ postcode }}
+                    It's about {{ distance_in_miles }} miles away or a {{ time_in_minutes }} minute drive from {{ postcode }}.
                 {% endblocktrans %}
             </p>
         {% endif %}
-    Get
-    <a href="https://www.google.com/maps/dir/{{ location.y }},{{ location.x }}/{{ station.location.y }},{{ station.location.x }}" target="_top">
-      {% trans "Walking/driving directions from Google" %}
-    </a>
-    or
-    <a href="https://www.cyclestreets.net/journey/{{ location.y }},{{ location.x }}/{{ station.location.y }},{{ station.location.x }}/" target="_top">
-      {% trans "Cycling directions from CycleStreets" %}
-    </a>
+
+        <p>
+            {% blocktrans trimmed with google_maps_url=directions.google_maps_url cyclestreets_url=directions.cyclestreets_url %}
+                Get <a href="{{ google_maps_url }}" target="_top">walking/driving directions from Google</a> or <a href="{{ cyclestreets_url }}" target="_top">cycling directions from CycleStreets</a>.
+            {% endblocktrans %}
+        </p>
   </div>
 {% endif %}
 


### PR DESCRIPTION
Three things that improve translations:

* more strings marked for translation
* the "It's about _x_ miles away or a _y_ minute walk/drive from _z_." string creation has been tidied up so it can be translated whole
* likewise with the "get Google / CycleStreets directions" paragraph, as before the "Get … or …" part was untranslatable.

As a side effect, directions handling has been made a bit more verbose, but is hopefully clearer now.

We'll run makemessages on a separate PR, to catch the covid-safe messaging text introduced in #3755.