### PR TITLE
Try and handle connection errors from nomisweb.co.uk

### DIFF
--- a/polling_stations/apps/data_importers/contexthelpers.py
+++ b/polling_stations/apps/data_importers/contexthelpers.py
@@ -12,7 +12,10 @@ def get_stat_from_nomis(dataset, measure, gss_code):
     url = "http://www.nomisweb.co.uk/api/v01/dataset/{dataset}.data.json?date=latest&geography={gss_code}&measures={measures}&c2021_dwell_1=0".format(
         dataset=dataset, gss_code=gss_code, measures=measure
     )
-    r = requests.get(url)
+    try:
+        r = requests.get(url)
+    except requests.exceptions.ConnectionError:
+        return 0
     if r.status_code != 200:
         return 0
     data = r.json()


### PR DESCRIPTION
This is meant to deal with CI failures like this: https://app.circleci.com/pipelines/github/DemocracyClub/UK-Polling-Stations/6014/workflows/b727aa30-ca92-4e74-b80d-e95d100e7e58/jobs/11392?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

It's also caused import scripts to fail. I don't really understand why requests doesn't just get a http status code. I guess it's something lower level that's failing.

Obviously a bit tricky to test, because it only happens occasionally. 

