### PR TITLE
Import script for Brighton and Hove (2023-05-04) (closes #5174)

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_brighton_hove.py
+++ b/polling_stations/apps/data_importers/management/commands/import_brighton_hove.py
@@ -24,3 +24,14 @@ class Command(BaseXpressDemocracyClubCsvImporter):
             return None
 
         return super().address_record_to_dict(record)
+
+    def station_record_to_dict(self, record):
+        # Correction request from the council
+        # Community Hall, Downland Court, Stonery Road, Portslade, BN41 2PS
+        if record.polling_place_id == "13566":
+            record = record._replace(
+                polling_place_easting="525057",
+                polling_place_northing="106606",
+            )
+
+        return super().station_record_to_dict(record)


### PR DESCRIPTION
Correction request from the council

> There’s just one change we’d like to make if possible. It’s for electors in polling district HNPY voting at Community Hall, Downland Court, Stonery Road BN41 2PS. The route takes them to Mile Oak Road – there’s no access this end and electors need to go via Stonery Road to Downland Court. I imagine we can fix this by adjusting the northings and eastings to 525057, 106606. We’ll change it on our end too so it’s fixed for next time.

