### PR TITLE
reduce cache length on election intersecting local auth query

### DIFF
--- a/polling_stations/apps/data_finder/helpers/every_election.py
+++ b/polling_stations/apps/data_finder/helpers/every_election.py
@@ -75,8 +75,9 @@ class EveryElectionWrapper:
                 council_id,
             )
         )
-        # Only used by council users atm so seems safe to cache for a whole day
-        return self.get_data(query_url, cache_hours=24)
+        # Only used by council users in the uploader
+        # This query is expensive, so we want to avoid making it too often
+        return self.get_data(query_url, cache_hours=0.5)
 
     def get_data(self, query_url, cache_hours=0):
         res_json = None


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208612753966995/f

This should mean we're not making this query too often, but if we hit a state where we've cached an unhelpful value it won't stick around for an inconveniently long time