### PR TITLE
Run imports in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,270 +1,34 @@
-
 version: 2.1
 
+# this allows you to use CircleCI's dynamic configuration feature
+setup: true
+
+# the path-filtering orb is required to continue a pipeline based on
+# the path of an updated fileset
 orbs:
-  node: circleci/node@5.0.2
-  slack: circleci/slack@4.1
-
-jobs:
-  build_and_test:
-    docker:
-      - image: cimg/python:3.10.8-browsers
-        environment:
-          CIRCLECI: true
-          PGHOST: 127.0.0.1
-      - image: cimg/postgres:14.5-postgis
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: polling_stations
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
-
-      - node/install:
-          node-version: '16.13.0'
-
-      - run:
-          name: Install node node_modules
-          command: npm install
-          cache-path: ~/repo/node_modules
-          override-ci-command: npm install
-
-      - run:
-          name: install app dependencies
-          command: |
-            sudo apt update && sudo apt install -y gdal-bin
-            pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
-            python -m venv .venv
-            . .venv/bin/activate
-            python -m pip install --upgrade pip
-            python -m pip install wheel
-            python -m pip install coveralls
-            python -m pip install -r requirements/testing.txt
-            playwright install
-
-      - run:
-          name: install CDK Python dependencies
-          command: |
-            . .venv/bin/activate
-            pip install -r requirements/cdk.txt
-
-      - save_cache:
-          paths:
-            - ./.venv
-            - ./node_modules
-            - ./home/circleci/.cache
-          key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
-
-      - run:
-          name: Install HTML Tidy
-          command: wget https://github.com/htacg/tidy-html5/releases/download/5.8.0/tidy-5.8.0-Linux-64bit.deb && sudo dpkg -i tidy-5.8.0-Linux-64bit.deb
-
-      - run:
-          name: Print versions
-          command: |
-            . .venv/bin/activate
-            python --version
-            python manage.py --version
-
-      - run:
-          name: Pre-test checks
-          command: |
-            . .venv/bin/activate
-            black --check .
-            python -m pip check
-            python manage.py check
-            python manage.py makemigrations --check
-
-      - run:
-          name: Pytest
-          command: |
-            . .venv/bin/activate
-            python manage.py collectstatic --no-input
-            pytest --flakes --cov-report= --cov=polling_stations
-
-      - run:
-          name: Submit coverage
-          command: |
-            . .venv/bin/activate
-            coveralls
-
-  cdk_synth:
-    machine:
-      image: ubuntu-2204:2022.10.2
-    working_directory: ~/repo
-    parameters:
-      dc-environment:
-        type: enum
-        enum: [ development, staging, production ]
-    environment:
-      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
-
-    steps:
-    - checkout
-    - restore_cache:
-        key: v1-machine-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
-    - run:
-        name: Install CDK Python dependencies
-        command: |
-          pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
-          python -m venv .venv
-          . .venv/bin/activate
-          python -m pip install -r requirements/cdk.txt
-    - save_cache:
-        paths:
-          - ./.venv
-          - ./node_modules
-        key: v1-machine-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
-
-  cdk_deploy:
-    machine:
-      image: ubuntu-2204:2022.10.2
-    working_directory: ~/repo
-    parameters:
-      dc-environment:
-        type: enum
-        enum: [ development, staging, production ]
-    environment:
-      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
-    steps:
-    - checkout
-    - restore_cache:
-        key: v1-machine-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
-    - run:
-        name: CDK deploy
-        command: |
-          pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
-          . .venv/bin/activate
-          npx cdk deploy --all --require-approval never --concurrency 3
-    # In the event the deployment has failed, alert the dev team
-    - slack/notify:
-        event: fail
-        template: basic_fail_1
-        channel: $SLACK_DEFAULT_CHANNEL
-
-  code_deploy:
-    docker:
-      - image: cimg/python:3.10.8-node
-        environment:
-          CIRCLECI: true
-          PGHOST: 127.0.0.1
-    working_directory: ~/repo
-    parameters:
-      min-size:
-        type: integer
-      max-size:
-        type: integer
-      desired-capacity:
-        type: integer
-      dc-environment:
-        type: enum
-        enum: [ development, staging, production ]
-    environment:
-      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
-      MIN_SIZE: "<<parameters.min-size>>"
-      MAX_SIZE: "<<parameters.max-size>>"
-      DESIRED_CAPACITY: "<<parameters.desired-capacity>>"
-
-    steps:
-    - checkout
-    - restore_cache:
-        key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
-    - run:
-        name: "Code Deploy: Create deployment group"
-        command: |
-          pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
-          . .venv/bin/activate
-          python deploy/create_deployment_group.py
-    - run:
-        name: "Code Deploy: Create deployment"
-        command: |
-          . .venv/bin/activate
-          COMMIT_SHA=$CIRCLE_SHA1 python deploy/create_deployment.py
-    - run:
-        name: Update auto scaling group
-        command: |
-          . .venv/bin/activate
-          python deploy/update_autoscaling_group.py
-        no_output_timeout: 15m # TODO reduce/discuss what is suitable?
-    - run:
-        name: "Publish a new Sentry Release"
-        command: |
-          curl -sL https://sentry.io/get-cli/ | bash
-          sentry-cli releases --org democracy-club-gp new $CIRCLE_SHA1 --project wdiv
-          sentry-cli releases --org democracy-club-gp set-commits --auto $CIRCLE_SHA1 --ignore-missing
-          sentry-cli releases --org democracy-club-gp finalize $CIRCLE_SHA1
-  # In the event the deployment has failed, alert the dev team
-    - slack/notify:
-        event: fail
-        template: basic_fail_1
-        channel: $SLACK_DEFAULT_CHANNEL
-
+  path-filtering: circleci/path-filtering@0.1.3
 
 workflows:
-  version: 2
-  test_build_deploy:
+  # the set-paths-changed workflow is always triggered, regardless of the pipeline parameters.
+  set-paths-changed:
     jobs:
-    - build_and_test
-    - cdk_synth:
-        name: "CDK Synth"
-        requires:
-        - build_and_test
-        context: [deployment-development-wdiv, slack-secrets]
-        dc-environment: development
-    - cdk_deploy:
-        name: "Development: CDK Deploy"
-        requires:
-        - "CDK Synth"
-        context: [deployment-development-wdiv, slack-secrets]
-        filters: { branches: { only: [ development ] } }
-        dc-environment: development
-    - code_deploy:
-        name: "Development: AWS CodeDeploy"
-        requires:
-        - "Development: CDK Deploy"
-        context: [deployment-development-wdiv, slack-secrets]
-        filters: { branches: { only: [ development ] } }
-        dc-environment: development
-        min-size: 1
-        max-size: 2
-        desired-capacity: 1
-    - cdk_deploy:
-        name: "Staging: CDK Deploy"
-        requires:
-        - "CDK Synth"
-        context: [deployment-staging-wdiv, slack-secrets]
-        filters: { branches: { only: [ main, master ] } }
-        dc-environment: staging
-    - code_deploy:
-        name: "Staging: AWS CodeDeploy"
-        requires:
-        - "Staging: CDK Deploy"
-        context: [deployment-staging-wdiv, slack-secrets]
-        filters: { branches: { only: [ main, master ] } }
-        dc-environment: staging
-        min-size: 1
-        max-size: 2
-        desired-capacity: 1
-    - cdk_deploy:
-        name: "Production: CDK Deploy"
-        requires:
-        - "CDK Synth"
-        - "Staging: AWS CodeDeploy"
-        context: [deployment-production-wdiv, slack-secrets]
-        filters: { branches: { only: [ main, master ] } }
-        dc-environment: production
-    - code_deploy:
-        name: "Production: AWS CodeDeploy"
-        requires:
-        - "Production: CDK Deploy"
-        context: [deployment-production-wdiv, slack-secrets]
-        filters: { branches: { only: [ main, master ] } }
-        dc-environment: production
-        min-size: 1
-        max-size: 2
-        desired-capacity: 1
+      # the path-filtering/filter job determines which pipeline
+      # parameters to update.
+      - path-filtering/filter:
+          name: check-updated-files
+          # 3-column, whitespace-delimited mapping. One mapping per line:
+          # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
+          # <path-to-test> is evaluated ~ `if re.compile(r'^' + <path-to-test> + r'$').match(changed_path)
+          # So we can use a look ahead, as it's python's re library doing the work.
+          # The regex should match whatever is in run_new_imports.py.
+          # It can probably be robustified by sticking all the council imports in their own subdir.
+          mapping: |
+            polling_stations/apps/data_importers/management/commands/import_[^eoni].+\.py imports-changed true
+            (?!polling_stations/apps/data_importers/management/commands/import_[^eoni].+\.py) application-changed true
+          base-revision: master
+          tag: 3.10.8
+          # this is the path of the configuration we should trigger once
+          # path filtering and pipeline parameter value updates are
+          # complete. In this case, we are using the parent dynamic
+          # configuration itself.
+          config-path: .circleci/deploy-config.yml

--- a/.circleci/deploy-config.yml
+++ b/.circleci/deploy-config.yml
@@ -1,0 +1,393 @@
+
+version: 2.1
+
+orbs:
+  node: circleci/node@5.0.2
+  slack: circleci/slack@4.1
+  aws-cli: circleci/aws-cli@3.1
+
+
+# the default pipeline parameters, which will be updated according to
+# the results of the path-filtering orb
+parameters:
+  imports-changed:
+    type: boolean
+    default: false
+  application-changed:
+    type: boolean
+    default: false
+
+
+jobs:
+  build_and_test:
+    docker:
+      - image: cimg/python:3.10.8-browsers
+        environment:
+          CIRCLECI: true
+          PGHOST: 127.0.0.1
+      - image: cimg/postgres:14.5-postgis
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: polling_stations
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
+
+      - node/install:
+          node-version: '16.13.0'
+
+      - run:
+          name: Install node node_modules
+          command: npm install
+          cache-path: ~/repo/node_modules
+          override-ci-command: npm install
+
+      - run:
+          name: install app dependencies
+          command: |
+            sudo apt update && sudo apt install -y gdal-bin
+            pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
+            python -m venv .venv
+            . .venv/bin/activate
+            python -m pip install --upgrade pip
+            python -m pip install wheel
+            python -m pip install coveralls
+            python -m pip install -r requirements/testing.txt
+            playwright install
+
+      - run:
+          name: install CDK Python dependencies
+          command: |
+            . .venv/bin/activate
+            pip install -r requirements/cdk.txt
+
+      - save_cache:
+          paths:
+            - ./.venv
+            - ./node_modules
+            - ./home/circleci/.cache
+          key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
+
+      - run:
+          name: Install HTML Tidy
+          command: wget https://github.com/htacg/tidy-html5/releases/download/5.8.0/tidy-5.8.0-Linux-64bit.deb && sudo dpkg -i tidy-5.8.0-Linux-64bit.deb
+
+      - run:
+          name: Print versions
+          command: |
+            . .venv/bin/activate
+            python --version
+            python manage.py --version
+
+      - run:
+          name: Pre-test checks
+          command: |
+            . .venv/bin/activate
+            black --check .
+            python -m pip check
+            python manage.py check
+            python manage.py makemigrations --check
+
+      - run:
+          name: Pytest
+          command: |
+            . .venv/bin/activate
+            python manage.py collectstatic --no-input
+            pytest --flakes --cov-report= --cov=polling_stations
+
+      - run:
+          name: Submit coverage
+          command: |
+            . .venv/bin/activate
+            coveralls
+
+  run_new_imports:
+    docker:
+      - image: cimg/python:3.10.8-browsers
+        environment:
+          CIRCLECI: true
+          PGHOST: 127.0.0.1
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
+      - aws-cli/setup
+      - run:
+          name: Check and run new import scripts.
+          command: |
+            sudo apt update && sudo apt install -y gdal-bin
+            pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
+            . .venv/bin/activate
+            export CI_DB_PASSWORD=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_PASSWORD' --output text`
+            export CI_DB_NAME=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_NAME' --output text`
+            export CI_DB_HOST=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_HOST' --output text`
+            export S3_DATA_BUCKET=pollingstations.elections.production
+            python manage.py run_new_imports
+
+  cdk_synth:
+    machine:
+      image: ubuntu-2204:2022.10.2
+    working_directory: ~/repo
+    parameters:
+      dc-environment:
+        type: enum
+        enum: [ development, staging, production ]
+    environment:
+      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
+
+    steps:
+    - checkout
+    - restore_cache:
+        key: v1-machine-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
+    - run:
+        name: Install CDK Python dependencies
+        command: |
+          pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install -r requirements/cdk.txt
+    - save_cache:
+        paths:
+          - ./.venv
+          - ./node_modules
+        key: v1-machine-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
+
+  cdk_deploy:
+    machine:
+      image: ubuntu-2204:2022.10.2
+    working_directory: ~/repo
+    parameters:
+      dc-environment:
+        type: enum
+        enum: [ development, staging, production ]
+    environment:
+      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
+    steps:
+    - checkout
+    - restore_cache:
+        key: v1-machine-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
+    - run:
+        name: CDK deploy
+        command: |
+          pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
+          . .venv/bin/activate
+          npx cdk deploy --all --require-approval never --concurrency 3
+    # In the event the deployment has failed, alert the dev team
+    - slack/notify:
+        event: fail
+        template: basic_fail_1
+        channel: $SLACK_DEFAULT_CHANNEL
+
+  code_deploy:
+    docker:
+      - image: cimg/python:3.10.8-node
+        environment:
+          CIRCLECI: true
+          PGHOST: 127.0.0.1
+    working_directory: ~/repo
+    parameters:
+      min-size:
+        type: integer
+      max-size:
+        type: integer
+      desired-capacity:
+        type: integer
+      dc-environment:
+        type: enum
+        enum: [ development, staging, production ]
+    environment:
+      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
+      MIN_SIZE: "<<parameters.min-size>>"
+      MAX_SIZE: "<<parameters.max-size>>"
+      DESIRED_CAPACITY: "<<parameters.desired-capacity>>"
+
+    steps:
+    - checkout
+    - restore_cache:
+        key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
+    - run:
+        name: "Code Deploy: Create deployment group"
+        command: |
+          pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
+          . .venv/bin/activate
+          python deploy/create_deployment_group.py
+    - run:
+        name: "Code Deploy: Create deployment"
+        command: |
+          . .venv/bin/activate
+          COMMIT_SHA=$CIRCLE_SHA1 python deploy/create_deployment.py
+    - run:
+        name: Update auto scaling group
+        command: |
+          . .venv/bin/activate
+          python deploy/update_autoscaling_group.py
+        no_output_timeout: 15m # TODO reduce/discuss what is suitable?
+    - run:
+        name: "Publish a new Sentry Release"
+        command: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli releases --org democracy-club-gp new $CIRCLE_SHA1 --project wdiv
+          sentry-cli releases --org democracy-club-gp set-commits --auto $CIRCLE_SHA1 --ignore-missing
+          sentry-cli releases --org democracy-club-gp finalize $CIRCLE_SHA1
+    # In the event the deployment has failed, alert the dev team
+    - slack/notify:
+        event: fail
+        template: basic_fail_1
+        channel: $SLACK_DEFAULT_CHANNEL
+
+  run_new_imports_post_deploy:
+    docker:
+      - image: cimg/python:3.10.8-browsers
+        environment:
+          CIRCLECI: true
+          PGHOST: 127.0.0.1
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-polling_stations-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}-{{ checksum "requirements/cdk.txt" }}
+      - aws-cli/setup
+      - run:
+          name: Check and run new import scripts after a deploy.
+          command: |
+            pyenv local $(pyenv versions --bare | grep 3.10 | head -n 1)
+            . .venv/bin/activate
+            export CI_DB_PASSWORD=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_PASSWORD' --output text`
+            export CI_DB_NAME=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_NAME' --output text`
+            export CI_DB_HOST=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_HOST' --output text`
+            python manage.py run_new_imports --post-deploy
+
+
+
+workflows:
+  version: 2
+  test_and_run_importers:
+    # NB the script called by run_new_imports will bail early if there are also application changes present
+    when: << pipeline.parameters.imports-changed >>
+    jobs:
+    - build_and_test
+    ###############
+    # DEVELOPMENT #
+    ###############
+    - run_new_imports:
+        name: "Development: Run New Imports"
+        requires: [build_and_test]
+        context: [deployment-development-wdiv]
+        filters: { branches: { only: [ development ] } }
+    ###########
+    # STAGING #
+    ###########
+    - run_new_imports:
+        name: "Staging: Run New Imports"
+        requires: [build_and_test]
+        context: [deployment-staging-wdiv]
+        filters: { branches: { only: [ main, master ] } }
+    ##############
+    # PRODUCTION #
+    ##############
+    - run_new_imports:
+        name: "Production: Run New Imports"
+        requires: [build_and_test, "Staging: Run New Imports"]
+        context: [production-staging-wdiv]
+        filters: { branches: { only: [ main, master ] } }
+
+
+  test_build_deploy_and_run_importers:
+    when: << pipeline.parameters.application-changed >>
+    jobs:
+    - build_and_test
+    ###############
+    # DEVELOPMENT #
+    ###############
+    - cdk_synth:
+        name: "CDK Synth"
+        requires:
+        - build_and_test
+        context: [deployment-development-wdiv, slack-secrets]
+        dc-environment: development
+    - cdk_deploy:
+        name: "Development: CDK Deploy"
+        requires:
+        - "CDK Synth"
+        context: [deployment-development-wdiv, slack-secrets]
+        filters: { branches: { only: [ development ] } }
+        dc-environment: development
+    - code_deploy:
+        name: "Development: AWS CodeDeploy"
+        requires:
+        - "Development: CDK Deploy"
+        context: [deployment-development-wdiv, slack-secrets]
+        filters: { branches: { only: [ development ] } }
+        dc-environment: development
+        min-size: 1
+        max-size: 2
+        desired-capacity: 1
+    - run_new_imports_post_deploy:
+        # NB if no imports have changed this is a no-op
+        name: "Development: Run New Imports Post Deploy"
+        requires: ["Development: AWS CodeDeploy"]
+        context: [deployment-development-wdiv]
+        filters: { branches: { only: [ development ] } }
+
+    ###########
+    # STAGING #
+    ###########
+    - cdk_deploy:
+        name: "Staging: CDK Deploy"
+        requires:
+        - "CDK Synth"
+        context: [deployment-staging-wdiv, slack-secrets]
+        filters: { branches: { only: [ main, master ] } }
+        dc-environment: staging
+    - code_deploy:
+        name: "Staging: AWS CodeDeploy"
+        requires:
+        - "Staging: CDK Deploy"
+        context: [deployment-staging-wdiv, slack-secrets]
+        filters: { branches: { only: [ main, master ] } }
+        dc-environment: staging
+        min-size: 1
+        max-size: 2
+        desired-capacity: 1
+    - run_new_imports_post_deploy:
+        # NB if no imports have changed this is a no-op
+        name: "Staging: Run New Imports Post Deploy"
+        requires: ["Staging: AWS CodeDeploy"]
+        context: [deployment-staging-wdiv]
+        filters: { branches: { only: [ main, master ] } }
+
+    ##############
+    # PRODUCTION #
+    ##############
+    - cdk_deploy:
+        name: "Production: CDK Deploy"
+        requires:
+        - "CDK Synth"
+        - "Staging: AWS CodeDeploy"
+        context: [deployment-production-wdiv, slack-secrets]
+        filters: { branches: { only: [ main, master ] } }
+        dc-environment: production
+    - code_deploy:
+        name: "Production: AWS CodeDeploy"
+        requires:
+        - "Production: CDK Deploy"
+        context: [deployment-production-wdiv, slack-secrets]
+        filters: { branches: { only: [ main, master ] } }
+        dc-environment: production
+        min-size: 1
+        max-size: 2
+        desired-capacity: 1
+    - run_new_imports_post_deploy:
+        # NB if no imports have changed this is a no-op
+        name: "Production: Run New Imports Post Deploy"
+        requires: ["Production: AWS CodeDeploy"]
+        context: [deployment-production-wdiv]
+        filters: { branches: { only: [ main, master ] } }

--- a/polling_stations/apps/data_importers/management/commands/import.py
+++ b/polling_stations/apps/data_importers/management/commands/import.py
@@ -89,6 +89,17 @@ class Command(BaseCommand):
             default=False,
         )
 
+        parser.add_argument(
+            "-i",
+            "--include-past-elections",
+            help(
+                "<optional> Include scripts that don't have current (i.e. future) elections"
+            ),
+            action="store_false",
+            required=False,
+            default=False,
+        )
+
     def importer_covers_these_elections(
         self, args_elections, importer_elections, regex
     ):
@@ -149,12 +160,10 @@ class Command(BaseCommand):
             "use_postcode_centroids": False,
         }
         if kwargs["multiprocessing"]:
-            opts = {
-                "noclean": False,
-                "nochecks": True,
-                "verbosity": 0,
-                "use_postcode_centroids": False,
-            }
+            opts["verbosity"] = 0
+
+        if kwargs["include_past_elections"]:
+            opts["include_past_elections"] = opts["include_past_elections"]
 
         # loop over all the import scripts
         # and build up a list of management commands to run

--- a/polling_stations/apps/data_importers/management/commands/import_malvern_hills.py
+++ b/polling_stations/apps/data_importers/management/commands/import_malvern_hills.py
@@ -3,28 +3,20 @@ from data_importers.management.commands import BaseXpressDemocracyClubCsvImporte
 
 class Command(BaseXpressDemocracyClubCsvImporter):
     council_id = "MAV"
-    addresses_name = "2021-03-03T13:39:58.634524/Democracy_Club__06May2021.tsv"
-    stations_name = "2021-03-03T13:39:58.634524/Democracy_Club__06May2021.tsv"
-    elections = ["2021-05-06"]
+    addresses_name = (
+        "2023-05-04/2023-02-07T10:13:27.529328/Democracy_Club__04May2023.tsv"
+    )
+    stations_name = (
+        "2023-05-04/2023-02-07T10:13:27.529328/Democracy_Club__04May2023.tsv"
+    )
+    elections = ["2023-05-04"]
     csv_delimiter = "\t"
 
     def station_record_to_dict(self, record):
-        if record.polling_place_id == "11488":
-            record = record._replace(polling_place_easting="379264")
-            record = record._replace(polling_place_northing="246303")
-
-        # Council not using Welland Village Hall instead of
-        # Castlemorton Village Hall Castlemorton Malvern
-        if record.polling_place_id == "11382":
+        # St Mary`s Church Hall Sherrards Green Road Malvern
+        if record.polling_place_id == "13513":
             record = record._replace(
-                polling_place_name="Welland Village Hall",
-                polling_place_address_1="Welland",
-                polling_place_address_2="Malvern",
-                polling_place_address_3="",
-                polling_place_address_4="",
-                polling_place_postcode="WR13 6AJ",
-                polling_place_easting="379639",
-                polling_place_northing="240002",
+                polling_place_easting="379264", polling_place_northing="246303"
             )
 
         return super().station_record_to_dict(record)
@@ -33,19 +25,29 @@ class Command(BaseXpressDemocracyClubCsvImporter):
         uprn = record.property_urn.strip().lstrip("0")
 
         if uprn in [
+            "10093062320",  # LOG CABIN AT 2 STRAWBERRY COTTAGE A443 NEWNHAM BRIDGE, NEWNHAM BRIDGE
+            "10014087730",  # 1 STRAWBERRY COTTAGE, NEWNHAM BRIDGE, TENBURY WELLS
+            "10014087731",  # 2 STRAWBERRY COTTAGE, NEWNHAM BRIDGE, TENBURY WELLS
+            "10014087728",  # KEEPERS COTTAGE, NEWNHAM BRIDGE, TENBURY WELLS
+            "10014088277",  # 2 BRICKYARD COTTAGES, FEATHERBED LANE, NEWNHAM BRIDGE, TENBURY WELLS"
+            "10014088278",  # 1 BRICKYARD COTTAGES, FEATHERBED LANE, NEWNHAM BRIDGE, TENBURY WELLS
+            "10014090439",  # BAKERS COTTAGE, WICHENFORD, WORCESTER
+            "10024321016",  # THE CARTHOUSE, BIRCHLEY MILL, BOCKLETON ROAD, OLDWOOD, TENBURY WELLS
+            "100120595356",  # HUNTERS LODGE, MAIN ROAD, KEMPSEY, WORCESTER
             "100121268209",  # CHERRY TREE COTTAGE MOSELEY ROAD, HALLOW
+            "10014090474",  # PENTOWAN, WICHENFORD, WORCESTER
         ]:
             return None
 
         if record.addressline6 in [
-            "WR5 3PA",
-            "WR6 6YY",
-            "WR15 8JF",
-            "WR15 8DP",
-            "WR2 6RB",
+            "WR1 42WE",
+            "WR2 4TD",
             "WR14 4JY",
+            "WR2 6RB",
+            "WR6 6BH",
+            "WR15 8DP",
+            "WR8 0AN",
         ]:
             return None
-        rec = super().address_record_to_dict(record)
 
-        return rec
+        return super().address_record_to_dict(record)

--- a/polling_stations/apps/data_importers/management/commands/run_new_imports.py
+++ b/polling_stations/apps/data_importers/management/commands/run_new_imports.py
@@ -1,4 +1,3 @@
-import shutil
 from pathlib import Path
 
 import boto3
@@ -41,12 +40,6 @@ def any_import_scripts(changed):
 
 def any_non_import_scripts(changed):
     return any(not is_import_script(path) for path in changed)
-
-
-def stop_job(stdout):
-    stdout.write("Using CircleCI Agent to stop jobs")
-    args = ["circleci-agent", "step", "halt"]
-    subprocess.check_output(args)
 
 
 def get_last_import_sha_from_ssm():

--- a/polling_stations/apps/data_importers/management/commands/run_new_imports.py
+++ b/polling_stations/apps/data_importers/management/commands/run_new_imports.py
@@ -1,0 +1,187 @@
+import shutil
+from pathlib import Path
+
+import boto3
+import botocore
+from django.apps import apps
+from django.core.management import BaseCommand, call_command
+
+import re
+import subprocess
+
+
+def get_paths_changed(from_sha, to_sha):
+    args = ["git", "diff", "--name-only", from_sha, to_sha]
+    output = subprocess.check_output(args)
+    return output.decode().splitlines()
+
+
+def git_rev_parse(rev):
+    return subprocess.check_output(["git", "rev-parse", f"{rev}"]).decode().strip()
+
+
+def get_changed_scripts(changed):
+    if any_import_scripts(changed):
+        return [p for p in changed if is_import_script(p)]
+    return []
+
+
+def is_import_script(path):
+    if re.search(
+        r"polling_stations/apps/data_importers/management/commands/import_[^eoni].+\.py",
+        path,
+    ):
+        return True
+    return False
+
+
+def any_import_scripts(changed):
+    return any(is_import_script(path) for path in changed)
+
+
+def any_non_import_scripts(changed):
+    return any(not is_import_script(path) for path in changed)
+
+
+def stop_job(stdout):
+    stdout.write("Using CircleCI Agent to stop jobs")
+    args = ["circleci-agent", "step", "halt"]
+    subprocess.check_output(args)
+
+
+def get_last_import_sha_from_ssm():
+    ssm_client = boto3.client("ssm")
+    response = ssm_client.get_parameter(Name="LAST_IMPORT_SHA")
+    return response["Parameter"]["Value"]
+
+
+class Command(BaseCommand):
+    help = """
+        Checks the files changed between two GIT commits
+        and decides if import scripts should be run
+    """
+
+    # Turn off auto system check for all apps
+    # We will manually run system checks only for the
+    # 'data_importers' and 'pollingstations' apps
+    requires_system_checks = []
+
+    summary = []
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-f",
+            "--from-sha",
+            help="<Optional> The earliest commit hash against which to search for changed scripts. "
+            "Defaults to value of LAST_IMPORT_SHA in ssm parameter store",
+        )
+        parser.add_argument(
+            "-t",
+            "--to-sha",
+            help="<Optional> The latest commit hash against which to search for changed scripts. Defaults to HEAD",
+            default=git_rev_parse("HEAD"),
+        )
+        parser.add_argument("--post-deploy", action="store_true", default=False)
+
+    def run_scripts(self, changed_paths, opts):
+        for script in changed_paths:
+            script_path = Path(script)
+            try:
+                call_command(script_path.stem, **opts)
+                self.summary.append(
+                    (
+                        "INFO",
+                        f"Ran import script: {script_path.name}",
+                    )
+                )
+            except Exception as e:
+                # usually we want to handle a specific exception, but in this situation
+                # if there is any issue (at all) trying to run the command,
+                # we just want to log it and move on to the next script
+                self.summary.append(
+                    ("WARNING", f"{script_path.name} could not be run. Due to {e}")
+                )
+                continue
+
+    def output_summary(self):
+        for line in self.summary:
+            if line[0] == "INFO":
+                self.stdout.write(line[1])
+            elif line[0] == "WARNING":
+                self.stdout.write(self.style.ERROR(line[1]))
+            else:
+                self.stdout.write(line[1])
+
+    def update_last_import_sha_on_ssm(self, to_sha):
+        try:
+            ssm_client = boto3.client("ssm")
+            ssm_client.put_parameter(
+                Name="LAST_IMPORT_SHA", Value=to_sha, Overwrite=True
+            )
+        except botocore.exceptions.ClientError as e:
+            self.summary.append(
+                (
+                    "WARNING",
+                    f"LAST_IMPORT_SHA not updated in parameter store, due to:\n{e}",
+                )
+            )
+        except botocore.exceptions.NoCredentialsError as e:
+            self.summary.append(
+                (
+                    "WARNING",
+                    f"LAST_IMPORT_SHA not updated in parameter store, due to:\n{e}",
+                )
+            )
+
+    def handle(self, *args, **options):
+        self.check(
+            [
+                apps.get_app_config("data_importers"),
+                apps.get_app_config("pollingstations"),
+            ]
+        )
+
+        if not (from_sha := options.get("from_sha")):
+            from_sha = get_last_import_sha_from_ssm()
+
+        to_sha = options.get("to_sha")
+        is_post_deploy = options.get("post_deploy")
+
+        changed_paths = get_paths_changed(from_sha, to_sha)
+        changed_scripts = get_changed_scripts(changed_paths)
+        has_imports = any_import_scripts(changed_paths)
+        has_application = any_non_import_scripts(changed_paths)
+
+        cmd_opts = {
+            "nochecks": True,
+            "verbosity": 1,
+            "use_postcode_centroids": False,
+            "include_past_elections": False,
+        }
+
+        self.stdout.write(
+            f"Comparing repo between {from_sha} and {to_sha}\n"
+            f"\tFrom: https://github.com/DemocracyClub/UK-Polling-Stations/commit/{git_rev_parse(from_sha)}\n"
+            f"\tTo: https://github.com/DemocracyClub/UK-Polling-Stations/commit/{git_rev_parse(to_sha)}\n"
+        )
+
+        if has_imports and not has_application:
+            self.stdout.write("Only import scripts have changed\n")
+            self.stdout.write("Running import scripts\n")
+            self.run_scripts(changed_scripts, cmd_opts)
+            self.stdout.write("updating LAST_IMPORT_SHA on ssm")
+            self.update_last_import_sha_on_ssm(to_sha)
+        elif has_imports and has_application and is_post_deploy:
+            self.stdout.write("App has deployed. OK to run import scripts")
+            self.run_scripts(changed_scripts, cmd_opts)
+            self.update_last_import_sha_on_ssm(to_sha)
+        elif has_imports and has_application and not is_post_deploy:
+            self.stdout.write("Need to deploy before running import scripts\n")
+        elif not has_imports:
+            self.stdout.write(
+                "No import scripts have changed. So nothing new to import.\n"
+            )
+        else:
+            self.stdout.write("Not running import scripts")
+
+        self.output_summary()

--- a/polling_stations/apps/data_importers/tests/test_advance_voting.py
+++ b/polling_stations/apps/data_importers/tests/test_advance_voting.py
@@ -99,7 +99,9 @@ class AdvanceVotingTests(TestCase):
                         polling_station_id=station.internal_council_id
                     ).update(advance_voting_station=avs)
 
-        AdvanceVotingImporter().handle(self.council.pk, verbosity=3)
+        AdvanceVotingImporter().handle(
+            self.council.pk, verbosity=3, include_past_elections=True
+        )
         self.assertTrue(AdvanceVotingStation.objects.all().exists())
         assigned_uprns = (
             UprnToCouncil.objects.filter(advance_voting_station_id=1)

--- a/polling_stations/apps/data_importers/tests/test_csv_imports.py
+++ b/polling_stations/apps/data_importers/tests/test_csv_imports.py
@@ -7,7 +7,7 @@ from data_importers.tests.stubs import stub_addressimport
 
 # High-level functional tests for import scripts
 class ImporterTest(TestCase):
-    opts = {"nochecks": True, "verbosity": 0}
+    opts = {"nochecks": True, "verbosity": 0, "include_past_elections": True}
 
     def set_up(self, addressbase, uprns, addresses_name):
         for address in addressbase:

--- a/polling_stations/apps/data_importers/tests/test_dcounts.py
+++ b/polling_stations/apps/data_importers/tests/test_dcounts.py
@@ -7,7 +7,7 @@ from pollingstations.models import PollingStation
 
 
 class DemocracyCountsImportTests(TestCase):
-    opts = {"nochecks": True, "verbosity": 0}
+    opts = {"nochecks": True, "verbosity": 0, "include_past_elections": True}
     uprns = ["1", "2", "3", "5", "6"]
     addressbase = [
         {

--- a/polling_stations/apps/data_importers/tests/test_district_imports.py
+++ b/polling_stations/apps/data_importers/tests/test_district_imports.py
@@ -16,7 +16,12 @@ from pollingstations.models import PollingDistrict, PollingStation
 
 
 class ImporterTest(TestCase):
-    opts = {"noclean": False, "nochecks": True, "verbosity": 0}
+    opts = {
+        "noclean": False,
+        "nochecks": True,
+        "verbosity": 0,
+        "include_past_elections": True,
+    }
 
     # create a dummy council which we're going to import data for
     def create_dummy_council(self):

--- a/polling_stations/apps/data_importers/tests/test_halarose.py
+++ b/polling_stations/apps/data_importers/tests/test_halarose.py
@@ -8,7 +8,7 @@ from pollingstations.models import PollingStation
 
 
 class HalaroseImportTests(TestCase):
-    opts = {"nochecks": True, "verbosity": 0}
+    opts = {"nochecks": True, "verbosity": 0, "include_past_elections": True}
     uprns = [
         "1",
         "2",

--- a/polling_stations/apps/data_importers/tests/test_run_new_imports.py
+++ b/polling_stations/apps/data_importers/tests/test_run_new_imports.py
@@ -1,0 +1,236 @@
+import re
+from io import StringIO
+from unittest.mock import Mock, patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from data_importers.management.commands.run_new_imports import (
+    get_paths_changed,
+    git_rev_parse,
+    get_changed_scripts,
+    is_import_script,
+    any_import_scripts,
+    any_non_import_scripts,
+    Command as run_new_imports_command,
+)
+
+no_scripts = [
+    "polling_stations/apps/councils/management/commands/import_councils.py",
+    "polling_stations/apps/data_importers/base_importers.py",
+    "polling_stations/apps/data_importers/data_quality_report.py",
+    "polling_stations/apps/data_importers/management/commands/import_eoni.py",
+]
+all_scripts = [
+    "polling_stations/apps/data_importers/management/commands/import_barrow_in_furness.py",
+    "polling_stations/apps/data_importers/management/commands/import_wigan.py",
+]
+mix_of_scripts_and_not_scripts = [
+    "polling_stations/apps/data_importers/management/commands/import_barrow_in_furness.py",
+    "polling_stations/apps/data_importers/management/commands/import_eoni.py",
+    "polling_stations/apps/data_importers/management/commands/import_wigan.py",
+    "requirements/base.txt",
+]
+
+
+def test_get_paths_changed():
+    expected_empty = []
+    expected = [
+        "package-lock.json",
+        "polling_stations/apps/councils/management/commands/import_councils.py",
+        "polling_stations/apps/data_importers/base_importers.py",
+        "polling_stations/apps/data_importers/data_quality_report.py",
+        "polling_stations/apps/data_importers/management/commands/import_barrow_in_furness.py",
+        "polling_stations/apps/data_importers/management/commands/import_eoni.py",
+        "polling_stations/apps/data_importers/management/commands/import_wigan.py",
+        "polling_stations/settings/constants/councils.py",
+        "polling_stations/templates/base.html",
+        "polling_stations/templates/postcode_view.html",
+        "requirements/base.txt",
+    ]
+    # This commit sha needs to be in the repos history
+    assert expected_empty == get_paths_changed(
+        "1012c398b13d2e9c87f718b87e07ee9cd1c26222",
+        "1012c398b13d2e9c87f718b87e07ee9cd1c26222",
+    )
+
+    # These are two commits in the path history that reflect changes only to those files listed in expected
+    # I wanted some edge cases (import_councils/import_eoni) so I `git logged` those files and picked something sensible
+    assert expected == get_paths_changed(
+        "3de44201",
+        "53a93ae7",
+    )
+
+
+def test_git_rev_parse():
+    assert re.match(r"[a-f0-9]{40}", git_rev_parse("HEAD"))
+
+    # This commit needs to exist in the repo history
+    assert "1012c398b13d2e9c87f718b87e07ee9cd1c26222" == git_rev_parse("1012c39")
+
+
+def test_is_import_script():
+    assert is_import_script(
+        "polling_stations/apps/data_importers/management/commands/import_barrow_in_furness.py"
+    )
+    assert not is_import_script(
+        "polling_stations/apps/councils/management/commands/import_councils.py"
+    )
+    assert not is_import_script(
+        "polling_stations/apps/data_importers/management/commands/import_eoni.py"
+    )
+    assert not is_import_script(
+        "polling_stations/apps/data_importers/management/commands/import.py"
+    )
+
+
+def test_get_changed_scripts():
+    changed = [
+        "polling_stations/apps/councils/management/commands/import_councils.py",
+        "polling_stations/apps/data_importers/base_importers.py",
+        "polling_stations/apps/data_importers/data_quality_report.py",
+        "polling_stations/apps/data_importers/management/commands/import_barrow_in_furness.py",
+        "polling_stations/apps/data_importers/management/commands/import_eoni.py",
+        "polling_stations/apps/data_importers/management/commands/import_wigan.py",
+        "requirements/base.txt",
+    ]
+    expected = [
+        "polling_stations/apps/data_importers/management/commands/import_barrow_in_furness.py",
+        "polling_stations/apps/data_importers/management/commands/import_wigan.py",
+    ]
+    assert expected == get_changed_scripts(changed)
+
+
+def test_any_import_scripts():
+    assert any_import_scripts(all_scripts)
+    assert not any_import_scripts(no_scripts)
+    assert any_import_scripts(mix_of_scripts_and_not_scripts)
+
+
+def test_any_non_import_scripts():
+    assert not any_non_import_scripts(all_scripts)
+    assert any_non_import_scripts(no_scripts)
+    assert any_non_import_scripts(mix_of_scripts_and_not_scripts)
+
+
+class test_run_new_imports(TestCase):
+    maxDiff = 1000
+    run_scripts_mock = Mock()
+    run_new_imports_name = "run_new_imports"
+
+    def setUp(self):
+        # To get these changes I just `git logged` the imports directory and picked some sensible pairs.
+        self.cases = {
+            "scripts_only": ("4173ae16", "13accc3f"),
+            "app_only": ("f865aaf1", "557c71d6"),
+            "scripts_and_app": ("4078f6ac", "cf57110a"),
+        }
+
+    @patch(
+        "data_importers.management.commands.run_new_imports.Command.run_scripts",
+        run_scripts_mock,
+    )
+    def test_called_with_scripts_only(self):
+        out = StringIO()
+        (to_sha, from_sha) = self.cases["scripts_only"]
+
+        call_command(
+            self.run_new_imports_name,
+            to_sha=to_sha,
+            from_sha=from_sha,
+            stdout=out,
+        )
+        expected_std_out = "Only import scripts have changed\n"
+        self.assertIn(expected_std_out, out.getvalue())
+        self.run_scripts_mock.assert_called_with(
+            [
+                "polling_stations/apps/data_importers/management/commands/import_glasgow_city.py",
+                "polling_stations/apps/data_importers/management/commands/import_hackney.py",
+                "polling_stations/apps/data_importers/management/commands/import_knowsley.py",
+                "polling_stations/apps/data_importers/management/commands/import_lambeth.py",
+            ],
+            {
+                "nochecks": True,
+                "verbosity": 1,
+                "use_postcode_centroids": False,
+                "include_past_elections": False,
+            },
+        )
+
+    def test_called_with_app_only(self):
+        out = StringIO()
+        (to_sha, from_sha) = self.cases["app_only"]
+
+        call_command(
+            self.run_new_imports_name,
+            to_sha=to_sha,
+            from_sha=from_sha,
+            stdout=out,
+        )
+        expected_std_out = "No import scripts have changed. So nothing new to import.\n"
+        self.assertIn(expected_std_out, out.getvalue())
+
+    def test_called_without_mock(self):
+        out = StringIO()
+        (to_sha, from_sha) = self.cases["scripts_and_app"]
+
+        call_command(
+            self.run_new_imports_name,
+            to_sha=to_sha,
+            from_sha=from_sha,
+            post_deploy=True,
+            stdout=out,
+        )
+        expected_std_out = "App has deployed. OK to run import scripts\n"
+        self.assertIn(expected_std_out, out.getvalue())
+        self.assertIn("could not be run", out.getvalue())
+
+    def test_called_with_app_and_scripts_before_deploy(self):
+        out = StringIO()
+        (to_sha, from_sha) = self.cases["scripts_and_app"]
+
+        call_command(
+            self.run_new_imports_name,
+            to_sha=to_sha,
+            from_sha=from_sha,
+            stdout=out,
+        )
+        expected_std_out = "Need to deploy before running import scripts\n"
+        self.assertIn(expected_std_out, out.getvalue())
+
+    @patch(
+        "data_importers.management.commands.run_new_imports.Command.run_scripts",
+        run_scripts_mock,
+    )
+    def test_called_with_app_and_scripts_after_deploy(self):
+        out = StringIO()
+        (to_sha, from_sha) = self.cases["scripts_and_app"]
+
+        call_command(
+            self.run_new_imports_name,
+            to_sha=to_sha,
+            from_sha=from_sha,
+            post_deploy=True,
+            stdout=out,
+        )
+        expected_std_out = "App has deployed. OK to run import scripts\n"
+        self.assertIn(expected_std_out, out.getvalue())
+        self.run_scripts_mock.assert_called_with(
+            [
+                "polling_stations/apps/data_importers/management/commands/import_birmingham.py",
+                "polling_stations/apps/data_importers/management/commands/import_hackney.py",
+                "polling_stations/apps/data_importers/management/commands/import_hambleton.py",
+                "polling_stations/apps/data_importers/management/commands/import_merthyr.py",
+                "polling_stations/apps/data_importers/management/commands/import_ryedale.py",
+                "polling_stations/apps/data_importers/management/commands/import_somerset_west_taunton.py",
+                "polling_stations/apps/data_importers/management/commands/import_south_cambridge.py",
+                "polling_stations/apps/data_importers/management/commands/import_south_tyneside.py",
+                "polling_stations/apps/data_importers/management/commands/import_welwyn_hatfield.py",
+            ],
+            {
+                "nochecks": True,
+                "verbosity": 1,
+                "use_postcode_centroids": False,
+                "include_past_elections": False,
+            },
+        )

--- a/polling_stations/apps/data_importers/tests/test_xpress.py
+++ b/polling_stations/apps/data_importers/tests/test_xpress.py
@@ -7,7 +7,7 @@ from addressbase.models import UprnToCouncil, Address
 
 
 class XpressDemocracyClubImportTests(TestCase):
-    opts = {"nochecks": True, "verbosity": 3}
+    opts = {"nochecks": True, "verbosity": 3, "include_past_elections": True}
     uprns = ["1", "2", "3", "4", "5"]
     addressbase = [
         {
@@ -95,7 +95,7 @@ class XpressDemocracyClubImportTests(TestCase):
 
 
 class XpressWebLookupImportTests(TestCase):
-    opts = {"nochecks": True, "verbosity": 0}
+    opts = {"nochecks": True, "verbosity": 0, "include_past_elections": True}
     uprns = ["1", "3", "4", "6"]
     addressbase = [
         {

--- a/polling_stations/settings/ci.py
+++ b/polling_stations/settings/ci.py
@@ -1,3 +1,5 @@
+import os
+
 from dc_logging_client import DCWidePostcodeLoggingClient
 
 STATICFILES_STORAGE = "pipeline.storage.PipelineStorage"
@@ -5,11 +7,11 @@ STATICFILES_STORAGE = "pipeline.storage.PipelineStorage"
 DATABASES = {
     "default": {
         "ENGINE": "django.contrib.gis.db.backends.postgis",
-        "NAME": "polling_stations",
-        "USER": "postgres",
-        "PASSWORD": "",
-        "HOST": "",
-        "PORT": "",
+        "USER": os.environ.get("CI_DB_USER", "postgres"),
+        "NAME": os.environ.get("CI_DB_NAME", "polling_stations"),
+        "PASSWORD": os.environ.get("CI_DB_PASSWORD", "postgres"),
+        "HOST": os.environ.get("CI_DB_HOST", ""),
+        "PORT": "5432",
     }
 }
 

--- a/polling_stations/settings/constants/importers.py
+++ b/polling_stations/settings/constants/importers.py
@@ -18,4 +18,6 @@ BOTO_SECTION = "wheredoivote"
 if SERVER_ENVIRONMENT := os.environ.get("DC_ENVIRONMENT"):
     S3_DATA_BUCKET = f"pollingstations.elections.{SERVER_ENVIRONMENT}"
 else:
-    S3_DATA_BUCKET = "pollingstations.elections.development"
+    S3_DATA_BUCKET = os.environ.get(
+        "S3_DATA_BUCKET", "pollingstations.elections.development"
+    )


### PR DESCRIPTION
The aim here is to run import scripts as they get merged in CI 
Closes https://github.com/DemocracyClub/UK-Polling-Stations/issues/4724

## Trello
https://trello.com/c/0bSKpmSv

## Run it locally
`./manage.py run_new_imports -f 4078f6ac -t fcf57110a`

Thoughts on the approach in #x-will. Key point is I made it a management command because it was easier to pinch code from other bits, and seemed better organised and easier to test to me.

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [ ] References a specific issue or if not, describes the bug or feature in detail
- [ ] Note what card in Trello this work relates to
- [ ] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [ ] Did I use the clear and concise names for variables and functions?
- [ ] Did I explain all possible solutions and why I chose the one I did?
- [ ] Have I rebased with the latest version of master?
- [ ] Added PR labels
```
