### PR TITLE
disable sync_elections cron job

### DIFF
--- a/deploy/files/conf/crontab
+++ b/deploy/files/conf/crontab
@@ -5,7 +5,8 @@ MAILTO=developers@democracyclub.org.uk
 # Import councils from EC hourly
 1 * * * * polling_stations /usr/bin/manage-py-command import_councils --only-contact-details --database default
 # Sync elections from EE
-*/5 * * * * every_election /usr/local/bin/ee-manage-py-command sync_elections
+# TODO: re-enable this!
+# */5 * * * * every_election /usr/local/bin/ee-manage-py-command sync_elections
 # Per instance cloudwatch custom metrics
 */5  * * * * polling_stations /var/www/polling_stations/per_instance_custom_metrics.sh
 */30  * * * * polling_stations sync_baked_elections_parquet.sh


### PR DESCRIPTION
Currently this is chucking a error into Sentry every 5 minutes. In the immediate term, I want it to stop so we don't just use our whole sentry quota logging the same error over and over.

Right now this does not matter as we have `EE_BASE` set to https://elections.democracyclub.org.uk/ However, if we just merge this we will forget it. I'm going to chuck a note in asana to come back to this next sprint.