### PR TITLE
Add flag to teardown NI stations

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/teardown.py
+++ b/polling_stations/apps/data_importers/management/commands/teardown.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
             "-c",
             "--council",
             nargs=1,
-            help="Council ID to clear in the format X01000001",
+            help="Council ID to clear, uses three letter council codes, e.g. 'ABC'",
         )
 
         group.add_argument(

--- a/polling_stations/apps/data_importers/tests/test_teardown.py
+++ b/polling_stations/apps/data_importers/tests/test_teardown.py
@@ -14,8 +14,21 @@ class TestTeardown(TestCase):
             {"council_id": "AAA", "identifiers": ["X01000000"]},
             {"council_id": "BBB", "identifiers": ["X01000001"]},
         ]
+        ni_councils = [
+            {"council_id": "ANN", "identifiers": ["N09000001"]},
+            {"council_id": "ABC", "identifiers": ["N09000002"]},
+            {"council_id": "BFS", "identifiers": ["N09000003"]},
+            {"council_id": "CCG", "identifiers": ["N09000004"]},
+            {"council_id": "DRS", "identifiers": ["N09000005"]},
+            {"council_id": "FMO", "identifiers": ["N09000006"]},
+            {"council_id": "LBC", "identifiers": ["N09000007"]},
+            {"council_id": "MEA", "identifiers": ["N09000008"]},
+            {"council_id": "MUL", "identifiers": ["N09000009"]},
+            {"council_id": "NMD", "identifiers": ["N09000010"]},
+            {"council_id": "AND", "identifiers": ["N09000011"]},
+        ]
 
-        for council in councils:
+        for council in councils + ni_councils:
             CouncilFactory(**council)
 
         pollingstations = [
@@ -32,6 +45,7 @@ class TestTeardown(TestCase):
                 "internal_council_id": "ps1",
             },
         ]
+
         pollingdistricts = [
             {
                 "council": Council.objects.get(pk="AAA"),
@@ -52,6 +66,24 @@ class TestTeardown(TestCase):
             {"uprn": "3", "lad": "X01000001", "polling_station_id": "ps1"},
         ]
 
+        for ni_council in ni_councils:
+            council_id = ni_council["council_id"]
+            identifier = ni_council["identifiers"][0]
+            ps_internal_council_id = f"ps-{council_id}"
+            pollingstations.append(
+                {
+                    "council": Council.objects.get(pk=council_id),
+                    "internal_council_id": ps_internal_council_id,
+                }
+            )
+            uprns.append(
+                {
+                    "uprn": identifier[2:],
+                    "lad": identifier,
+                    "polling_station_id": ps_internal_council_id,
+                }
+            )
+
         for ps in pollingstations:
             PollingStation.objects.update_or_create(**ps)
 
@@ -66,19 +98,32 @@ class TestTeardown(TestCase):
                 polling_station_id=uprn["polling_station_id"],
             )
 
+        self.uprn_lad_ps = [
+            ("N09000001", "ps-ANN"),
+            ("N09000002", "ps-ABC"),
+            ("N09000003", "ps-BFS"),
+            ("N09000004", "ps-CCG"),
+            ("N09000005", "ps-DRS"),
+            ("N09000006", "ps-FMO"),
+            ("N09000007", "ps-LBC"),
+            ("N09000008", "ps-MEA"),
+            ("N09000009", "ps-MUL"),
+            ("N09000010", "ps-NMD"),
+            ("N09000011", "ps-AND"),
+            ("X01000000", "ps1"),
+            ("X01000000", "ps2"),
+            ("X01000001", "ps1"),
+        ]
+
     def test_teardown_one_council(self):
-        self.assertEqual(Council.objects.count(), 2)
-        self.assertEqual(PollingStation.objects.count(), 3)
+        self.assertEqual(Council.objects.count(), 13)
+        self.assertEqual(PollingStation.objects.count(), 14)
         self.assertEqual(PollingDistrict.objects.count(), 3)
         self.assertListEqual(
             sorted(
                 UprnToCouncil.objects.all().values_list("lad", "polling_station_id")
             ),
-            [
-                ("X01000000", "ps1"),
-                ("X01000000", "ps2"),
-                ("X01000001", "ps1"),
-            ],
+            self.uprn_lad_ps,
         )
 
         self.assertEqual(
@@ -96,14 +141,25 @@ class TestTeardown(TestCase):
         cmd = Command()
         cmd.handle(council=["AAA"])
 
-        self.assertEqual(Council.objects.count(), 2)
-        self.assertEqual(PollingStation.objects.count(), 1)
+        self.assertEqual(Council.objects.count(), 13)
+        self.assertEqual(PollingStation.objects.count(), 12)
         self.assertEqual(PollingDistrict.objects.count(), 1)
         self.assertListEqual(
             sorted(
                 UprnToCouncil.objects.all().values_list("lad", "polling_station_id")
             ),
-            [
+            [  # Only one council's stations have been remove from uprntocouncil table (id X01000000)
+                ("N09000001", "ps-ANN"),
+                ("N09000002", "ps-ABC"),
+                ("N09000003", "ps-BFS"),
+                ("N09000004", "ps-CCG"),
+                ("N09000005", "ps-DRS"),
+                ("N09000006", "ps-FMO"),
+                ("N09000007", "ps-LBC"),
+                ("N09000008", "ps-MEA"),
+                ("N09000009", "ps-MUL"),
+                ("N09000010", "ps-NMD"),
+                ("N09000011", "ps-AND"),
                 ("X01000000", ""),
                 ("X01000000", ""),
                 ("X01000001", "ps1"),
@@ -125,19 +181,54 @@ class TestTeardown(TestCase):
             DataEvent.objects.filter(event_type=DataEventType.TEARDOWN).count(), 1
         )
 
-    def test_teardown_all_councils(self):
-        self.assertEqual(Council.objects.count(), 2)
+    def test_teardown_eoni(self):
+        self.assertEqual(Council.objects.count(), 13)
+        self.assertEqual(PollingStation.objects.count(), 14)
+        self.assertEqual(PollingDistrict.objects.count(), 3)
+        self.assertListEqual(
+            sorted(
+                UprnToCouncil.objects.all().values_list("lad", "polling_station_id")
+            ),
+            self.uprn_lad_ps,
+        )
+
+        cmd = Command()
+        cmd.handle(council=None, eoni=True)
+
+        self.assertEqual(Council.objects.count(), 13)
         self.assertEqual(PollingStation.objects.count(), 3)
         self.assertEqual(PollingDistrict.objects.count(), 3)
         self.assertListEqual(
             sorted(
                 UprnToCouncil.objects.all().values_list("lad", "polling_station_id")
             ),
-            [
+            [  # NI stations removed from uprntocounciltable
+                ("N09000001", ""),
+                ("N09000002", ""),
+                ("N09000003", ""),
+                ("N09000004", ""),
+                ("N09000005", ""),
+                ("N09000006", ""),
+                ("N09000007", ""),
+                ("N09000008", ""),
+                ("N09000009", ""),
+                ("N09000010", ""),
+                ("N09000011", ""),
                 ("X01000000", "ps1"),
                 ("X01000000", "ps2"),
                 ("X01000001", "ps1"),
             ],
+        )
+
+    def test_teardown_all_councils(self):
+        self.assertEqual(Council.objects.count(), 13)
+        self.assertEqual(PollingStation.objects.count(), 14)
+        self.assertEqual(PollingDistrict.objects.count(), 3)
+        self.assertListEqual(
+            sorted(
+                UprnToCouncil.objects.all().values_list("lad", "polling_station_id")
+            ),
+            self.uprn_lad_ps,
         )
 
         self.assertEqual(
@@ -167,14 +258,29 @@ class TestTeardown(TestCase):
         cmd = Command()
         cmd.handle(council=None, all=True)
 
-        self.assertEqual(Council.objects.count(), 2)
+        self.assertEqual(Council.objects.count(), 13)
         self.assertEqual(PollingStation.objects.count(), 0)
         self.assertEqual(PollingDistrict.objects.count(), 0)
         self.assertListEqual(
             sorted(
                 UprnToCouncil.objects.all().values_list("lad", "polling_station_id")
             ),
-            [("X01000000", ""), ("X01000000", ""), ("X01000001", "")],
+            [  # All stations removed from uprntocounciltable
+                ("N09000001", ""),
+                ("N09000002", ""),
+                ("N09000003", ""),
+                ("N09000004", ""),
+                ("N09000005", ""),
+                ("N09000006", ""),
+                ("N09000007", ""),
+                ("N09000008", ""),
+                ("N09000009", ""),
+                ("N09000010", ""),
+                ("N09000011", ""),
+                ("X01000000", ""),
+                ("X01000000", ""),
+                ("X01000001", ""),
+            ],
         )
         self.assertEqual(
             DataQuality.objects.get(council_id="AAA"),
@@ -202,5 +308,5 @@ class TestTeardown(TestCase):
         )
 
         self.assertEqual(
-            DataEvent.objects.filter(event_type=DataEventType.TEARDOWN).count(), 2
+            DataEvent.objects.filter(event_type=DataEventType.TEARDOWN).count(), 13
         )


### PR DESCRIPTION
This just gives us a short hand way of tearing down the Northern Irish Councils. 
The rational for this is that if there are unexpected scheme changes it would be nice to have a quick way of saying 'we don't know' while we make sure the right data is up. 