### PR TITLE
Move to tokens on a 2hr timeout

### DIFF
--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -133,8 +133,8 @@ AUTHENTICATION_BACKENDS = [
     "sesame.backends.ModelBackend",
 ]
 
-SESAME_MAX_AGE = 60 * 10
-SESAME_ONE_TIME = True
+SESAME_MAX_AGE = 60 * 60 * 2
+SESAME_ONE_TIME = False
 SESAME_TOKEN_NAME = "login_token"
 
 ROOT_URLCONF = "polling_stations.urls"


### PR DESCRIPTION
This is because automatic link checking email systems hit the magic link
and invalidate the token if it's onetime. 2 hrs gives users time to
request a magic link and get a cup of tea.