### PR TITLE
Hotfix/countermanded poll edits

### DIFF
--- a/.circleci/deploy-config.yml
+++ b/.circleci/deploy-config.yml
@@ -342,14 +342,14 @@ workflows:
         requires:
         - "CDK Synth"
         context: [deployment-development-wdiv, slack-secrets]
-        filters: { branches: { only: [ development ] } }
+        filters: { branches: { only: [ development, hotfix/superuser-conf-email ] } }
         dc-environment: development
     - code_deploy:
         name: "Development: AWS CodeDeploy"
         requires:
         - "Development: CDK Deploy"
         context: [deployment-development-wdiv, slack-secrets]
-        filters: { branches: { only: [ development ] } }
+        filters: { branches: { only: [ development, hotfix/superuser-conf-email ] } }
         dc-environment: development
         min-size: 1
         max-size: 2

--- a/polling_stations/templates/fragments/cancelled_election.html
+++ b/polling_stations/templates/fragments/cancelled_election.html
@@ -14,12 +14,11 @@
     {% else %}
         <p>{% blocktrans with cancelled_election_name=cancelled_election.name %}The poll for <strong>{{ cancelled_election_name }}</strong> has been cancelled.{% endblocktrans %}</p>
     {% endif %}
+    <p>To learn more, please visit <a href="https://whocanivotefor.co.uk/elections/{{ cancelled_election.slug }}/">Who Can I Vote For?</a></p>
 {% endif %}
 
 {% if cancelled_election.metadata.cancelled_election.detail %}
-    {% filter markdown %}
-        {{ cancelled_election.metadata.cancelled_election.detail }}
-    {% endfilter %}
+    {% filter markdown %}{{ cancelled_election.metadata.cancelled_election.detail }}{% endfilter %}
 {% else %}
     {% if council.electoral_services_phone_numbers %}
         <p>


### PR DESCRIPTION
Ref https://trello.com/c/xJEReIxB/3334-%E2%98%B9-countermanded-poll-issues-%E2%98%B9

https://wheredoivote.co.uk/address/100010661523/

This work repairs the broken markdown filter and adds a link to the corresponding cancelled election on WCIVF. 

To test: WDIV pulls data from EE so rather than manipulating objects in the shell, I edited [this method](https://github.com/DemocracyClub/UK-Polling-Stations/blob/7cc8d2fbf7282572992ed6ae7c88f3132bd2547b/polling_stations/apps/data_finder/helpers/every_election.py#L150) as follows: 

```
def get_cancelled_election_info(self):
        rec = {
            "cancelled": True,
            "name": "Test Election",
            "rescheduled_date": "March 4th",
            "metadata": "This is test data",
        }
```
and changed conditionals in templates until I was able to manufacture a cancelled election. 

![Screenshot 2023-04-27 at 4 07 46 PM](https://user-images.githubusercontent.com/7017118/234907075-29f1fc88-fb24-4e97-a038-6bfd8c52ebcd.png)


```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [ ] Tests have been added and/or updated
- [x] Screenshot of the feature/bug fix (if applicable)
