### PR TITLE
Get server env from environment

### DIFF
--- a/cdk/lambdas/wdiv-s3-trigger/trigger/handler.py
+++ b/cdk/lambdas/wdiv-s3-trigger/trigger/handler.py
@@ -5,7 +5,6 @@ from pathlib import PurePath
 
 import boto3
 import botocore
-from django.conf import settings
 import sentry_sdk
 
 from .csv_helpers import get_csv_report, get_object_report
@@ -93,7 +92,7 @@ def send_error_email(ses, report, email_address):
     reasons = get_email_text(report)
     council = f"{report['gss']}-{report['council_name']}"
     source = "pollingstations@democracyclub.org.uk"
-    server_env = getattr(settings, "SERVER_ENVIRONMENT", None)
+    server_env = os.environ.get("SERVER_ENVIRONMENT", None)
     message = (
         {
             "Subject": {

--- a/cdk/stacks/wdiv_s3_trigger_stack.py
+++ b/cdk/stacks/wdiv_s3_trigger_stack.py
@@ -82,6 +82,7 @@ class WDIVS3TriggerStack(Stack):
             "WDIV_WEBHOOK_URL": ssm.StringParameter.value_for_string_parameter(
                 self, "/wdiv_s3_trigger/WDIV_WEBHOOK_URL"
             ),
+            "SERVER_ENVIRONMENT": self.dc_environment,
         }
 
     def get_policy_json(self):


### PR DESCRIPTION
Ref https://trello.com/c/M4uUNZMl/3229-priority-wdiv-uploader-fixes-needed-before-next-election

Following council uploads for Braintree and Chesire, the upload status was stuck in "Pending" for nearly 24 hours. An error in cloudfront revealed the first issue: 
The councils had uploaded their files at the same time that I had accidentally [pushed a commit ](https://github.com/DemocracyClub/UK-Polling-Stations/commit/4f9ecb8cb375c370f78d350e330bbb01fc96a9bf#diff-eac5b9a79a7241d4d16ae2ffab759d031351fac2218f1b1ec83264311bab6f0fR10 )to master that I thought I had stopped and was later refactored in [this PR](https://github.com/DemocracyClub/UK-Polling-Stations/pull/4955). 

Once we confirmed that both of the council upload files were in S3, we tried the uploader again. 

This resulted in `[ERROR] Runtime.ImportModuleError: Unable to import module 'trigger.handler': No module named 'django' Traceback (most recent call last)` that pointed to the same file and the need to refactor how we access the server env, which is what is addressed in this PR. 

### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->

When creating a Pull Request please delete items as necessary, leaving those that are relevant.

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
