### PR TITLE
Add Authorization headers to CloudFront

### DIFF
--- a/cdk/stacks/wdiv_stack.py
+++ b/cdk/stacks/wdiv_stack.py
@@ -419,6 +419,7 @@ class WDIVStack(Stack):
                         "X-CSRFToken",
                         "Accept",
                         "Accept-Language",
+                        "Authorization",
                         "Cache-Control",
                         "Referer",
                     ),


### PR DESCRIPTION
This allows Basic Auth in dev and stage.
