### PR TITLE
Fix EONI import errors

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_eoni.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni.py
@@ -292,7 +292,9 @@ class Command(BaseStationsImporter, CsvMixin):
                 self.stdout.write(
                     f"Updating UprnToCouncil record for {address.uprn} with gss {other_uprn.lad}"
                 )
-                address_uprn = address.uprntocouncil
+                address_uprn = UprnToCouncil.objects.using(DB_NAME).get(
+                    uprn=address.uprn
+                )
                 address_uprn.lad = other_uprn.lad
                 address_uprn.save(using=DB_NAME)
                 self.deduced_addresses[address.uprn] = other_uprn.lad

--- a/polling_stations/apps/data_importers/management/commands/import_eoni.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni.py
@@ -90,7 +90,7 @@ class Command(BaseStationsImporter, CsvMixin):
             }
             self.stations_only = options.get("stations_only")
             self.pre_process_data(reprojected=options["reprojected"])
-            with transaction.atomic():
+            with transaction.atomic(using=DB_NAME):
                 self.clear_old_data()
                 self.copy_data()
                 self.assign_uprn_to_councils()
@@ -129,7 +129,7 @@ class Command(BaseStationsImporter, CsvMixin):
         # Only remove old polling stations, as the UPRN to Council table
         # is populated by this command previously, so deleting data form it
         # isn't useful.
-        with transaction.atomic():
+        with transaction.atomic(using=DB_NAME):
             CustomFinder.objects.using(DB_NAME).filter(area_code="N07000001").delete()
             PollingStation.objects.using(DB_NAME).filter(
                 council_id__in=NIR_IDS


### PR DESCRIPTION
This will probably fix the immediate race conditions we know about, but fundamentally running import scripts from inside a deployed VM (as opposed to CI) is broken by default.