### PR TITLE
Feature/show eoni stations when theres no election

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -70,6 +70,14 @@ msgstr "Cod post:"
 msgid "Enter your postcode"
 msgstr "Rhowch eich cod post"
 
+#: polling_stations/apps/data_finder/views.py:186
+msgid "local Councillor"
+msgstr ""
+
+#: polling_stations/apps/data_finder/views.py:187
+msgid "Member of the Legislative Assembly, and Member of Parliament"
+msgstr ""
+
 #: polling_stations/apps/feedback/forms.py:19
 #: polling_stations/apps/feedback/templates/feedback/feedback_form.html:21
 msgid "Did you find this useful?"

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: UK-Polling-Stations\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-11 16:57+0000\n"
+"POT-Creation-Date: 2024-12-10 18:14+0000\n"
 "PO-Revision-Date: 2021-05-04 14:37+0000\n"
 "Last-Translator: Lowri Lewis <lowrilewis@gmail.com>\n"
 "Language-Team: Welsh (http://www.transifex.com/democracy-club/uk-polling-"
@@ -640,15 +640,51 @@ msgstr ""
 "Peidiwch â phoeni, gallwch bleidleisio ym mhob un yn yr un orsaf bleidleisio "
 "a darllen amdanynt ar"
 
+#: polling_stations/templates/fragments/ni_out_of_cycle_station.html:7
 #: polling_stations/templates/fragments/no_election.html:7
 msgid "We don't know of any upcoming elections in your area"
 msgstr ""
 "Nid ydym yn ymwybodol o unrhyw etholiadau sydd ar ddod yn eich ardal chi"
 
+#: polling_stations/templates/fragments/ni_out_of_cycle_station.html:9
 #: polling_stations/templates/fragments/no_election.html:9
 msgid "We're not aware of any upcoming elections in your area."
 msgstr ""
 "Nid ydym yn ymwybodol o unrhyw etholiadau sydd ar ddod yn eich ardal chi."
+
+#: polling_stations/templates/fragments/ni_out_of_cycle_station.html:10
+#, fuzzy, python-format
+#| msgid ""
+#| "If you think there may be elections in your area, check your local <a "
+#| "href=\"%(council_website)s\">council website</a> for more information, or "
+#| "contact %(council)s on <strong><a href=\"tel:"
+#| "%(council_phone)s\">%(council_phone)s</a></strong>."
+msgid ""
+"If you think there may be elections in your area, check the <a "
+"href=\"%(council_website)s\">website</a> of The Electoral Office for "
+"Northern Ireland for more information, or contact them on on <strong><a "
+"href=\"tel:%(council_phone)s\">%(council_phone)s</a></strong>."
+msgstr ""
+"Os ydych chi'n credu bod yna etholiadau yn eich ardal chi, gwiriwch wefan "
+"eich <a href=\"%(council_website)s\">cyngor lleol</a> am ragor o wybodaeth, "
+"neu cysylltwch â %(council_aspirate)s ar <strong><a href=\"tel:"
+"%(council_phone)s\">%(council_phone)s</a></strong>."
+
+#: polling_stations/templates/fragments/ni_out_of_cycle_station.html:18
+#: polling_stations/templates/multiple_councils.html:6
+#: polling_stations/templates/postcode_view.html:15
+msgid "Your Polling Station"
+msgstr "Eich Gorsaf Bleidleisio"
+
+#: polling_stations/templates/fragments/ni_out_of_cycle_station.html:20
+msgid "This polling station is for elections for your"
+msgstr ""
+
+#: polling_stations/templates/fragments/ni_out_of_cycle_station.html:22
+msgid ""
+"It may change before the next election, please check back before travelling "
+"to vote."
+msgstr ""
 
 #: polling_stations/templates/fragments/no_election.html:10
 #, python-format
@@ -1012,11 +1048,6 @@ msgid ""
 msgstr ""
 "ydd angen dull adnabod ffotograffig i bleidleisio mewn etholiadau lleol yn "
 "Lloegr, ac etholiadau seneddol ar draws y DU, ar ac ar ôl 4 Mai 2023."
-
-#: polling_stations/templates/multiple_councils.html:6
-#: polling_stations/templates/postcode_view.html:15
-msgid "Your Polling Station"
-msgstr "Eich Gorsaf Bleidleisio"
 
 #: polling_stations/templates/multiple_councils.html:11
 msgid "Contact Your Council"

--- a/polling_stations/apps/data_finder/fixtures/bt15_3jx_ee_get_data_with_election.json
+++ b/polling_stations/apps/data_finder/fixtures/bt15_3jx_ee_get_data_with_election.json
@@ -1,0 +1,9 @@
+[
+  {
+    "election_id": "local.belfast.2099-12-31",
+    "group_type": null,
+    "cancelled": false,
+    "poll_open_date": "2099-12-31",
+    "requires_voter_id": "EFA-2002"
+  }
+]

--- a/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
+++ b/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from django.test import override_settings
 
 from addressbase.tests.factories import UprnToCouncilFactory
 from context_managers import check_for_console_errors
@@ -164,6 +165,7 @@ def bt_15_3jx_station_data():
     )
 
 
+@override_settings(SHOW_EONI_STATIONS_ALL_THE_TIME=True)
 @pytest.mark.django_db
 def test_northern_ireland_with_station_no_election(
     page,

--- a/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
+++ b/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
@@ -184,7 +184,9 @@ def test_northern_ireland_with_station_no_election(
             page.locator("text=website of The Electoral Office for Northern Ireland")
         ).not_to_be_empty()
         expect(
-            page.locator("text=We're not aware of any upcoming elections in your area.")
+            page.locator(
+                "text=We are not aware of any upcoming elections in your area."
+            )
         ).to_have_count(1)
         expect(page.locator('h2:has-text("Your polling station")')).not_to_be_empty()
         expect(

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -178,6 +178,32 @@ class BasePollingStationView(
     def we_know_where_you_should_vote(self):
         return polling_station_current(self.get_station())
 
+    def show_map(self, context):
+        station = context.get("station")
+        station_location = getattr(station, "location", None)
+        advance_voting_station = context.get("advance_voting_station")
+        advance_voting_station_location = getattr(
+            advance_voting_station, "location", None
+        )
+        we_know_where_you_should_vote = context.get("we_know_where_you_should_vote")
+        errors = context.get("errors")
+        has_election = context.get("has_election")
+
+        # If there are any errors return false
+        if errors:
+            return False
+
+        # If we have a station location or advance station location, and there are upcoming elections return true
+        if (
+            we_know_where_you_should_vote
+            and (station_location or advance_voting_station_location)
+            and has_election
+        ):
+            return True
+
+        # Otherwise return false
+        return False
+
     def get_context_data(self, **context):
         context["tile_layer"] = settings.TILE_LAYER
         context["mq_key"] = settings.MQ_KEY
@@ -239,6 +265,8 @@ class BasePollingStationView(
 
                 except MultipleCodesException:
                     context["custom"] = None
+
+        context["show_map"] = self.show_map(context)
 
         self.log_postcode(self.postcode, context, type(self).__name__)
 

--- a/polling_stations/settings/constants/importers.py
+++ b/polling_stations/settings/constants/importers.py
@@ -17,4 +17,6 @@ class EONIImportScheme(models.TextChoices):
 
 EONI_IMPORT_SCHEME = EONIImportScheme.NATIONAL
 
-SHOW_EONI_STATIONS_ALL_THE_TIME = True
+SHOW_EONI_STATIONS_ALL_THE_TIME = os.environ.get(
+    "SHOW_EONI_STATIONS_ALL_THE_TIME", False
+)

--- a/polling_stations/settings/constants/importers.py
+++ b/polling_stations/settings/constants/importers.py
@@ -16,3 +16,5 @@ class EONIImportScheme(models.TextChoices):
 
 
 EONI_IMPORT_SCHEME = EONIImportScheme.NATIONAL
+
+SHOW_EONI_STATIONS_ALL_THE_TIME = True

--- a/polling_stations/templates/fragments/ni_out_of_cycle_station.html
+++ b/polling_stations/templates/fragments/ni_out_of_cycle_station.html
@@ -1,0 +1,39 @@
+{% load i18n_with_welsh %}
+{% load dc_forms %}
+
+{% if cancelled_election.cancelled %}
+    {% include "fragments/cancelled_election.html" %}
+{% else %}
+    <h2>{% trans "We don't know of any upcoming elections in your area" %}</h2>
+    <p>
+        {% trans "We're not aware of any upcoming elections in your area." %}
+        {% blocktrans trimmed with council.electoral_services_phone_numbers.0 as council_phone and council.electoral_services_website as council_website %}
+            If you think there may be elections in your area,
+            check the <a href="{{ council_website }}">website</a> of The Electoral Office for Northern Ireland for more information,
+            or contact them on on <strong><a href="tel:{{ council_phone }}">{{ council_phone }}</a></strong>.
+        {% endblocktrans %}
+    </p>
+{% endif %}
+
+<h2>{% trans "Your Polling Station" %}</h2>
+<p>
+    {% trans "This polling station is for elections for your" %}
+    {{ ni_elected_rep_type }}.
+    {% trans "It may change before the next election, please check back before travelling to vote." %}
+</p>
+<p>
+    <address>
+        {% if station.formatted_address %}
+            {{ station.formatted_address|linebreaksbr }}<br />
+        {% endif %}
+
+        {% if station.postcode %}
+            {% if not station.postcode in station.address %}
+                {{ station.postcode }}
+            {% endif %}
+        {% endif %}
+    </address>
+</p>
+{% if show_map %}
+    <div id="area_map" class="ds-card-image"></div>
+{% endif %}

--- a/polling_stations/templates/fragments/ni_out_of_cycle_station.html
+++ b/polling_stations/templates/fragments/ni_out_of_cycle_station.html
@@ -4,9 +4,9 @@
 {% if cancelled_election.cancelled %}
     {% include "fragments/cancelled_election.html" %}
 {% else %}
-    <h2>{% trans "We don't know of any upcoming elections in your area" %}</h2>
+    <h2>{% trans "You don't have any upcoming elections in your area" %}</h2>
     <p>
-        {% trans "We're not aware of any upcoming elections in your area." %}
+        {% trans "We are not aware of any upcoming elections in your area." %}
         {% blocktrans trimmed with council.electoral_services_phone_numbers.0 as council_phone and council.electoral_services_website as council_website %}
             If you think there may be elections in your area,
             check the <a href="{{ council_website }}">website</a> of The Electoral Office for Northern Ireland for more information,
@@ -19,7 +19,7 @@
 <p>
     {% trans "This polling station is for elections for your" %}
     {{ ni_elected_rep_type }}.
-    {% trans "It may change before the next election, please check back before travelling to vote." %}
+    {% trans "It may change before the next election, please check again before travelling to vote." %}
 </p>
 <p>
     <address>

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -32,7 +32,8 @@
                 {% endif %}
 
             {% endif %}
-
+        {%  elif ni_out_of_cycle_station %}
+            {% include "fragments/ni_out_of_cycle_station.html" %}
         {% else %}
             {% include "fragments/no_election.html" %}
         {% endif %}

--- a/polling_stations/templates/postcode_view.html
+++ b/polling_stations/templates/postcode_view.html
@@ -6,7 +6,7 @@
 
 {% block extra_page_css %}
 
-    {% if we_know_where_you_should_vote and station.location or advance_voting_station.location %}
+    {% if show_map %}
         {% stylesheet 'map' %}
     {% endif %}
 
@@ -81,7 +81,7 @@
             var mq_key = null;
         {% endif %}
 
-        {% if we_know_where_you_should_vote and station.location %}
+        {% if show_map %}
             $(document).ready(function() {
                 var station_point = [{{ station.location.1 }}, {{ station.location.0 }}];
                 var tile_layer = '{{ tile_layer }}';
@@ -113,7 +113,7 @@
 
     {% javascript 'scripts' %}
 
-    {% if we_know_where_you_should_vote and station.location or advance_voting_station.location and has_election and not error %}
+    {% if show_map %}
         {% javascript 'map' %}
     {% endif %}
 


### PR DESCRIPTION
This should mean we show polling stations in Northern Ireland when we know about them, but there's no election. 
When there is an election we should have the same behaviour in Northern Ireland as the rest of UK. 

I guess another change would be to explain which scheme NI stations are, when there is an election. But I would probably punt that to another PR.

We can turn the feature on and off by using the  `SHOW_EONI_STATIONS_ALL_THE_TIME` setting. At the moment this is set to `True`, but  would suggest we initially merge this to master with it set to `False`. We can then deploy to the dev site andchange the setting there, to get thumbs up from EONI before progressing. Alternatively we just deploy this branch to dev without merging. 

