### PR TITLE
Fix spacing in Welsh string

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -494,7 +494,7 @@ msgstr "Darllen mwy am bleidleisio ym Mhrydain Fawr"
 #: polling_stations/templates/home.html:33
 #, python-format
 msgid "%(election_date)s Elections"
-msgstr "Etholiadau%(election_date)s "
+msgstr "Etholiadau %(election_date)s"
 
 #: polling_stations/templates/home.html:36
 msgid "Polling stations are open from 7am to 10pm <strong>today</strong>."


### PR DESCRIPTION
The website header at the moment is "Etholiadau6 Mai 2021 ".
It should probably be "Etholiadau 6 Mai 2021".