### PR TITLE
Assign custom email domains to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,9 @@ If you are interested in helping the project by writing an import script, see th
 ## Install git hooks
 
 If you like you can use the commit hooks defined in `.pre-commit-config.yaml`. Run `pre-commit install && pre-commit install -t pre-push`.
+
+## Custom council domains
+If a user requests access to the council uploader using a custom domain, the domain should be added to the [`CUSTOM_DOMAINS` setting](https://github.com/DemocracyClub/UK-Polling-Stations/blob/master/polling_stations/settings/constants/uploads.py).
+To remove a custom domain, follow these steps:
+1) Delete the entry from the CUSTOM_DOMAIN list in `polling_stations/settings/constants/uploads.py`
+2) In the admin panel, delete the UserCouncil object from the bottom of the Council profile page

--- a/polling_stations/apps/file_uploads/models.py
+++ b/polling_stations/apps/file_uploads/models.py
@@ -178,7 +178,7 @@ class Upload(models.Model):
         email = EmailMessage(
             subject,
             message,
-            [settings.DEFAULT_FROM_EMAIL],
+            settings.DEFAULT_FROM_EMAIL,
             [settings.DEFAULT_FROM_EMAIL],
             reply_to=[settings.DEFAULT_FROM_EMAIL],
             headers={"Message-ID": subject},

--- a/polling_stations/apps/file_uploads/models.py
+++ b/polling_stations/apps/file_uploads/models.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
 from commitment import GitHubCredentials, GitHubClient
 from django.conf import settings
-from django.db import transaction
-from django.core.mail import EmailMessage
 from django.contrib.gis.db import models
 from django.utils.timezone import now
+from django.db import transaction
+from django.core.mail import EmailMessage
 
 
 from django.template.loader import render_to_string

--- a/polling_stations/apps/file_uploads/tests/test_utils.py
+++ b/polling_stations/apps/file_uploads/tests/test_utils.py
@@ -1,0 +1,74 @@
+from unittest import mock
+from django.test import TestCase
+
+import pytest
+from councils.models import Council, UserCouncils
+from django.contrib.auth.models import User
+from file_uploads.utils import assign_councils_to_user
+
+TEST_CUSTOM_DOMAINS = {
+    "custom_council.gov.uk": ["ABD", "ABE"],
+    "another_custom_council.gov.uk": ["ALL"],
+}
+
+
+class TestCustomDomainEmailCheck(TestCase):
+    def setUp(self):
+        Council.objects.create(
+            council_id="ABD",
+            electoral_services_email="bob@not_custom_council.gov.uk",
+            registration_email="bob@not_custom_council.gov.uk",
+        )
+        Council.objects.create(
+            council_id="ABE",
+            electoral_services_email="bob@not_custom_council.gov.uk",
+            registration_email="bob@not_custom_council.gov.uk",
+        )
+        Council.objects.create(
+            council_id="ALL",
+            electoral_services_email="bob@council.gov.uk",
+            registration_email="bob@council.gov.uk",
+        )
+
+    @pytest.mark.django_db
+    @mock.patch("file_uploads.utils.CUSTOM_DOMAINS", TEST_CUSTOM_DOMAINS)
+    def test_assign_approved_custom_domains(self, custom_domains=TEST_CUSTOM_DOMAINS):
+        user = User.objects.create(email="james@custom_council.gov.uk")
+        assign_councils_to_user(user)
+        self.assertEqual(user.council_set.count(), 2)
+        self.assertEqual(user.council_set.all()[0].council_id, "ABD")
+        self.assertEqual(user.council_set.all()[1].council_id, "ABE")
+        self.assertFalse(
+            UserCouncils.objects.filter(user=user, council__council_id="ALL").exists()
+        )
+
+    @pytest.mark.django_db
+    @mock.patch("file_uploads.utils.CUSTOM_DOMAINS", TEST_CUSTOM_DOMAINS)
+    def test_standard_domains(self, custom_domains=TEST_CUSTOM_DOMAINS):
+        user = User.objects.create(email="james@not_custom_council.gov.uk")
+        assign_councils_to_user(user)
+        self.assertEqual(user.council_set.count(), 2)
+        self.assertTrue(
+            UserCouncils.objects.filter(user=user, council__council_id="ABD").exists()
+        )
+        self.assertTrue(
+            UserCouncils.objects.filter(user=user, council__council_id="ABE").exists()
+        )
+        self.assertFalse(
+            UserCouncils.objects.filter(user=user, council__council_id="ALL").exists()
+        )
+
+    @pytest.mark.django_db
+    @mock.patch("file_uploads.utils.CUSTOM_DOMAINS", TEST_CUSTOM_DOMAINS)
+    def test_login_for_user_with_multiple_councils_assigned(self):
+        user = User.objects.create(email="james@custom_council.gov.uk")
+        assign_councils_to_user(user)
+        self.assertEqual(user.council_set.count(), 2)
+
+        self.client.force_login(user)
+        response = self.client.get("/uploads/councils/")
+        self.assertTrue(response.status_code, 200)
+        # response contains a list of councils
+        self.assertContains(response, "ABD")
+        self.assertContains(response, "ABE")
+        self.assertNotContains(response, "ALL")

--- a/polling_stations/apps/file_uploads/utils.py
+++ b/polling_stations/apps/file_uploads/utils.py
@@ -3,10 +3,31 @@ import os
 from django.db.models import Q
 
 from councils.models import Council, UserCouncils
+from polling_stations.settings.constants.uploads import CUSTOM_DOMAINS
 
 
 def get_domain(request):
     return os.environ.get("FQDN", request.META.get("HTTP_HOST"))
+
+
+# This is a quick fix: Raise a PR to
+# update CUSTOM_DOMAINS in
+# polling_stations/settings/constants/uploads.py
+# with the the actual list of email domains
+# and councils, as the need arises.
+# TO REMOVE:
+# 1) Delete the entry from the CUSTOM_DOMAIN list
+# 2) In the admin panel, delete the UserCouncil
+# object from the bottom of the Council profile page
+
+
+def assign_approved_custom_domains(user, email_domain):
+    # if email_domain in custom_domains, assign it to the
+    # corresponding council, otherwise do nothing
+    if email_domain := CUSTOM_DOMAINS.get(email_domain, None):
+        for council_id in email_domain:
+            council = Council.objects.get(council_id=council_id)
+            UserCouncils.objects.update_or_create(user=user, council=council)
 
 
 def assign_councils_to_user(user):
@@ -14,6 +35,7 @@ def assign_councils_to_user(user):
     Adds rows to the join table between User and Council
     """
     email_domain = user.email.rsplit("@", 1)[1]
+    assign_approved_custom_domains(user, email_domain)
     councils = Council.objects.filter(
         Q(electoral_services_email__contains=email_domain)
         | Q(registration_email__contains=email_domain)

--- a/polling_stations/settings/constants/uploads.py
+++ b/polling_stations/settings/constants/uploads.py
@@ -10,3 +10,11 @@ GITHUB_USERNAME = "polling-bot-4000"
 GITHUB_EMAIL = "developers@democracyclub.org.uk"
 GITHUB_REPO = "DemocracyClub/UK-Polling-Stations"
 GITHUB_API_KEY = os.environ.get("GITHUB_API_KEY", "")
+
+# update this constant with email domains
+# (i.e. the bit after '@') and the corresponding
+# three letter council_ids in a list as shown below:
+CUSTOM_DOMAINS = {
+    # "example.com": ["EXC"],
+    # "example.org": ["EXO", "EXP"],
+}


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/UK-Polling-Stations/issues/4220

This work adds a check and alternative route to `assign_council_to_user` when the user wants to login with an email address that contains a domain which differs from the council website domain. 

As noted in the comments, this is a quick fix for the few cases where this need arises; A PR to customise the list will be required as this functionality is not accessible from the admin site. I've added this instruction inline and to the README.

I've tested the following scenarios in the dev server: 

- Login with a standard domain email and be redirected to the matching council
- Login with a custom domain email and be redirected to the designated council
- Try to login with an email address that is neither custom or standard (error)

I've testing the following scenarios on the staging server: 

- Login with a custom domain email and be redirected to the designated council
- Try to login with an email address that is neither custom or standard (error)