### PR TITLE
import script geocoding updates (resolves #6831)

### DIFF
--- a/polling_stations/apps/data_importers/ems_importers.py
+++ b/polling_stations/apps/data_importers/ems_importers.py
@@ -500,6 +500,12 @@ class BaseDemocracyCountsCsvImporter(
             "uprn": uprn,
         }
 
+    def get_station_address(self, record):
+        return format_polling_station_address(
+            [getattr(record, self.station_name_field)]
+            + [getattr(record, field) for field in self.address_fields]
+        )
+
     def get_station_point(self, record):
         location = None
 
@@ -527,11 +533,7 @@ class BaseDemocracyCountsCsvImporter(
         return location
 
     def station_record_to_dict(self, record):
-        address = format_polling_station_address(
-            [getattr(record, self.station_name_field)]
-            + [getattr(record, field) for field in self.address_fields]
-        )
-
+        address = self.get_station_address(record)
         location = self.get_station_point(record)
 
         return {


### PR DESCRIPTION
Current changes:
- Moves the Xpress `geocode_by_uprn() ` and related method to parent class `BaseCsvStationsCsvAddressesImporter` for greater accessibility
- Refactors Halarose `get_station_point()` to use `geocode_by_uprn() ` if the record has a non-empty `pollingvenueurpn` field
- minor refactor of democracy counts `get_station_point()` for readability



potential to-dos:
- More Testing?
    - Have tested manually with existing Xpress and Halarose scripts but I can't find any existing tests that directly test get_station_point() - does it need them?