### PR TITLE
2023 EONI importer

### DIFF
--- a/cdk/lambdas/ssm_run_command_once/command_runner.py
+++ b/cdk/lambdas/ssm_run_command_once/command_runner.py
@@ -52,6 +52,10 @@ class RunOncePerTagRunCommandClient:
             InstanceIds=[self.instance_id],
             DocumentName="AWS-RunShellScript",
             Parameters={"commands": [command]},
+            CloudWatchOutputConfig={
+                "CloudWatchLogGroupName": "/aws/ssm/command_runner",
+                "CloudWatchOutputEnabled": True,
+            },
         )
         return self.command_invocation
 
@@ -66,9 +70,14 @@ class RunOncePerTagRunCommandClient:
             )
             status = response["Status"]
             if status == "Success":
+                print("Command Succeeded!")
                 print(response["StandardOutputContent"])
             if status == "Failed":
-                raise ValueError("Command filed")
+                print("Command Failed...")
+                print(response)
+                print(f"Stderr:{response['StandardErrorContent']}")
+                print(f"Stdout:{response['StandardOutputContent']}")
+                raise ValueError("Command failed")
 
 
 if __name__ == "__main__":

--- a/cdk/stacks/command_runner_stack.py
+++ b/cdk/stacks/command_runner_stack.py
@@ -52,6 +52,13 @@ class WDIVOncePerTagCommandRunner(Stack):
                 "/usr/bin/manage-py-command import_councils --only-contact-details --database principal",
             )
 
+        if dc_environment in ["development", "staging", "production"]:
+            self.add_job(
+                "import_eoni_data_from_s3",
+                "cron(30 1 * * ? *)",
+                "runuser -l polling_stations -c '/var/www/polling_stations/import_eoni_from_s3.sh'",
+            )
+
     def add_job(
         self,
         command_name,

--- a/deploy/files/scripts/import_eoni_from_s3.sh
+++ b/deploy/files/scripts/import_eoni_from_s3.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+set -x
+
+DC_ENVIRONMENT=$DC_ENVIRONMENT
+BUCKET_NAME="eoni-data.wheredoivote.co.uk.${DC_ENVIRONMENT}"
+SRCDIR='/tmp/eoni_production_data'
+PREM_4326_CSV=${SRCDIR}/PREM_4326.csv
+PRO_4326_CSV=${SRCDIR}/PRO_4326.csv
+
+LATEST_FILE=$(/usr/local/bin/aws s3 ls s3://"${BUCKET_NAME}/" | sort | tail -n1 | rev | cut -d' ' -f1 | rev)
+
+rm -rf $SRCDIR && mkdir -p $SRCDIR
+
+/usr/local/bin/aws s3 cp s3://"${BUCKET_NAME}/${LATEST_FILE}" $SRCDIR
+
+echo '"PREM_X_4326","PREM_Y_4326"' > ${PREM_4326_CSV}
+mlr --icsv --otsv --headerless-csv-output cut -f PREM_X_COR,PREM_Y_COR $SRCDIR/"${LATEST_FILE}" |
+	cs2cs -f "%.6f" +init=epsg:29902 +to +init=epsg:4326 |
+	awk '{print "\""$1"\",\""$2"\""}' >> ${PREM_4326_CSV}
+
+echo '"PRO_X_4326","PRO_Y_4326"' > ${PRO_4326_CSV}
+mlr --icsv --otsv --headerless-csv-output cut -f PRO_X_COR,PRO_Y_COR $SRCDIR/"${LATEST_FILE}" |
+	cs2cs -f "%.6f" +init=epsg:29902 +to +init=epsg:4326 |
+	awk '{print "\""$1"\",\""$2"\""}'  >> ${PRO_4326_CSV}
+
+paste -d ',' ${PRO_4326_CSV} ${PREM_4326_CSV} $SRCDIR/"${LATEST_FILE}" > eoni_reprojected.csv
+
+/usr/bin/manage-py-command import_eoni --cleanup --reprojected eoni_reprojected.csv
+
+rm ${PREM_4326_CSV} ${PRO_4326_CSV} eoni_reprojected.csv

--- a/deploy/hooks/afterinstall/system_files.sh
+++ b/deploy/hooks/afterinstall/system_files.sh
@@ -26,7 +26,7 @@ systemctl start "$PROJECT_NAME"_cloudwatch.service
 for script in "$PROJECT_ROOT"/code/deploy/files/scripts/*.sh; do
   script_name=$(basename "$script")
   # shellcheck disable=SC2016
-  envsubst '$PROJECT_NAME $PROJECT_ROOT' < "$script" > "$PROJECT_ROOT"/"$script_name"
+  envsubst '$PROJECT_NAME $PROJECT_ROOT $DC_ENVIRONMENT' < "$script" > "$PROJECT_ROOT"/"$script_name"
   chmod 755 "$PROJECT_ROOT"/"$script_name"
 done
 

--- a/deploy/hooks/beforeinstall/initial_setup.sh
+++ b/deploy/hooks/beforeinstall/initial_setup.sh
@@ -41,7 +41,7 @@ echo "Apt finished, continuing"
 
 
 # Install apt packages
-apt-get install --yes nginx nodejs npm gettext
+apt-get install --yes nginx nodejs npm gettext miller
 
 # Reinstall unattended-upgrades
 apt-get install --yes unattended-upgrades

--- a/tasks.py
+++ b/tasks.py
@@ -59,6 +59,20 @@ def bootstrap_django():
 
 
 @task
+def import_eoni(ctx, environment):
+    """
+    AWS_PROFILE=dev-wdiv-dc inv import-eoni development
+    """
+    tag_name = "dc-environment"
+    tag_value = environment
+    command = "runuser -l polling_stations -c '/var/www/polling_stations/import_eoni_from_s3.sh'"
+    runner = RunOncePerTagRunCommandClient(tag_name=tag_name, tag_value=tag_value)
+    runner.run_command_on_single_instance(command)
+    print(runner.command_invocation)
+    runner.poll_response()
+
+
+@task
 def import_council(ctx, environment, reg_code):
     """
     AWS_PROFILE=dev-wdiv-dc inv import-council development MDE


### PR DESCRIPTION
_I have manually run this against the staging RDS_

---

Take the script form the previous deploy and gets it to run using `RunOncePerTagRunCommandClient` (AWS RunCommand).

This is an initial bit of work to get it on staging for them (and us) to QA. We need to figure out how we want to drive this in terms of how we map our staging on to their staging.

Option 1 is that we give them access to the staging bucket and import any data on there in our staging, same for production.

Option 2 is that our staging is only for us, and "production" is the only thing they see. We manage staging imports by giving them access to the production bucket, but import form a "staging" and "production" folder on the bucket. 

I can see some complications with both, but I think option 1 is easier for all of us, especially as they'll not use the staging bucket very much (maybe a couple of times before each major NI election).

https://trello.com/c/XFvRPMEz/3291-eoni-data-staging-site-import


### TODO

```[tasklist]
### Tasks
- [ ] Document process from EONI's point of view
- [ ] Document how we import data, what the commands do
- [ ] (depending on the above options) take the bucket name form the environment
```

