### PR TITLE
Expose `requires_voter_id` from EE in API

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -62,6 +62,7 @@ class BallotSerializer(serializers.Serializer):
     cancellation_reason = serializers.CharField(read_only=True, allow_null=True)
     replaced_by = serializers.CharField(read_only=True, allow_null=True)
     replaces = serializers.CharField(read_only=True, allow_null=True)
+    requires_voter_id = serializers.CharField(read_only=True, allow_null=True)
 
     def get_ballot_paper_id(self, obj):
         return obj["election_id"]

--- a/polling_stations/apps/api/tests/test_postcode.py
+++ b/polling_stations/apps/api/tests/test_postcode.py
@@ -130,6 +130,7 @@ class PostcodeTest(APITestCase):
         self.assertIsNone(response.data["custom_finder"])
         self.assertIsInstance(response.data["postcode_location"], dict)
         self.assertEqual(1, len(response.data["ballots"]))
+        self.assertTrue("requires_voter_id" in response.data["ballots"][0])
 
     def test_station_found_but_no_election(self):
         self.endpoint.get_ee_wrapper = lambda x, rh, params: EEMockWithoutElection()


### PR DESCRIPTION
This is missing from the API but generally useful to 3rd parties. Especially true now the elections act covers `parl` by-elections