### PR TITLE
Assume address location on api address view

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -94,17 +94,12 @@ class AddressViewSet(ViewSet, LogLookUpMixin):
         return Address.objects.get(uprn=kwargs["uprn"])
 
     def get_ee_wrapper(self, address, query_params):
-        rh = RoutingHelper(address.postcode)
         kwargs = {}
         query_params = parse_qs_to_python(query_params)
         if include_current := query_params.get("include_current", False):
             kwargs["include_current"] = any(include_current)
 
-        if not rh.addresses_have_single_station:
-            if address.location:
-                return EveryElectionWrapper(point=address.location, **kwargs)
-
-        return EveryElectionWrapper(postcode=address.postcode, **kwargs)
+        return EveryElectionWrapper(point=address.location, **kwargs)
 
     def retrieve(
         self, request, uprn=None, format=None, geocoder=geocode_point_only, log=True


### PR DESCRIPTION
When we get the EE wrapper we were only using the addresss location when there wasn't a single station for the postcode. However this meant when all addresses vote at a single station, but they are split across wards, we weren't returning the correct ward for an address that was in a different ward to the postcode centroid. With this change we'll still omit an address picker when there should be one, but this endpoint will be right