### PR TITLE
Log all postcode lookups

### DIFF
--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -222,6 +222,14 @@ class PostcodeView(BasePollingStationView):
         if "postcode" not in kwargs or kwargs["postcode"] == "":
             return HttpResponseRedirect(reverse("home"))
 
+        # Log to firehose
+        entry = settings.POSTCODE_LOGGER.entry_class(
+            postcode=kwargs["postcode"],
+            dc_product=settings.POSTCODE_LOGGER.dc_product.wdiv,
+            **self.request.session.get("utm_data"),
+        )
+        settings.POSTCODE_LOGGER.log(entry)
+
         rh = RoutingHelper(self.kwargs["postcode"])
 
         if rh.view != "postcode_view":

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -1,5 +1,6 @@
 import os, sys
 
+from dc_logging_client import DCWidePostcodeLoggingClient
 from django.utils.translation import gettext_lazy as _
 
 # PATH vars
@@ -293,6 +294,9 @@ BASICAUTH_DISABLE = True
 
 
 SHOW_ADVANCE_VOTING_STATIONS = True
+
+# DC Logging Client
+POSTCODE_LOGGER = DCWidePostcodeLoggingClient(fake=True)
 
 # settings for load balancer status check
 CHECK_SERVER_CLEAN = True

--- a/polling_stations/settings/local.example.py
+++ b/polling_stations/settings/local.example.py
@@ -16,3 +16,10 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
     }
 }
+
+
+# To test the DC logging client you must authenticate against the AWS monitoring
+# account directly by exporting the AWS creds (or using SSO) and then
+# enable the `direct_connection` mode
+# from dc_logging_client import DCWidePostcodeLoggingClient
+# POSTCODE_LOGGER = DCWidePostcodeLoggingClient(direct_connection=True)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,3 +29,4 @@ uk-geo-utils==0.10.3
 git+https://github.com/DemocracyClub/dc_signup_form.git@2.1.1
 git+https://github.com/DemocracyClub/design-system.git@0.1.6
 git+https://github.com/DemocracyClub/dc_django_utils.git@0.1.8
+git+https://github.com/DemocracyClub/dc_logging.git@0.0.9


### PR DESCRIPTION
I'm not logging postcodes that look wrong, and at the moment we only care about postcodes, not addresses. 

We also don't care about API postcodes, as we'll assume they're logged via devs.DC.

Might be of use when working on https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1166