### PR TITLE
Dependabot should ignore boto3 patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: boto3
+    update-types: ["version-update:semver-patch"]
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+-


### PR DESCRIPTION
AWS releases patch versions of `boto3` on a daily basis, but we don't need to incorporate these changes on the same schedule. This work ensures a dependabot PR will not be raised for patched versions. 

More info https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/