### PR TITLE
has_election is a method not a property

### DIFF
--- a/polling_stations/apps/data_finder/helpers/every_election.py
+++ b/polling_stations/apps/data_finder/helpers/every_election.py
@@ -282,7 +282,7 @@ class EveryElectionWrapper:
 
     @property
     def multiple_elections(self):
-        if self.has_election and self.request_success:
+        if self.has_election() and self.request_success:
             uncancelled_ballots = [b for b in self.ballots if not b["cancelled"]]
             return len(uncancelled_ballots) > 1
         return False
@@ -347,7 +347,7 @@ class StaticElectionsAPIElectionWrapper:
 
     @property
     def multiple_elections(self):
-        if self.has_election:
+        if self.has_election():
             uncancelled_ballots = [b for b in self.ballots if not b["cancelled"]]
             return len(uncancelled_ballots) > 1
         return False


### PR DESCRIPTION
A little something I noticed while working on #8147
This has probably been a bug for a long time
`has_election()` is a method not a property in both classes
so `self.has_election` would have been always evaluating to `True`