### PR TITLE
Notify slack on deploy fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.0.2
+  slack: circleci/slack@4.1
 
 jobs:
   build_and_test:
@@ -92,7 +93,6 @@ jobs:
             . .venv/bin/activate
             coveralls
 
-
   cdk_synth:
     machine:
       image: ubuntu-2204:2022.10.2
@@ -141,6 +141,11 @@ jobs:
           pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
           . .venv/bin/activate
           npx cdk deploy --all --require-approval never --concurrency 3
+    # In the event the deployment has failed, alert the dev team
+    - slack/notify:
+        event: fail
+        template: basic_fail_1
+        channel: $SLACK_DEFAULT_CHANNEL
 
   code_deploy:
     docker:
@@ -193,6 +198,11 @@ jobs:
           sentry-cli releases --org democracy-club-gp new $CIRCLE_SHA1 --project wdiv
           sentry-cli releases --org democracy-club-gp set-commits --auto $CIRCLE_SHA1 --ignore-missing
           sentry-cli releases --org democracy-club-gp finalize $CIRCLE_SHA1
+  # In the event the deployment has failed, alert the dev team
+    - slack/notify:
+        event: fail
+        template: basic_fail_1
+        channel: $SLACK_DEFAULT_CHANNEL
 
 
 workflows:
@@ -204,19 +214,19 @@ workflows:
         name: "CDK Synth"
         requires:
         - build_and_test
-        context: [deployment-development-wdiv]
+        context: [deployment-development-wdiv, slack-secrets]
         dc-environment: development
     - cdk_deploy:
         name: "Development: CDK Deploy"
         requires:
         - "CDK Synth"
-        context: [deployment-development-wdiv]
+        context: [deployment-development-wdiv, slack-secrets]
         dc-environment: development
     - code_deploy:
         name: "Development: AWS CodeDeploy"
         requires:
         - "Development: CDK Deploy"
-        context: [deployment-development-wdiv]
+        context: [deployment-development-wdiv, slack-secrets]
         dc-environment: development
         min-size: 1
         max-size: 2
@@ -225,14 +235,14 @@ workflows:
         name: "Staging: CDK Deploy"
         requires:
         - "CDK Synth"
-        context: [deployment-staging-wdiv]
+        context: [deployment-staging-wdiv, slack-secrets]
         filters: { branches: { only: [ main, master ] } }
         dc-environment: staging
     - code_deploy:
         name: "Staging: AWS CodeDeploy"
         requires:
         - "Staging: CDK Deploy"
-        context: [deployment-staging-wdiv]
+        context: [deployment-staging-wdiv, slack-secrets]
         filters: { branches: { only: [ main, master ] } }
         dc-environment: staging
         min-size: 1
@@ -243,14 +253,14 @@ workflows:
         requires:
         - "CDK Synth"
         - "Staging: AWS CodeDeploy"
-        context: [deployment-production-wdiv]
+        context: [deployment-production-wdiv, slack-secrets]
         filters: { branches: { only: [ main, master ] } }
         dc-environment: production
     - code_deploy:
         name: "Production: AWS CodeDeploy"
         requires:
         - "Production: CDK Deploy"
-        context: [deployment-production-wdiv]
+        context: [deployment-production-wdiv, slack-secrets]
         filters: { branches: { only: [ main, master ] } }
         dc-environment: production
         min-size: 1


### PR DESCRIPTION
Ref https://trello.com/c/7Qmm5gtY/3268-make-deploy-fails-more-visible

This work follows on from a sprint retro action to make deploy fails more visible with notifications in Slack. It often happens that we merge work and move the Trello card to done, but then don't notice if a fail occurs on master. 

Testing this work can only be done on master (unless we intentionally build in an error to cause a deploy failure); but the CI should check for the accessibility of the required env variables in the CI organisational settings. That said, we have completed several trial and error commits with the config on WCIVF and this work is based on that learning. 

Confirmation that job and related variables have been found https://app.circleci.com/pipelines/github/DemocracyClub/UK-Polling-Stations/3969/workflows/66f292bc-b779-45de-bb84-3c96b8d04d2b/jobs/5045

### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [ ] Tests have been added and/or updated
- [x] Screenshot of the feature/bug fix (if applicable)
- [ ] If any new text is added, it's internationalized
- [ ] Any new elements have aria labels
- [ ] No unintentional console.logs left behind after debugging
- [x] Did I use the clear and concise names for variables and functions?
- [x] Did I explain all possible solutions and why I chose the one I did?
- [x] Added any comments to make new functions clearer
- [ ] Did I added or updated any new dependencies? Explain why.
- [ ] Did I update the package.json and/or Pipfile.lock version if relevant?
- [ ] Have I rebased with the latest version of master?
- [ ] Added PR labels
- [ ] Update any history/changelog file
- [ ] Update any documentation
- [ ] Update dev handbook
