### PR TITLE
Fix slack setting in import eoni from s3 cmd

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
@@ -12,6 +12,7 @@ from data_importers.s3wrapper import parse_s3_uri, S3Wrapper
 from data_importers.management.commands.import_eoni import Command as EONI_Importer
 
 from polling_stations.settings.constants.importers import EONIImportScheme
+from polling_stations.settings.constants.slack import BOTS_TESTING_CHANNEL, BOTS_CHANNEL
 
 
 def attempt_decode(body: bytes):
@@ -420,9 +421,9 @@ class Command(BaseCommand):
 
         if options.get("send_slack_report"):
             if self.dc_environment == "production":
-                channel = settings.BOTS_CHANNEL
+                channel = BOTS_CHANNEL
             else:
-                channel = settings.BOT_TESTING_CHANNEL
+                channel = BOTS_TESTING_CHANNEL
 
             importer_opts["slack"] = channel
 

--- a/polling_stations/settings/constants/slack.py
+++ b/polling_stations/settings/constants/slack.py
@@ -1,2 +1,2 @@
 BOTS_CHANNEL = "bots"
-BOT_TESTING_CHANNEL = "bot-testing"
+BOTS_TESTING_CHANNEL = "bot-testing"


### PR DESCRIPTION
The settings object was a LazySettings, and the constants weren't showing up.

I also renamed them to hopefully make typos harder.


