### PR TITLE
Remove inaccurate NI postal vote messaging

### DIFF
--- a/polling_stations/templates/fragments/polling_station_known.html
+++ b/polling_stations/templates/fragments/polling_station_known.html
@@ -81,9 +81,11 @@
         <p><strong>
             {% blocktrans %}Polling stations are open from 7am to 10pm{% endblocktrans %}{% if NEXT_CHARISMATIC_ELECTION_DATE %}{% blocktrans %} on {{ NEXT_CHARISMATIC_ELECTION_DATE }}{% endblocktrans %}{% endif %}.
         </strong></p>
-        <p>
-            {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
-        </p>
+        {% if territory != 'NI' %}
+            <p>
+                {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
+            </p>
+        {% endif %}
 
     </div>
     {% if station.location %}


### PR DESCRIPTION
Sym reported a bug where NI voters were being told they're allowed to drop their postal vote ballot papers into polling stations. This is not true of NI.

To test locally:
- Have NI data imported
- Search for a postcode you know has an election coming up
- You should no longer see the message "If you have a postal vote, you can hand it in at this polling station on election day up to 10pm"

```[tasklist]
### PR Checklist

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
```
