### PR TITLE
Run `pre-commit autoupdate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: local
@@ -18,13 +18,13 @@ repos:
         pass_filenames: false
         stages: [push]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
     -   id: check-json
 -   repo: https://github.com/rtts/djhtml
-    rev: v1.4.9
+    rev: v1.5.0
     hooks:
     -   id: djhtml


### PR DESCRIPTION
black was broken per psf/black#2964, so our pre-commit config needed updating to reference the newer version. This provided a prompt to update all pre-commit hook versions.