### PR TITLE
Show different registration info/polling station opening times for City of London local elections

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: UK-Polling-Stations\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-09 07:51+0100\n"
+"POT-Creation-Date: 2024-11-06 14:29+0000\n"
 "PO-Revision-Date: 2021-05-04 14:37+0000\n"
 "Last-Translator: Lowri Lewis <lowrilewis@gmail.com>\n"
 "Language-Team: Welsh (http://www.transifex.com/democracy-club/uk-polling-"
@@ -107,19 +107,19 @@ msgstr "Anfon adborth"
 msgid "Uploads"
 msgstr "Uwchlwythiadau"
 
-#: polling_stations/apps/pollingstations/models.py:137
+#: polling_stations/apps/pollingstations/models.py:138
 msgid "level access"
 msgstr "mynediad gwastad"
 
-#: polling_stations/apps/pollingstations/models.py:139
+#: polling_stations/apps/pollingstations/models.py:140
 msgid "a temporary ramp for access"
 msgstr "ramp dros dro ar gyfer mynediad"
 
-#: polling_stations/apps/pollingstations/models.py:141
+#: polling_stations/apps/pollingstations/models.py:142
 msgid "a ramp for access"
 msgstr "ramp ar gyfer mynediad"
 
-#: polling_stations/settings/base.py:281
+#: polling_stations/settings/base.py:304
 #: polling_stations/templates/base.html:66
 msgid "Where Do I Vote?"
 msgstr "Ble Ydw i'n Pleidleisio?"
@@ -710,18 +710,24 @@ msgstr "Pleidleisiwch ar y diwrnod pleidleisio"
 msgid "You can vote in person at:"
 msgstr "Gallwch bleidleisio yn y cnawd yn:"
 
-#: polling_stations/templates/fragments/polling_station_known.html:57
+#: polling_stations/templates/fragments/polling_station_known.html:58
+#, fuzzy
+#| msgid "Polling stations are open from 7am to 10pm on Thursday 6 May."
+msgid "Polling stations are open from 8am to 8pm"
+msgstr "Mae gorsafoedd pleidleisio ar agor o 7yb i 10yh ar ddydd Iau 6 Mai."
+
+#: polling_stations/templates/fragments/polling_station_known.html:60
 #, fuzzy
 #| msgid "Polling stations are open from 7am to 10pm on Thursday 6 May."
 msgid "Polling stations are open from 7am to 10pm"
 msgstr "Mae gorsafoedd pleidleisio ar agor o 7yb i 10yh ar ddydd Iau 6 Mai."
 
-#: polling_stations/templates/fragments/polling_station_known.html:57
+#: polling_stations/templates/fragments/polling_station_known.html:62
 #, python-format
 msgid " on %(NEXT_CHARISMATIC_ELECTION_DATE)s"
 msgstr ""
 
-#: polling_stations/templates/fragments/polling_station_known.html:87
+#: polling_stations/templates/fragments/polling_station_known.html:92
 msgid ""
 "\n"
 "                <h3>Advance voting trial</h3>\n"
@@ -790,7 +796,13 @@ msgstr ""
 msgid "Or, you need to contact %(council)s."
 msgstr "Neu, mae angen i chi gysylltu â %(council_aspirate)s."
 
-#: polling_stations/templates/fragments/polling_station_unknown.html:32
+#: polling_stations/templates/fragments/polling_station_unknown.html:34
+#, fuzzy
+#| msgid "Polling stations are open from 7am to 10pm on Thursday 6 May."
+msgid "Polling stations are open from 8am to 8pm."
+msgstr "Mae gorsafoedd pleidleisio ar agor o 7yb i 10yh ar ddydd Iau 6 Mai."
+
+#: polling_stations/templates/fragments/polling_station_unknown.html:36
 #, fuzzy
 #| msgid "Polling stations are open from 7am to 10pm on Thursday 6 May."
 msgid "Polling stations are open from 7am to 10pm."
@@ -815,6 +827,22 @@ msgid ""
 msgstr ""
 "Nid oes angen i chi gofrestru eto os ydych chi eisoes wedi cofrestru yn eich "
 "cyfeiriad cyfredol."
+
+#: polling_stations/templates/fragments/register_to_vote.html:17
+msgid ""
+"City of London council elections do not use the same electoral register as "
+"other elections."
+msgstr ""
+
+#: polling_stations/templates/fragments/register_to_vote.html:22
+msgid ""
+"Both residents and city workers are eligible to vote. There is one register "
+"published annually, and the deadline to apply is 30 November each year. The "
+"new register comes into force on 16 February each year, and cannot be "
+"modified after that date. For more information, visit the <a href=\"https://"
+"www.speakforthecity.com/\">Speak for the City</a> website or contact City of "
+"London electoral services."
+msgstr ""
 
 #: polling_stations/templates/fragments/travel_time.html:6
 #, python-format

--- a/polling_stations/apps/data_finder/helpers/every_election.py
+++ b/polling_stations/apps/data_finder/helpers/every_election.py
@@ -287,6 +287,18 @@ class EveryElectionWrapper:
             return len(uncancelled_ballots) > 1
         return False
 
+    @property
+    def has_city_of_london_ballots(self):
+        # City of London local elections have some edge cases e.g:
+        # diffrent polling station opening times, different registration rules
+        if not self.request_success:
+            return False
+        uncancelled_ballots = [b for b in self.ballots if not b["cancelled"]]
+        for b in uncancelled_ballots:
+            if b["election_id"].startswith("local.city-of-london"):
+                return True
+        return False
+
 
 class EmptyEveryElectionWrapper:
     """
@@ -321,6 +333,10 @@ class EmptyEveryElectionWrapper:
 
     def get_cancelled_election_info(self):
         return {}
+
+    @property
+    def has_city_of_london_ballots(self) -> bool:
+        return False
 
 
 class StaticElectionsAPIElectionWrapper:
@@ -445,3 +461,13 @@ class StaticElectionsAPIElectionWrapper:
             if b["election_id"] not in settings.ELECTION_BLACKLIST
         ]
         return sorted(ballots, key=lambda k: k["poll_open_date"])
+
+    @property
+    def has_city_of_london_ballots(self):
+        # City of London local elections have some edge cases e.g:
+        # diffrent polling station opening times, different registration rules
+        uncancelled_ballots = [b for b in self.ballots if not b["cancelled"]]
+        for b in uncancelled_ballots:
+            if b["election_id"].startswith("local.city-of-london."):
+                return True
+        return False

--- a/polling_stations/apps/data_finder/helpers/every_election.py
+++ b/polling_stations/apps/data_finder/helpers/every_election.py
@@ -294,27 +294,23 @@ class EmptyEveryElectionWrapper:
     when we are going to show an address picker.
 
     This class allows us to swap out the EveryElectionWrapper while keeping
-    exisitng code the same.
+    existing code the same.
     """
 
-    @staticmethod
-    def has_election() -> bool:
+    def has_election(self) -> bool:
         return False
 
-    @staticmethod
-    def get_metadata() -> None:
+    def get_metadata(self) -> None:
         return None
 
-    @staticmethod
-    def get_ballots_for_next_date() -> List:
+    def get_ballots_for_next_date(self) -> List:
         return []
 
-    @staticmethod
-    def get_all_ballots() -> List:
+    def get_all_ballots(self) -> List:
         return []
 
-    @staticmethod
-    def multiple_elections():
+    @property
+    def multiple_elections(self):
         return False
 
     def get_explanations(self):

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -216,6 +216,7 @@ class BasePollingStationView(
         context["cancelled_election"] = ee.get_cancelled_election_info()
         context["advance_voting_station"] = self.get_advance_voting_station()
         context["requires_voter_id"] = ee.get_voter_id_status()
+        context["has_city_of_london_ballots"] = ee.has_city_of_london_ballots
 
         context["postcode"] = self.postcode.with_space
         context["location"] = self.location
@@ -226,6 +227,7 @@ class BasePollingStationView(
         context["we_know_where_you_should_vote"] = self.we_know_where_you_should_vote()
         context["noindex"] = True
         context["territory"] = self.postcode.territory
+
         if not context["we_know_where_you_should_vote"]:
             if loc is None:
                 context["custom"] = None

--- a/polling_stations/templates/fragments/polling_station_known.html
+++ b/polling_stations/templates/fragments/polling_station_known.html
@@ -54,7 +54,12 @@
         </address>
 
         <p><strong>
-            {% blocktrans %}Polling stations are open from 7am to 10pm{% endblocktrans %}{% if NEXT_CHARISMATIC_ELECTION_DATE %}{% blocktrans %} on {{ NEXT_CHARISMATIC_ELECTION_DATE }}{% endblocktrans %}{% endif %}.
+            {% if has_city_of_london_ballots %}
+                {% blocktrans %}Polling stations are open from 8am to 8pm{% endblocktrans %}{% if not NEXT_CHARISMATIC_ELECTION_DATE %}.{% endif %}
+            {% else %}
+                {% blocktrans %}Polling stations are open from 7am to 10pm{% endblocktrans %}{% if not NEXT_CHARISMATIC_ELECTION_DATE %}.{% endif %}
+            {% endif %}
+            {% if NEXT_CHARISMATIC_ELECTION_DATE %}{% blocktrans %} on {{ NEXT_CHARISMATIC_ELECTION_DATE }}{% endblocktrans %}.{% endif %}
         </strong></p>
         {% comment %} {% if territory != 'NI' %}
             <p>

--- a/polling_stations/templates/fragments/polling_station_unknown.html
+++ b/polling_stations/templates/fragments/polling_station_unknown.html
@@ -29,4 +29,10 @@
     {% endif %}
 </p>
 
-<p><strong>{% blocktrans %}Polling stations are open from 7am to 10pm.{% endblocktrans %}</strong></p>
+<p><strong>
+    {% if has_city_of_london_ballots %}
+        {% blocktrans %}Polling stations are open from 8am to 8pm.{% endblocktrans %}
+    {% else %}
+        {% blocktrans %}Polling stations are open from 7am to 10pm.{% endblocktrans %}
+    {% endif %}
+</strong></p>

--- a/polling_stations/templates/fragments/register_to_vote.html
+++ b/polling_stations/templates/fragments/register_to_vote.html
@@ -12,5 +12,22 @@
         </p>
         {#    <p>{% trans "Register before midnight on Monday 19th April to vote in the election(s) on Thursday 6th May." %}</p>#}
         <p>{% trans "You don't need to register again if you've already registered at your current address." %}</p>
+        {% if has_city_of_london_ballots %}
+            <p>
+                {% blocktrans trimmed %}
+                    City of London council elections do not use the same electoral register as other elections.
+                {% endblocktrans %}
+            </p>
+            <p>
+                {% blocktrans trimmed %}
+                    Both residents and city workers are eligible to vote. There is one register
+                    published annually, and the deadline to apply is 30 November each year.
+                    The new register comes into force on 16 February each year,
+                    and cannot be modified after that date. For more information, visit the
+                    <a href="https://www.speakforthecity.com/">Speak for the City</a>
+                    website or contact City of London electoral services.
+                {% endblocktrans %}
+            </p>
+        {% endif %}
     </div>
 </div>


### PR DESCRIPTION
Refs
- https://app.asana.com/0/1204880927741389/1208540419887296/f
- https://app.asana.com/0/1204880927741389/1208687275764618/f
- https://app.asana.com/0/1204880927741389/1208687275764619/f

This PR is part of the big pile of "deal with City of London edge cases" issues.

This is quite hard to do well on WDIV because it has the least nuanced view of "what election(s) are we telling the user about?"

In this PR I am looking at electoral registration details and polling station opening times but not ID requirements.