### PR TITLE
Put URL on newline, don't add full stop

### DIFF
--- a/polling_stations/apps/file_uploads/templates/file_uploads/email/login_message.txt
+++ b/polling_stations/apps/file_uploads/templates/file_uploads/email/login_message.txt
@@ -1,4 +1,6 @@
-Use the following URL to log in and upload polling station data to Democracy Club: {{ authenticate_url }}.
+Use the following URL to log in and upload polling station data to Democracy Club: 
+
+{{ authenticate_url }}
 
 This is a one-time link which will expire as soon as it is used.
 To login on future occasions please visit https://wheredoivote.co.uk/uploads/login/ to request a new link.


### PR DESCRIPTION
Some email clients include the full stop in the link. As the end of the URL is the token, this results in URLs like:

`?token=123456.` `123456.` isn't a valid token (`123456` is), so authentication fails.

This change puts the URL on a new line and remove the full stop. This should prevent an (imagined) case where email clients break the link on a new line.
