### PR TITLE
Initial system for patching council contact details based on election ID

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from uk_geo_utils.helpers import Postcode
 
-from .councils import CouncilDataSerializer
+from .councils import CouncilDataSerializer, tmp_fix_parl_24_scotland_details
 from .fields import PointField
 from .mixins import parse_qs_to_python
 from .pollingstations import PollingStationGeoSerializer
@@ -176,6 +176,8 @@ class AddressViewSet(ViewSet, LogLookUpMixin):
         ret["polling_station"] = None
         ee = self.get_ee_wrapper(address, request.query_params)
         has_election = ee.has_election()
+        ret["council"] = tmp_fix_parl_24_scotland_details(ret["council"], ee)
+
         # An address might have an election but we might not know the polling station.
         if has_election and address.polling_station_id:
             # get polling station if there is an election in this area

--- a/polling_stations/apps/api/councils.py
+++ b/polling_stations/apps/api/councils.py
@@ -1,4 +1,5 @@
 from councils.models import Council
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count
 from django.http import Http404, HttpResponsePermanentRedirect
@@ -172,3 +173,12 @@ class CouncilCSVViewSet(ReadOnlyModelViewSet):
         .order_by("council_id")
         .annotate(stations=Count("pollingstation"))
     )
+
+
+def tmp_fix_parl_24_scotland_details(council, ee_wrapper):
+    for ballot in getattr(ee_wrapper, "ballots", []):
+        if details := settings.PARL_24_ID_TO_CONTACT_DETAILS.get(ballot["election_id"]):
+            for k, v in details.items():
+                setattr(council, k, v)
+            return council
+    return council

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -19,6 +19,7 @@ from uk_geo_utils.geocoders import MultipleCodesException
 from uk_geo_utils.helpers import AddressSorter, Postcode
 
 from .address import PostcodeResponseSerializer, get_bug_report_url
+from .councils import tmp_fix_parl_24_scotland_details
 from .mixins import parse_qs_to_python
 
 
@@ -115,6 +116,8 @@ class PostcodeViewSet(ViewSet, LogLookUpMixin):
         ee = self.get_ee_wrapper(postcode, rh, request.query_params)
         has_election = ee.has_election()
         if has_election:
+            ret["council"] = tmp_fix_parl_24_scotland_details(ret["council"], ee)
+
             # get polling station if there is an election in this area
             ret["polling_station_known"] = False
             ret["polling_station"] = self.generate_polling_station(rh)

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Optional
 
 from addressbase.models import Address
+from api.councils import tmp_fix_parl_24_scotland_details
 from councils.models import Council
 from django.conf import settings
 from django.contrib.gis.geos import Point
@@ -219,6 +220,7 @@ class BasePollingStationView(
         context["postcode"] = self.postcode.with_space
         context["location"] = self.location
         context["council"] = self.council
+        context["council"] = tmp_fix_parl_24_scotland_details(context["council"], ee)
         context["station"] = self.station
         context["directions"] = self.directions
         context["we_know_where_you_should_vote"] = self.we_know_where_you_should_vote()

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -8,7 +8,6 @@ EC_COUNCIL_CONTACT_DETAILS_API_URL = (
     "https://electoralcommission.org.uk/api/v1/data/local-authorities.json"
 )
 
-
 OLD_TO_NEW_MAP = {}
 
 NEW_COUNCILS = []
@@ -38,7 +37,6 @@ WELSH_COUNCIL_NAMES = {
     "WRX": "Cyngor Bwrdeistref Sirol Wrecsam",  # Wrexham County Borough Council
 }
 
-
 NIR_IDS = [
     "ABC",
     "AND",
@@ -52,3 +50,14 @@ NIR_IDS = [
     "MUL",
     "NMD",
 ]
+
+PARL_24_ID_TO_CONTACT_DETAILS = {
+    "parl.edinburgh-east-and-musselburgh.2024-07-04": {
+        "name": "City of Edinburgh Council",
+        "electoral_services_email": "elections@edinburgh.gov.uk",
+        "electoral_services_website": "https://www.edinburgh.gov.uk",
+        "electoral_services_postcode": "EH1 1YJ",
+        "electoral_services_address": "City Chambers\nHigh Street\nEdinburgh\nEH1 1YJ",
+        "electoral_services_phone_numbers": ["0131 200 2315"],
+    }
+}

--- a/polling_stations/templates/fragments/polling_station_unknown.html
+++ b/polling_stations/templates/fragments/polling_station_unknown.html
@@ -16,7 +16,7 @@
                 or <strong><a href="{{ council_website }}">visit their website</a></strong>.
             {% endblocktrans %}
         {% else %}
-            {% trans "If you don't have a poll card, you need to contact your local council." %}
+            {% trans "If you don't have a poll card, you need to contact your appropriate electoral services team." %}
             {% blocktrans trimmed with council.electoral_services_phone_numbers.0 as council_phone and council.electoral_services_website as council_website %}
                 You can call {{ council }} on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong>
                 or <strong><a href="{{ council_website }}">visit their website</a></strong>.


### PR DESCRIPTION
This allows us to change contact details based on a ballot paper ID.

Designed for short-term patching of councils in Scotland.