### PR TITLE
The Parquet files we make at the moment are from AddressBase.

### DIFF
--- a/polling_stations/apps/data_finder/helpers/routing.py
+++ b/polling_stations/apps/data_finder/helpers/routing.py
@@ -29,6 +29,8 @@ class RoutingHelper:
         self._elections_response = None
 
     def get_elections_backend(self):
+        if self.postcode.with_space.startswith("BT"):
+            return NoOpElectionsHelper
         if getattr(settings, "USE_LOCAL_PARQUET_ELECTIONS", False):
             return LocalParquetElectionsHelper
         return NoOpElectionsHelper


### PR DESCRIPTION
AddressBase doesn't include NI addreses, so we never want to use that backend for any postocde that starts `BT`.
