### PR TITLE
Add a council csv api endpoint

### DIFF
--- a/polling_stations/apps/api/councils.py
+++ b/polling_stations/apps/api/councils.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from django.http import HttpResponsePermanentRedirect, Http404
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -146,10 +147,7 @@ class CouncilCSVSerializer(CouncilDataSerializer):
         model = Council
         fields = ("council_id", "name", "station_count")
 
-    station_count = serializers.SerializerMethodField()
-
-    def get_station_count(self, council):
-        return council.pollingstation_set.count()
+    station_count = serializers.IntegerField(source="stations", read_only=True)
 
 
 class CouncilCSVRenderer(CSVRenderer):
@@ -164,4 +162,8 @@ class CouncilCSVViewSet(ReadOnlyModelViewSet):
 
     renderer_classes = (CouncilCSVRenderer,)
     serializer_class = CouncilCSVSerializer
-    queryset = Council.objects.all().order_by("council_id")
+    queryset = (
+        Council.objects.all()
+        .order_by("council_id")
+        .annotate(stations=Count("pollingstation"))
+    )

--- a/polling_stations/apps/api/router.py
+++ b/polling_stations/apps/api/router.py
@@ -1,7 +1,7 @@
 from django.urls import re_path
 from rest_framework import routers
 from .address import AddressViewSet
-from .councils import CouncilViewSet
+from .councils import CouncilViewSet, CouncilCSVViewSet
 from .pollingstations import PollingStationViewSet
 from .postcode import PostcodeViewSet
 from .sandbox import SandboxView
@@ -10,6 +10,11 @@ from file_uploads.api import UploadViewSet
 
 router = routers.DefaultRouter()
 router.register(r"councils", CouncilViewSet)
+router.register(
+    r"council_csv",
+    CouncilCSVViewSet,
+    basename="council_csv",
+)
 router.register(r"pollingstations", PollingStationViewSet)
 router.register(r"postcode", PostcodeViewSet, basename="postcode")
 router.register(r"address", AddressViewSet, basename="address")

--- a/polling_stations/apps/api/tests/test_councils.py
+++ b/polling_stations/apps/api/tests/test_councils.py
@@ -1,6 +1,7 @@
+from django.core.management import call_command
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from api.councils import CouncilViewSet
+from api.councils import CouncilViewSet, CouncilCSVViewSet
 from councils.tests.factories import CouncilFactory
 
 
@@ -23,6 +24,16 @@ class CouncilsTest(TestCase):
             identifiers=["X01000002"],
             geography__geography=None,
         )
+        CouncilFactory(
+            council_id="GHI",
+            identifiers=["X01000002"],
+            geography__geography=None,
+        )
+        call_command(  # Hack to avoid converting all fixtures to factories
+            "loaddata",
+            "polling_stations/apps/api/fixtures/test_api_pollingdistricts_stations.json",
+            verbosity=0,
+        )
 
     def setUp(self):
         factory = APIRequestFactory()
@@ -31,7 +42,7 @@ class CouncilsTest(TestCase):
     def test_list(self):
         response = CouncilViewSet.as_view({"get": "list"})(self.request)
         self.assertEqual(200, response.status_code)
-        self.assertEqual(2, len(response.data))
+        self.assertEqual(3, len(response.data))
 
     def test_valid_council(self):
         response = CouncilViewSet.as_view({"get": "retrieve"})(self.request, pk="ABC")
@@ -96,4 +107,18 @@ class CouncilsTest(TestCase):
                     "website": "",
                 },
             },
+        )
+
+    def test_council_csv_endpoint(self):
+        response = CouncilCSVViewSet.as_view({"get": "list"})(
+            APIRequestFactory().get("/api/beta/council_csv/", format="csv")
+        )
+        self.assertEqual(response.status_code, 200)
+        response.render()
+        self.assertEqual(
+            response.content.decode(),
+            "council_id,name,station_count\r\n"
+            "ABC,ABC Council,2\r\n"
+            "DEF,,1\r\n"
+            "GHI,,0\r\n",
         )

--- a/polling_stations/apps/api/tests/test_councils.py
+++ b/polling_stations/apps/api/tests/test_councils.py
@@ -110,9 +110,10 @@ class CouncilsTest(TestCase):
         )
 
     def test_council_csv_endpoint(self):
-        response = CouncilCSVViewSet.as_view({"get": "list"})(
-            APIRequestFactory().get("/api/beta/council_csv/", format="csv")
-        )
+        with self.assertNumQueries(1):
+            response = CouncilCSVViewSet.as_view({"get": "list"})(
+                APIRequestFactory().get("/api/beta/council_csv/", format="csv")
+            )
         self.assertEqual(response.status_code, 200)
         response.render()
         self.assertEqual(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ django-localflavor==3.1
 django-markdown-deux==1.0.5
 django==3.2.12
 djangorestframework==3.13.1
+djangorestframework-csv==2.1.1
 djangorestframework-gis==0.18
 django-cors-headers==3.10.0
 django-sesame==2.4


### PR DESCRIPTION
This lets us easily import this into a google sheet, in order to keep
track of which councils are live on the site.