### PR TITLE
Run makemessages, for additional translations

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: UK-Polling-Stations\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-08 14:13+0100\n"
+"POT-Creation-Date: 2021-04-29 21:16+0100\n"
 "PO-Revision-Date: 2021-04-28 15:19+0000\n"
 "Last-Translator: Alex Dutton <transifex@alexdutton.co.uk>\n"
 "Language-Team: Welsh (http://www.transifex.com/democracy-club/uk-polling-stations/language/cy/)\n"
@@ -24,6 +24,18 @@ msgstr ""
 #: polling_stations/apps/bug_reports/forms.py:13
 msgid "Description"
 msgstr "Disgrifiad"
+
+#: polling_stations/apps/bug_reports/models.py:15
+msgid "Provide information about the problem to help us improve our service:"
+msgstr ""
+
+#: polling_stations/apps/bug_reports/models.py:23
+msgid "(Optional) Email address:"
+msgstr ""
+
+#: polling_stations/apps/bug_reports/templates/bug_reports/disclaimer.html:3
+msgid "If you provide an email address, we may contact you to request more information or notify you of improvements related to this report. It will not be used for email marketing purposes."
+msgstr ""
 
 #: polling_stations/apps/bug_reports/templates/bug_reports/report_form_inline.html:8
 #: polling_stations/apps/bug_reports/templates/bug_reports/report_form_view.html:17
@@ -49,14 +61,6 @@ msgstr "Cod post:"
 msgid "Enter your postcode"
 msgstr "Rhowch eich cod post"
 
-#: polling_stations/apps/data_finder/helpers/directions.py:83
-msgid "minute"
-msgstr "munud"
-
-#: polling_stations/apps/data_finder/helpers/directions.py:87
-msgid "miles"
-msgstr "milltir"
-
 #: polling_stations/apps/feedback/forms.py:19
 #: polling_stations/apps/feedback/templates/feedback/feedback_form.html:7
 msgid "Did you find this useful?"
@@ -77,6 +81,10 @@ msgstr "Nac oedd"
 #: polling_stations/apps/feedback/templates/feedback/feedback_form.html:16
 msgid "Can you tell us anything more?"
 msgstr "Allwch chi ddweud rhagor i ni?"
+
+#: polling_stations/apps/feedback/templates/feedback/feedback_form.html:18
+msgid "Send feedback"
+msgstr ""
 
 #: polling_stations/apps/file_uploads/templates/file_uploads/council_detail.html:5
 #: polling_stations/apps/file_uploads/templates/file_uploads/council_list.html:4
@@ -100,38 +108,42 @@ msgctxt "not shown to general public"
 msgid "This is a staging site."
 msgstr "Safle Llwyfannu yw hwn."
 
-#: polling_stations/templates/base.html:80
+#: polling_stations/templates/base.html:41
+msgid "Language:"
+msgstr ""
+
+#: polling_stations/templates/base.html:78
 msgid "Home"
 msgstr "Hafan"
 
-#: polling_stations/templates/base.html:81
+#: polling_stations/templates/base.html:79
 msgid "About"
 msgstr "Amdanom ni"
 
-#: polling_stations/templates/base.html:82
+#: polling_stations/templates/base.html:80
 msgid "Privacy"
 msgstr "Preifatrwydd"
 
-#: polling_stations/templates/base.html:83
+#: polling_stations/templates/base.html:81
 msgctxt "Application Programming Interface"
 msgid "API"
 msgstr "API"
 
-#: polling_stations/templates/base.html:84
-#: polling_stations/templates/base.html:96
+#: polling_stations/templates/base.html:82
+#: polling_stations/templates/base.html:94
 msgid "Blog"
 msgstr "Blog"
 
-#: polling_stations/templates/base.html:85
-#: polling_stations/templates/base.html:97
+#: polling_stations/templates/base.html:83
+#: polling_stations/templates/base.html:95
 msgid "Mailing List"
 msgstr "Rhestr Bostio"
 
-#: polling_stations/templates/base.html:86
+#: polling_stations/templates/base.html:84
 msgid "Contact"
 msgstr "Cyswllt"
 
-#: polling_stations/templates/base.html:90
+#: polling_stations/templates/base.html:88
 msgid "Made by Democracy Club"
 msgstr "Gwnaed gan y <span lang=\"en\">Democracy Club</span>"
 
@@ -141,49 +153,49 @@ msgid ""
 "digital infrastructure needed for a 21st century democracy."
 msgstr "Cwmni Buddiannau Cymunedol yn y DU yw'r <span lang=\"en\">Democracy Club</span> sy'n adeiladu'r isadeiledd digidol sydd ei angen ar gyfer democratiaeth y 21ain ganrif."
 
-#: polling_stations/templates/base.html:94
+#: polling_stations/templates/base.html:92
 msgid "About Democracy Club"
 msgstr "Ynglŷn â'r <span lang=\"en\">Democracy Club</span>"
 
-#: polling_stations/templates/base.html:95
+#: polling_stations/templates/base.html:93
 msgid "Contact Us"
 msgstr "Cysylltu â Ni"
 
-#: polling_stations/templates/base.html:98
+#: polling_stations/templates/base.html:96
 msgctxt "link to Democracy Club Twitter page"
 msgid "Twitter"
 msgstr "Twitter"
 
-#: polling_stations/templates/base.html:99
+#: polling_stations/templates/base.html:97
 msgctxt "link to Democracy Club Facebook page"
 msgid "Facebook"
 msgstr "Facebook"
 
-#: polling_stations/templates/base.html:100
+#: polling_stations/templates/base.html:98
 msgctxt "link to Democracy Club GitHub page"
 msgid "GitHub"
 msgstr "GitHub"
 
-#: polling_stations/templates/base.html:105
+#: polling_stations/templates/base.html:103
 #, python-format
 msgid ""
 "Copyright ©\n"
 "        %(current_year)s Democracy Club Community Interest Company Company No: <a href=\"%(companies_house_url)s\">%(company_number)s</a>"
 msgstr "Hawlfraint ©\n        %(current_year)s <span lang=\"en\">Democracy Club</span> Cwmni Buddiannau Cymunedol Rhif: <a href=\"%(companies_house_url)s\">%(company_number)s</a>"
 
-#: polling_stations/templates/base.html:108
+#: polling_stations/templates/base.html:106
 #, python-format
 msgid "Contains OS data © Crown copyright and database right %(current_year)s"
 msgstr "Yn cynnwys data Arolwg Ordnans © Hawlfraint a hawliau cronfa ddata'r Goron %(current_year)s"
 
-#: polling_stations/templates/base.html:109
+#: polling_stations/templates/base.html:107
 #, python-format
 msgid ""
 "Contains Royal Mail data © Royal Mail copyright and database right "
 "%(current_year)s"
 msgstr "Yn cynnwys data'r Post Brenhinol © Hawlfraint a hawliau cronfa ddata'r Post Brenhinol %(current_year)s"
 
-#: polling_stations/templates/base.html:110
+#: polling_stations/templates/base.html:108
 #, python-format
 msgid ""
 "Contains National Statistics data © Crown copyright and database right "
@@ -193,6 +205,23 @@ msgstr "Yn cynnwys data Ystadegau Gwladol © Hawlfraint a hawliau cronfa ddata'r
 #: polling_stations/templates/base_embed.html:13
 msgid "Democracy Club logo"
 msgstr "Logo'r <span lang=\"en\">Democracy Club</span>"
+
+#: polling_stations/templates/base_full.html:8
+#, fuzzy, python-format
+#| msgid "Made by Democracy Club"
+msgid "%(site_title)s by Democracy Club"
+msgstr "Gwnaed gan y <span lang=\"en\">Democracy Club</span>"
+
+#: polling_stations/templates/base_full.html:12
+#: polling_stations/templates/base_full.html:25
+#, python-format
+msgid "Find out where to vote on %(election_date)s"
+msgstr ""
+
+#: polling_stations/templates/base_full.html:12
+#: polling_stations/templates/base_full.html:25
+msgid "Find out where to vote"
+msgstr ""
 
 #: polling_stations/templates/custom_finder.html:4
 #: polling_stations/templates/custom_finder.html:7
@@ -346,6 +375,42 @@ msgctxt "followed by link to whocanivotefor.co.uk, with that link text"
 msgid "You can find information on your candidates at"
 msgstr "Gallwch ddod o hyd i wybodaeth ar eich ymgeiswyr yn"
 
+#: polling_stations/templates/fragments/keep_safe.html:3
+msgid "Keeping you and fellow voters safe!"
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:4
+msgid "Local election teams will be doing everything they can to ensure voting in person on polling day is safe for everyone. This means there will be safety measures in place at polling stations to prevent the spread of COVID-19, many of which you’ll be very familiar with! "
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:7
+msgid "There will be a limit to the number of people allowed in a polling station at any given time to allow for <strong>social distancing</strong>."
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:8
+msgid "Please remember your <strong>face covering</strong> - you will need this to enter the polling station and will be expected to wear it throughout."
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:9
+msgid "Make sure to <strong>sanitise your hands</strong> before and after voting. In many places, sanitiser will be available but it may be a good idea to carry your own!"
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:10
+msgid "Some polling stations will supply clean pencils for voters but it may be best to bring your own with you."
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:11
+msgid "Polling Stations will be cleaned regularly by polling staff. You may need to wait while a booth is sanitised before you enter."
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:12
+msgid "Polling Station staff may be working behind safety screens - this doesn’t mean you can’t <strong>ask for assistance if you require it!</strong>"
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:14
+msgid "With these new safety measures in place, it may take a little bit longer to vote than usual. Remember that if you are in the queue to vote before 10pm, you will still be able to vote even when polls officially close."
+msgstr ""
+
 #: polling_stations/templates/fragments/multiple_elections.html:5
 msgid "Multiple elections are happening!"
 msgstr "Mae nifer o etholiadau'n digwydd!"
@@ -382,20 +447,24 @@ msgstr "Os ydych chi'n credu bod yna etholiadau yn eich ardal chi, gwiriwch wefa
 msgid "Your polling station"
 msgstr "Eich gorsaf bleidleisio"
 
-#: polling_stations/templates/fragments/polling_station_known.html:22
-#, python-format
-msgid "It's about %(dist)s away or a %(time)s %(mode)s from %(postcode)s."
+#: polling_stations/templates/fragments/polling_station_known.html:23
+#, fuzzy, python-format
+#| msgid "It's about %(dist)s away or a %(time)s %(mode)s from %(postcode)s."
+msgid "It's about %(distance_in_miles)s miles away or a %(time_in_minutes)s minute walk from %(postcode)s."
 msgstr "Mae tua %(dist)s i ffwrdd neu %(time)s %(mode)s o %(postcode)s."
 
-#: polling_stations/templates/fragments/polling_station_known.html:28
-msgid "Walking/driving directions from Google"
-msgstr "Cyfarwyddiadau cerdded/gyrru gan Google"
+#: polling_stations/templates/fragments/polling_station_known.html:29
+#, fuzzy, python-format
+#| msgid "It's about %(dist)s away or a %(time)s %(mode)s from %(postcode)s."
+msgid "It's about %(distance_in_miles)s miles away or a %(time_in_minutes)s minute drive from %(postcode)s."
+msgstr "Mae tua %(dist)s i ffwrdd neu %(time)s %(mode)s o %(postcode)s."
 
-#: polling_stations/templates/fragments/polling_station_known.html:32
-msgid "Cycling directions from CycleStreets"
-msgstr "Cyfarwyddiadau seiclo gan CycleStreets"
+#: polling_stations/templates/fragments/polling_station_known.html:36
+#, python-format
+msgid "Get <a href=\"%(google_maps_url)s\" target=\"_top\">walking/driving directions from Google</a> or <a href=\"%(cyclestreets_url)s\" target=\"_top\">cycling directions from CycleStreets</a>."
+msgstr ""
 
-#: polling_stations/templates/fragments/polling_station_known.html:37
+#: polling_stations/templates/fragments/polling_station_known.html:43
 #: polling_stations/templates/fragments/polling_station_unknown.html:23
 msgid "Polling stations are open from 7am to 10pm on Thursday 6 May."
 msgstr "Mae gorsafoedd pleidleisio ar agor o 7yb i 10yh ar ddydd Iau 6 Mai."

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-08 14:13+0100\n"
+"POT-Creation-Date: 2021-04-29 21:16+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,18 @@ msgstr ""
 
 #: polling_stations/apps/bug_reports/forms.py:13
 msgid "Description"
+msgstr ""
+
+#: polling_stations/apps/bug_reports/models.py:15
+msgid "Provide information about the problem to help us improve our service:"
+msgstr ""
+
+#: polling_stations/apps/bug_reports/models.py:23
+msgid "(Optional) Email address:"
+msgstr ""
+
+#: polling_stations/apps/bug_reports/templates/bug_reports/disclaimer.html:3
+msgid "If you provide an email address, we may contact you to request more information or notify you of improvements related to this report. It will not be used for email marketing purposes."
 msgstr ""
 
 #: polling_stations/apps/bug_reports/templates/bug_reports/report_form_inline.html:8
@@ -45,14 +57,6 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr ""
 
-#: polling_stations/apps/data_finder/helpers/directions.py:83
-msgid "minute"
-msgstr ""
-
-#: polling_stations/apps/data_finder/helpers/directions.py:87
-msgid "miles"
-msgstr ""
-
 #: polling_stations/apps/feedback/forms.py:19
 #: polling_stations/apps/feedback/templates/feedback/feedback_form.html:7
 msgid "Did you find this useful?"
@@ -72,6 +76,10 @@ msgstr ""
 
 #: polling_stations/apps/feedback/templates/feedback/feedback_form.html:16
 msgid "Can you tell us anything more?"
+msgstr ""
+
+#: polling_stations/apps/feedback/templates/feedback/feedback_form.html:18
+msgid "Send feedback"
 msgstr ""
 
 #: polling_stations/apps/file_uploads/templates/file_uploads/council_detail.html:5
@@ -96,99 +104,112 @@ msgctxt "not shown to general public"
 msgid "This is a staging site."
 msgstr ""
 
-#: polling_stations/templates/base.html:80
+#: polling_stations/templates/base.html:41
+msgid "Language:"
+msgstr ""
+
+#: polling_stations/templates/base.html:78
 msgid "Home"
 msgstr ""
 
-#: polling_stations/templates/base.html:81
+#: polling_stations/templates/base.html:79
 msgid "About"
 msgstr ""
 
-#: polling_stations/templates/base.html:82
+#: polling_stations/templates/base.html:80
 msgid "Privacy"
 msgstr ""
 
-#: polling_stations/templates/base.html:83
+#: polling_stations/templates/base.html:81
 msgctxt "Application Programming Interface"
 msgid "API"
 msgstr ""
 
-#: polling_stations/templates/base.html:84
-#: polling_stations/templates/base.html:96
+#: polling_stations/templates/base.html:82
+#: polling_stations/templates/base.html:94
 msgid "Blog"
 msgstr ""
 
-#: polling_stations/templates/base.html:85
-#: polling_stations/templates/base.html:97
+#: polling_stations/templates/base.html:83
+#: polling_stations/templates/base.html:95
 msgid "Mailing List"
 msgstr ""
 
-#: polling_stations/templates/base.html:86
+#: polling_stations/templates/base.html:84
 msgid "Contact"
 msgstr ""
 
-#: polling_stations/templates/base.html:90
+#: polling_stations/templates/base.html:88
 msgid "Made by Democracy Club"
 msgstr ""
 
-#: polling_stations/templates/base.html:91
-msgid ""
-"Democracy Club is a UK based Community Interest Company that builds the "
-"digital infrastructure needed for a 21st century democracy."
+#: polling_stations/templates/base.html:89
+msgid "Democracy Club is a UK based Community Interest Company that builds the digital infrastructure needed for a 21st century democracy."
 msgstr ""
 
-#: polling_stations/templates/base.html:94
+#: polling_stations/templates/base.html:92
 msgid "About Democracy Club"
 msgstr ""
 
-#: polling_stations/templates/base.html:95
+#: polling_stations/templates/base.html:93
 msgid "Contact Us"
 msgstr ""
 
-#: polling_stations/templates/base.html:98
+#: polling_stations/templates/base.html:96
 msgctxt "link to Democracy Club Twitter page"
 msgid "Twitter"
 msgstr ""
 
-#: polling_stations/templates/base.html:99
+#: polling_stations/templates/base.html:97
 msgctxt "link to Democracy Club Facebook page"
 msgid "Facebook"
 msgstr ""
 
-#: polling_stations/templates/base.html:100
+#: polling_stations/templates/base.html:98
 msgctxt "link to Democracy Club GitHub page"
 msgid "GitHub"
 msgstr ""
 
-#: polling_stations/templates/base.html:105
+#: polling_stations/templates/base.html:103
 #, python-format
 msgid ""
 "Copyright ©\n"
-"        %(current_year)s Democracy Club Community Interest Company Company "
-"No: <a href=\"%(companies_house_url)s\">%(company_number)s</a>"
+"        %(current_year)s Democracy Club Community Interest Company Company No: <a href=\"%(companies_house_url)s\">%(company_number)s</a>"
 msgstr ""
 
-#: polling_stations/templates/base.html:108
+#: polling_stations/templates/base.html:106
 #, python-format
 msgid "Contains OS data © Crown copyright and database right %(current_year)s"
 msgstr ""
 
-#: polling_stations/templates/base.html:109
+#: polling_stations/templates/base.html:107
 #, python-format
-msgid ""
-"Contains Royal Mail data © Royal Mail copyright and database right "
-"%(current_year)s"
+msgid "Contains Royal Mail data © Royal Mail copyright and database right %(current_year)s"
 msgstr ""
 
-#: polling_stations/templates/base.html:110
+#: polling_stations/templates/base.html:108
 #, python-format
-msgid ""
-"Contains National Statistics data © Crown copyright and database right "
-"%(current_year)s"
+msgid "Contains National Statistics data © Crown copyright and database right %(current_year)s"
 msgstr ""
 
 #: polling_stations/templates/base_embed.html:13
 msgid "Democracy Club logo"
+msgstr ""
+
+#: polling_stations/templates/base_full.html:8
+#, python-format
+msgid "%(site_title)s by Democracy Club"
+msgstr ""
+
+#: polling_stations/templates/base_full.html:12
+#: polling_stations/templates/base_full.html:25
+#, python-format
+msgid "Find out where to vote on %(election_date)s"
+msgstr ""
+
+#: polling_stations/templates/base_full.html:12
+#: polling_stations/templates/base_full.html:25
+msgid "Find out where to vote"
 msgstr ""
 
 #: polling_stations/templates/custom_finder.html:4
@@ -223,9 +244,7 @@ msgstr ""
 
 #: polling_stations/templates/fragments/cancelled_election.html:10
 #, python-format
-msgid ""
-"The poll for <strong>%(cancelled_election_name)s</strong> has been "
-"rescheduled."
+msgid "The poll for <strong>%(cancelled_election_name)s</strong> has been rescheduled."
 msgstr ""
 
 #. Translators: 'it' is a postponed election
@@ -236,15 +255,12 @@ msgstr ""
 
 #: polling_stations/templates/fragments/cancelled_election.html:14
 #, python-format
-msgid ""
-"The poll for <strong>%(cancelled_election_name)s</strong> has been cancelled."
+msgid "The poll for <strong>%(cancelled_election_name)s</strong> has been cancelled."
 msgstr ""
 
 #: polling_stations/templates/fragments/cancelled_election.html:25
 #, python-format
-msgid ""
-"For more information contact %(council)s on <strong><a href=\"tel:"
-"%(phone_number)s\">%(phone_number)s</a></strong>."
+msgid "For more information contact %(council)s on <strong><a href=\"tel:%(phone_number)s\">%(phone_number)s</a></strong>."
 msgstr ""
 
 #: polling_stations/templates/fragments/cancelled_election.html:30
@@ -309,21 +325,15 @@ msgstr ""
 
 #: polling_stations/templates/fragments/help_your_council.html:8
 #, python-format
-msgid ""
-"A lot of people are needed to make an election happen. Your council may be "
-"hiring polling station and counting staff for the upcoming elections. "
-"Contact %(council)s Electoral Services team to see if they need help."
+msgid "A lot of people are needed to make an election happen. Your council may be hiring polling station and counting staff for the upcoming elections. Contact %(council)s Electoral Services team to see if they need help."
 msgstr ""
 
 #: polling_stations/templates/fragments/help_your_council.html:15
 #, python-format
 msgid ""
 "\n"
-"            You can email them at <strong><a href=\"mailto:"
-"%(council_electoral_services_email)s\">%(council_electoral_services_email)s</"
-"a></strong>\n"
-"            or call them on <strong><a href=\"tel:%(council_phone)s\">"
-"%(council_phone)s</a></strong>.\n"
+"            You can email them at <strong><a href=\"mailto:%(council_electoral_services_email)s\">%(council_electoral_services_email)s</a></strong>\n"
+"            or call them on <strong><a href=\"tel:%(council_phone)s\">%(council_phone)s</a></strong>.\n"
 "        "
 msgstr ""
 
@@ -345,6 +355,42 @@ msgctxt "followed by link to whocanivotefor.co.uk, with that link text"
 msgid "You can find information on your candidates at"
 msgstr ""
 
+#: polling_stations/templates/fragments/keep_safe.html:3
+msgid "Keeping you and fellow voters safe!"
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:4
+msgid "Local election teams will be doing everything they can to ensure voting in person on polling day is safe for everyone. This means there will be safety measures in place at polling stations to prevent the spread of COVID-19, many of which you’ll be very familiar with! "
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:7
+msgid "There will be a limit to the number of people allowed in a polling station at any given time to allow for <strong>social distancing</strong>."
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:8
+msgid "Please remember your <strong>face covering</strong> - you will need this to enter the polling station and will be expected to wear it throughout."
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:9
+msgid "Make sure to <strong>sanitise your hands</strong> before and after voting. In many places, sanitiser will be available but it may be a good idea to carry your own!"
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:10
+msgid "Some polling stations will supply clean pencils for voters but it may be best to bring your own with you."
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:11
+msgid "Polling Stations will be cleaned regularly by polling staff. You may need to wait while a booth is sanitised before you enter."
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:12
+msgid "Polling Station staff may be working behind safety screens - this doesn’t mean you can’t <strong>ask for assistance if you require it!</strong>"
+msgstr ""
+
+#: polling_stations/templates/fragments/keep_safe.html:14
+msgid "With these new safety measures in place, it may take a little bit longer to vote than usual. Remember that if you are in the queue to vote before 10pm, you will still be able to vote even when polls officially close."
+msgstr ""
+
 #: polling_stations/templates/fragments/multiple_elections.html:5
 msgid "Multiple elections are happening!"
 msgstr ""
@@ -355,9 +401,7 @@ msgstr ""
 
 #: polling_stations/templates/fragments/multiple_elections.html:11
 msgctxt "followed by link to whocanivotefor.co.uk, with that link text"
-msgid ""
-"Don't worry, you can vote in all of them at the same polling station and "
-"read about them at"
+msgid "Don't worry, you can vote in all of them at the same polling station and read about them at"
 msgstr ""
 
 #: polling_stations/templates/fragments/no_election.html:7
@@ -370,31 +414,29 @@ msgstr ""
 
 #: polling_stations/templates/fragments/no_election.html:10
 #, python-format
-msgid ""
-"If you think there may be elections in your area, check your local <a href="
-"\"%(council_website)s\">council website</a> for more information, or contact "
-"%(council)s on <strong><a href=\"tel:%(council_phone)s\">%(council_phone)s</"
-"a></strong>."
+msgid "If you think there may be elections in your area, check your local <a href=\"%(council_website)s\">council website</a> for more information, or contact %(council)s on <strong><a href=\"tel:%(council_phone)s\">%(council_phone)s</a></strong>."
 msgstr ""
 
 #: polling_stations/templates/fragments/polling_station_known.html:3
 msgid "Your polling station"
 msgstr ""
 
-#: polling_stations/templates/fragments/polling_station_known.html:22
+#: polling_stations/templates/fragments/polling_station_known.html:23
 #, python-format
-msgid "It's about %(dist)s away or a %(time)s %(mode)s from %(postcode)s."
+msgid "It's about %(distance_in_miles)s miles away or a %(time_in_minutes)s minute walk from %(postcode)s."
 msgstr ""
 
-#: polling_stations/templates/fragments/polling_station_known.html:28
-msgid "Walking/driving directions from Google"
+#: polling_stations/templates/fragments/polling_station_known.html:29
+#, python-format
+msgid "It's about %(distance_in_miles)s miles away or a %(time_in_minutes)s minute drive from %(postcode)s."
 msgstr ""
 
-#: polling_stations/templates/fragments/polling_station_known.html:32
-msgid "Cycling directions from CycleStreets"
+#: polling_stations/templates/fragments/polling_station_known.html:36
+#, python-format
+msgid "Get <a href=\"%(google_maps_url)s\" target=\"_top\">walking/driving directions from Google</a> or <a href=\"%(cyclestreets_url)s\" target=\"_top\">cycling directions from CycleStreets</a>."
 msgstr ""
 
-#: polling_stations/templates/fragments/polling_station_known.html:37
+#: polling_stations/templates/fragments/polling_station_known.html:43
 #: polling_stations/templates/fragments/polling_station_unknown.html:23
 msgid "Polling stations are open from 7am to 10pm on Thursday 6 May."
 msgstr ""
@@ -406,9 +448,7 @@ msgstr ""
 
 #: polling_stations/templates/fragments/polling_station_unknown.html:6
 #: polling_stations/templates/multiple_councils.html:12
-msgid ""
-"Your polling station address should be printed on your polling card, which "
-"is delivered by post before an election."
+msgid "Your polling station address should be printed on your polling card, which is delivered by post before an election."
 msgstr ""
 
 #: polling_stations/templates/fragments/polling_station_unknown.html:11
@@ -417,10 +457,7 @@ msgstr ""
 
 #: polling_stations/templates/fragments/polling_station_unknown.html:12
 #, python-format
-msgid ""
-"You can call %(council)s on <strong><a href=\"tel:%(council_phone)s\">"
-"%(council_phone)s</a></strong> or <strong><a href=\"%(council_website)s"
-"\">visit their website</a></strong>."
+msgid "You can call %(council)s on <strong><a href=\"tel:%(council_phone)s\">%(council_phone)s</a></strong> or <strong><a href=\"%(council_website)s\">visit their website</a></strong>."
 msgstr ""
 
 #: polling_stations/templates/fragments/polling_station_unknown.html:17
@@ -441,15 +478,11 @@ msgid "https://www.gov.uk/register-to-vote"
 msgstr ""
 
 #: polling_stations/templates/fragments/register_to_vote.html:12
-msgid ""
-"Register before midnight on Monday 19th April to vote in the election(s) on "
-"Thursday 6th May."
+msgid "Register before midnight on Monday 19th April to vote in the election(s) on Thursday 6th May."
 msgstr ""
 
 #: polling_stations/templates/fragments/register_to_vote.html:13
-msgid ""
-"You don't need to register again if you've already registered at your "
-"current address."
+msgid "You don't need to register again if you've already registered at your current address."
 msgstr ""
 
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:10
@@ -469,9 +502,7 @@ msgstr ""
 
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:21
 #: polling_stations/templates/home.html:50
-msgid ""
-"If you are registered to vote, but you don't have your poll card, you can go "
-"to the polling station and give them your name and address."
+msgid "If you are registered to vote, but you don't have your poll card, you can go to the polling station and give them your name and address."
 msgstr ""
 
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:25
@@ -501,12 +532,8 @@ msgstr ""
 
 #: polling_stations/templates/home.html:39
 #, python-format
-msgctxt ""
-"day_of_week  and election_date are localised, e.g. 'Dydd Lau' and '6 Mai "
-"2021'. If it's awkward, leave out the day of the week."
-msgid ""
-"Polling stations are open from 7am to 10pm on <strong>%(day_of_week)s "
-"%(election_date)s</strong>."
+msgctxt "day_of_week  and election_date are localised, e.g. 'Dydd Lau' and '6 Mai 2021'. If it's awkward, leave out the day of the week."
+msgid "Polling stations are open from 7am to 10pm on <strong>%(day_of_week)s %(election_date)s</strong>."
 msgstr ""
 
 #: polling_stations/templates/home.html:45
@@ -514,9 +541,7 @@ msgid "You don't need your poll card to vote."
 msgstr ""
 
 #: polling_stations/templates/home.html:53
-msgid ""
-"In England, Wales and Scotland, you don't need any form of ID. In Northern "
-"Ireland, you must bring photo ID."
+msgid "In England, Wales and Scotland, you don't need any form of ID. In Northern Ireland, you must bring photo ID."
 msgstr ""
 
 #: polling_stations/templates/multiple_councils.html:6
@@ -530,7 +555,5 @@ msgstr ""
 
 #: polling_stations/templates/multiple_councils.html:13
 #, python-format
-msgid ""
-"Or, you need to contact your council. Residents in %(postcode)s may be in "
-"one of the following council areas:"
+msgid "Or, you need to contact your council. Residents in %(postcode)s may be in one of the following council areas:"
 msgstr ""


### PR DESCRIPTION
This follows up on #3755 and #3756.

It's not quite a straight run of `makemessages --no-wrap`, as it still
wanted to do things slightly differently to Transifex, so I've omitted
the non-substantive reformatting changes introduced by makemessages
alone.