### PR TITLE
Set status based on EMS and file count

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
 
       - node/install:
-          node-version: '10.19.0'
+          node-version: '16.13.0'
 
       - run:
           name: Install node node_modules

--- a/polling_stations/apps/file_uploads/models.py
+++ b/polling_stations/apps/file_uploads/models.py
@@ -16,7 +16,9 @@ from data_importers.import_script import ImportScript
 
 status_map = {
     "Pending": "⌛",
+    "Waiting": "⌛ waiting for second file",
     "Error": "❌",
+    "Error One File": "❌ only one file uploaded",
     "OK": "✔️",
 }
 
@@ -64,6 +66,15 @@ class Upload(models.Model):
         if not self.file_set.all():
             return "Pending"
         for f in self.file_set.all():
+            if ("Expected 2 files, found 1" in f.errors) and (
+                self.timestamp + timedelta(seconds=180) > now()
+            ):
+                return "Waiting"
+            elif ("Expected 2 files, found 1" in f.errors) and (
+                self.timestamp + timedelta(seconds=180) < now()
+            ):
+                return "Error One File"
+
             if not f.csv_valid:
                 return "Error"
         return "OK"

--- a/polling_stations/apps/file_uploads/templates/file_uploads/council_detail.html
+++ b/polling_stations/apps/file_uploads/templates/file_uploads/council_detail.html
@@ -46,14 +46,14 @@
                             {% endif %}
                         </td>
                         <td>
-                            {{ upload.status }}
-                            {% if upload.status == "Pending" %}
+                            {{ upload.status_emoji }}
+                            {% if upload.status == "Pending" or upload.status == "Waiting" %}
                                 <br><small>(Refresh page to update)</small>
                             {% endif %}
                         </td>
                         <td>
                             {% if upload.status != "Pending" %}
-                                {% if STATIONS  %}✔{% else %}❌{% endif %}
+                                {% if STATIONS %}✔{% else %}❌{% endif %}
                             {% endif %}
                         </td>
                     </tr>


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/UK-Polling-Stations/issues/3051
Ref https://trello.com/c/M4uUNZMl/3229-priority-wdiv-uploader-fixes-needed-before-next-election

- This work adds a status check to each file in the file set during the upload process and returns a more specific status message to the user.
- I've also added a server environment check for prod to send custom error emails as not to confuse anyone in Fresh Desk while we are testing the uploader. 
- Lastly, I've updated the node version in CI as the previous orb was no longer in use. 

Changes can be tested by uploading 1/2 and/or 2/2 EMS files such as http://dev.wdiv.club/uploads/councils/BDF/

![Screenshot 2023-02-27 at 3 51 07 PM](https://user-images.githubusercontent.com/7017118/221612216-0c2929c3-bc27-499b-849a-68f936f57299.png)

REMINDER! Drop this commit once reviewed and approved [12bf87b](https://github.com/DemocracyClub/UK-Polling-Stations/pull/4955/commits/12bf87bbfa9717f9ed5236eb8a59af948ccbac42)
