### PR TITLE
Get object from same database we wrote it to.

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_eoni.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni.py
@@ -253,8 +253,9 @@ class Command(BaseStationsImporter, CsvMixin):
             )
             if len(others_in_postcode) == 1:
                 other_address = others_in_postcode[0]
-                other_uprn = other_address.uprntocouncil
-                other_uprn.refresh_from_db(using=DB_NAME)
+                other_uprn = UprnToCouncil.objects.using(DB_NAME).get(
+                    uprn=other_address.uprn
+                )
                 self.stdout.write(
                     f"Updating UprnToCouncil record for {address.uprn} with gss {other_uprn.lad}"
                 )


### PR DESCRIPTION
This hopefully fixes issues like: https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/%2Faws%2Fssm%2Fcommand_runner/log-events/81818ffb-dceb-4a7d-88dd-c43cb743032b%2Fi-07def40bcbc55bf22%2Faws-runShellScript%2Fstdout

I think there might be a separate issue that https://github.com/DemocracyClub/UK-Polling-Stations/pull/8161 addresses - i.e. the sentry reports like: https://democracy-club-gp.sentry.io/issues/5914149783/events/736643c39f84462aa060d54caef2971b/