### PR TITLE
Remove ID messaging for En/Sc/Cy

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -571,10 +571,6 @@ msgstr "Os ydych chi wedi cofrestru i bleidleisio ond nad oes gennych chi eich c
 msgid "You will need photographic identification"
 msgstr "Bydd angen dogfen adnabod â llun arnoch chi"
 
-#: polling_stations/templates/fragments/you_dont_need_poll_card.html:27
-msgid "You don't need any other form of ID."
-msgstr "Nid oes angen unrhyw fath arall o ID arnoch chi."
-
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:34
 msgid "Read more about voting in Northern Ireland"
 msgstr "Darllen mwy am bleidleiso yng Ngogledd Iwerddon"
@@ -608,9 +604,8 @@ msgstr "Nid oes angen eich cerdyn pleidleisio arnoch i bleidleisio."
 
 #: polling_stations/templates/home.html:53
 msgid ""
-"In England, Wales and Scotland, you don't need any form of ID. In Northern "
-"Ireland, you must bring photo ID."
-msgstr "Yng Nghymru, Lloegr a'r Alban nid oes angen unrhyw fath o ID arnoch chi. Yng Ngogledd Iwerddon, rhaid i chi ddod â dogfen adnabod â llun."
+"In Northern Ireland, you must bring photo ID."
+msgstr "Yng Ngogledd Iwerddon, rhaid i chi ddod â dogfen adnabod â llun."
 
 #: polling_stations/templates/multiple_councils.html:6
 #: polling_stations/templates/postcode_view.html:33

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -602,11 +602,6 @@ msgstr "Mae gorsafoedd pleidleisio ar agor o 7yb i 10yh ar <strong>%(day_of_week
 msgid "You don't need your poll card to vote."
 msgstr "Nid oes angen eich cerdyn pleidleisio arnoch i bleidleisio."
 
-#: polling_stations/templates/home.html:53
-msgid ""
-"In Northern Ireland, you must bring photo ID."
-msgstr "Yng Ngogledd Iwerddon, rhaid i chi ddod â dogfen adnabod â llun."
-
 #: polling_stations/templates/multiple_councils.html:6
 #: polling_stations/templates/postcode_view.html:33
 msgid "Your Polling Station"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -708,11 +708,6 @@ msgstr ""
 msgid "You don't need your poll card to vote."
 msgstr ""
 
-#: polling_stations/templates/home.html:51
-msgid ""
-"In Northern Ireland, you must bring photo ID."
-msgstr ""
-
 #: polling_stations/templates/multiple_councils.html:6
 #: polling_stations/templates/postcode_view.html:35
 msgid "Your Polling Station"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -677,10 +677,6 @@ msgstr ""
 msgid "You will need photographic identification"
 msgstr ""
 
-#: polling_stations/templates/fragments/you_dont_need_poll_card.html:30
-msgid "You don't need any other form of ID."
-msgstr ""
-
 #: polling_stations/templates/fragments/you_dont_need_poll_card.html:37
 msgid "Read more about voting in Northern Ireland"
 msgstr ""
@@ -714,8 +710,7 @@ msgstr ""
 
 #: polling_stations/templates/home.html:51
 msgid ""
-"In England, Wales and Scotland, you don't need any form of ID. In Northern "
-"Ireland, you must bring photo ID."
+"In Northern Ireland, you must bring photo ID."
 msgstr ""
 
 #: polling_stations/templates/multiple_councils.html:6

--- a/polling_stations/templates/fragments/you_dont_need_poll_card.html
+++ b/polling_stations/templates/fragments/you_dont_need_poll_card.html
@@ -26,8 +26,6 @@
 
             {% if territory == 'NI' %}
                 <p>{% trans "You will need photographic identification" %}</p>
-            {% else %}
-                <p>{% trans "You don't need any other form of ID." %}</p>
             {% endif %}
 
             <p>{% trans "You must vote at your assigned polling station." %}</p>

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -48,8 +48,6 @@
                         <p>
                             {% trans "If you are registered to vote, but you don't have your poll card, you can go to the polling station and give them your name and address." %}
                         </p>
-
-                        <p>{% trans "In Northern Ireland, you must bring photo ID." %}</p>
                     </div>
                 </div>
             {% endif %}

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -49,7 +49,7 @@
                             {% trans "If you are registered to vote, but you don't have your poll card, you can go to the polling station and give them your name and address." %}
                         </p>
 
-                        <p>{% trans "In England, Wales and Scotland, you don't need any form of ID. In Northern Ireland, you must bring photo ID." %}</p>
+                        <p>{% trans "In Northern Ireland, you must bring photo ID." %}</p>
                     </div>
                 </div>
             {% endif %}


### PR DESCRIPTION
New legislation = new messaging :grin:

NI messaging around voter ID is unchanged but messaging for the other nations has been removed - potentially to be replaced by new messaging when we have that figured out. 

<img width="959" alt="Screenshot 2023-01-25 at 11 41 55" src="https://user-images.githubusercontent.com/9531063/214557470-7f527b0f-12fe-44d4-aef5-e3633b712cb6.png">
<img width="960" alt="Screenshot 2023-01-25 at 11 50 36" src="https://user-images.githubusercontent.com/9531063/214557517-2e2a7559-0e96-4d97-a72f-ea4e0cb292cb.png">
