### PR TITLE
Send email confirmation to councils following successful upload

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_west_lancashire.py
+++ b/polling_stations/apps/data_importers/management/commands/import_west_lancashire.py
@@ -3,6 +3,10 @@ from data_importers.management.commands import BaseXpressDemocracyClubCsvImporte
 
 class Command(BaseXpressDemocracyClubCsvImporter):
     council_id = "WLA"
-    addresses_name = "2023-02-09/2023-01-19T09:29:09.859821/Democracy_Club__09February2023.CSV"
-    stations_name = "2023-02-09/2023-01-19T09:29:09.859821/Democracy_Club__09February2023.CSV"
-    elections = ['2023-02-09']
+    addresses_name = (
+        "2023-02-09/2023-01-19T09:29:09.859821/Democracy_Club__09February2023.CSV"
+    )
+    stations_name = (
+        "2023-02-09/2023-01-19T09:29:09.859821/Democracy_Club__09February2023.CSV"
+    )
+    elections = ["2023-02-09"]

--- a/polling_stations/apps/file_uploads/api.py
+++ b/polling_stations/apps/file_uploads/api.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import PermissionDenied
+
 from .models import File, Upload
 
 
@@ -58,8 +59,12 @@ class UploadSerializer(serializers.ModelSerializer):
             if (
                 file_set.first().ems == "Democracy Counts" and file_set.count() == 2
             ) or file_set.first().ems != "Democracy Counts":
-                upload.make_pull_request()
 
+                user = self.context["request"].user
+                upload.make_pull_request()
+                upload.send_confirmation_email(user=user)
+        else:
+            upload.send_error_email()
         return upload
 
 

--- a/polling_stations/apps/file_uploads/templates/file_uploads/email/file_upload_error.txt
+++ b/polling_stations/apps/file_uploads/templates/file_uploads/email/file_upload_error.txt
@@ -1,0 +1,1 @@
+File upload for council {self.gss} failed. Please try again with a new export or contact {settings.DEFAULT_FROM_EMAIL} for assistance.

--- a/polling_stations/apps/file_uploads/templates/file_uploads/email/upload_confirmation.txt
+++ b/polling_stations/apps/file_uploads/templates/file_uploads/email/upload_confirmation.txt
@@ -1,0 +1,1 @@
+Your file was successfully uploaded to Democracy Club’s polling station data uploader.

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -285,7 +285,7 @@ ONSUD_MODEL = "addressbase.UprnToCouncil"
 
 EMAIL_SIGNUP_ENDPOINT = "https://democracyclub.org.uk/mailing_list/api_signup/v1/"
 EMAIL_SIGNUP_API_KEY = ""
-
+DEFAULT_FROM_EMAIL = "Democracy Club <pollingstations@democracyclub.org.uk>"
 
 # Disable Basic Auth by default
 # We only want to use this on staging deploys


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/UK-Polling-Stations/issues/4794
Ref https://trello.com/c/M4uUNZMl/3229-priority-wdiv-uploader-fixes-needed-before-next-election

This work:

- sends an email to councils (based on certain EMS uploads) once a file(s) has been uploaded and a PR has been raised
- sends an email to DC if an upload fails
- adds a `reply_to` address has been added to settings
- addresses a deprecation warning with `django.utils.timezone.utc`
