### PR TITLE
Only serve from replica when there is a request in scope

### DIFF
--- a/polling_stations/db_routers.py
+++ b/polling_stations/db_routers.py
@@ -27,7 +27,10 @@ class ReplicationRouter(object):
         # We only care about trying to scale
         # by serving traffic from a replica
         # when we are serving HTTP traffic
-        if get_request():
+        request = get_request()
+        if request:
+            if request.path.startswith("/admin"):
+                return PRIMARY
             return REPLICA
 
         # in all other cases (e.g: management commands, shell)

--- a/polling_stations/db_routers.py
+++ b/polling_stations/db_routers.py
@@ -3,20 +3,27 @@ import os
 from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 
+PRIMARY = settings.PRINCIPAL_DB_NAME
+REPLICA = DEFAULT_DB_ALIAS
+
 
 class ReplicationRouter(object):
     def db_for_read(self, model, **hints):
+        if os.environ.get("CIRCLECI"):
+            return DEFAULT_DB_ALIAS
+
         if model._meta.label in (
             "file_uploads.Upload",
             "file_uploads.File",
-        ) and not os.environ.get("CIRCLECI"):
-            return settings.PRINCIPAL_DB_NAME
-        return DEFAULT_DB_ALIAS
+        ):
+            return PRIMARY
+        return REPLICA
 
     def db_for_write(self, model, **hints):
         if os.environ.get("CIRCLECI"):
             return DEFAULT_DB_ALIAS
-        return settings.PRINCIPAL_DB_NAME
+
+        return PRIMARY
 
     def allow_relation(self, obj1, obj2, **hints):
         return True
@@ -26,6 +33,6 @@ class ReplicationRouter(object):
 
 
 def get_principal_db_name():
-    if settings.PRINCIPAL_DB_NAME in settings.DATABASES:
-        return settings.PRINCIPAL_DB_NAME
-    return DEFAULT_DB_ALIAS
+    if PRIMARY in settings.DATABASES:
+        return PRIMARY
+    return REPLICA

--- a/polling_stations/db_routers.py
+++ b/polling_stations/db_routers.py
@@ -5,7 +5,7 @@ from django.db import DEFAULT_DB_ALIAS
 from django_middleware_global_request import get_request
 
 
-PRIMARY = settings.PRINCIPAL_DB_NAME
+PRINCIPAL = settings.PRINCIPAL_DB_NAME
 REPLICA = DEFAULT_DB_ALIAS
 
 
@@ -22,7 +22,7 @@ class ReplicationRouter(object):
             "file_uploads.Upload",
             "file_uploads.File",
         ):
-            return PRIMARY
+            return PRINCIPAL
 
         # We only care about trying to scale
         # by serving traffic from a replica
@@ -30,18 +30,18 @@ class ReplicationRouter(object):
         request = get_request()
         if request:
             if request.path.startswith("/admin"):
-                return PRIMARY
+                return PRINCIPAL
             return REPLICA
 
         # in all other cases (e.g: management commands, shell)
-        # perform reads from the primary to prevent race conditions
-        return PRIMARY
+        # perform reads from the principal to prevent race conditions
+        return PRINCIPAL
 
     def db_for_write(self, model, **hints):
         if os.environ.get("CIRCLECI"):
             return DEFAULT_DB_ALIAS
 
-        return PRIMARY
+        return PRINCIPAL
 
     def allow_relation(self, obj1, obj2, **hints):
         return True
@@ -51,6 +51,6 @@ class ReplicationRouter(object):
 
 
 def get_principal_db_name():
-    if PRIMARY in settings.DATABASES:
-        return PRIMARY
+    if PRINCIPAL in settings.DATABASES:
+        return PRINCIPAL
     return REPLICA

--- a/polling_stations/db_routers.py
+++ b/polling_stations/db_routers.py
@@ -2,6 +2,8 @@ import os
 
 from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
+from django_middleware_global_request import get_request
+
 
 PRIMARY = settings.PRINCIPAL_DB_NAME
 REPLICA = DEFAULT_DB_ALIAS
@@ -17,7 +19,11 @@ class ReplicationRouter(object):
             "file_uploads.File",
         ):
             return PRIMARY
-        return REPLICA
+
+        if get_request():
+            return REPLICA
+
+        return PRIMARY
 
     def db_for_write(self, model, **hints):
         if os.environ.get("CIRCLECI"):

--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -124,6 +124,7 @@ from .static_files import PIPELINE, STATICFILES_FINDERS  # noqa
 MIDDLEWARE = (
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "django_middleware_global_request.middleware.GlobalRequestMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -197,6 +198,7 @@ INSTALLED_APPS = (
     "dc_design_system",
     "dc_utils",
     "drf_spectacular",
+    "django_middleware_global_request",
 )
 
 PROJECT_APPS = (

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,6 +11,7 @@ django-dotenv
 django-extensions
 django-filter
 django-localflavor
+django-middleware-global-request
 django-sesame
 djangorestframework
 djangorestframework-csv

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -198,6 +198,7 @@ django==4.2.13 \
     #   django-extensions
     #   django-filter
     #   django-localflavor
+    #   django-middleware-global-request
     #   django-sesame
     #   djangorestframework
     #   drf-spectacular
@@ -233,6 +234,12 @@ django-localflavor==4.0 \
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   dc-django-utils
+django-middleware-global-request==0.3.5 \
+    --hash=sha256:37c79c9cd80e73751ae2821696e20af13ba7628a0915ff1818d124e0e72980b1 \
+    --hash=sha256:7beb2c8ca9106aac641692cda2bac290bd7083a315446a12db06fa91b73903d6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django-pipeline==3.0.0 \
     --hash=sha256:49a8bee298668100bb6e8a2144dff8c607baa5297820a2503793c38693f34103 \
     --hash=sha256:e9e08b084ef3ebf599795510519a8d44f2240b487782bebf4a8fcaf6302c31d1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -381,6 +381,7 @@ django==4.2.13 \
     #   django-extensions
     #   django-filter
     #   django-localflavor
+    #   django-middleware-global-request
     #   django-sesame
     #   djangorestframework
     #   drf-spectacular
@@ -415,6 +416,10 @@ django-localflavor==4.0 \
     # via
     #   -r requirements/base.in
     #   dc-django-utils
+django-middleware-global-request==0.3.5 \
+    --hash=sha256:37c79c9cd80e73751ae2821696e20af13ba7628a0915ff1818d124e0e72980b1 \
+    --hash=sha256:7beb2c8ca9106aac641692cda2bac290bd7083a315446a12db06fa91b73903d6
+    # via -r requirements/base.in
 django-pipeline==3.0.0 \
     --hash=sha256:49a8bee298668100bb6e8a2144dff8c607baa5297820a2503793c38693f34103 \
     --hash=sha256:e9e08b084ef3ebf599795510519a8d44f2240b487782bebf4a8fcaf6302c31d1


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208838937595665/f

I'm going to walk through each of the changes in this commit one by one.

## 1. https://github.com/DemocracyClub/UK-Polling-Stations/commit/b14e19a938802f822748d0fd1baccf5ad34e9cf5 - make DB router code easier to understand

This is just a little cleanup of terminology before we start making functional changes. While I was trying to work on this code, I found myself thinking "is the main one default or principal?". Default is sometimes the primary and sometimes the replica, depending on context. I think this makes it clearer what is going on, hopefully :crossed_fingers: 

## 2. https://github.com/DemocracyClub/UK-Polling-Stations/commit/f8c429b1b2b230b41d59e72bd255a8bd7daa6150 - only serve from replica when there is a request in scope

This is the meat of it really. When we talked about this earlier, we decided an important question was: Does the request detection add much overhead? Essentially, we don't want to add something slow to every round-trip to the DB. Having read over the source of django-middleware-global-request, here's how it works...

We register a middleware, which saves the request into a thread-safe global variable.
The middleware runs once per request (or zero times, if there is no request).

The subset of code that gets executed when we call `get_request()` is:

```py
class GlobalRequestStorage(object):
    storage = threading.local()

    def get(self):
        if hasattr(self.storage, "request"):
            return self.storage.request
        else:
            return None

...

GLOBAL_REQUEST_STORAGE = GlobalRequestStorage()

...

def get_request():
    return GLOBAL_REQUEST_STORAGE.get()
```

So fundamentally, it is just:

- Is there a value set for request (by the middleware)?
- If yes, return it
- Otherwise, return None

so that's the only code we're adding into every DB (read) round-trip.

I'm not worried about the performance impact of this and I don't see the need to try and "optimise" that.

## 3. https://github.com/DemocracyClub/UK-Polling-Stations/commit/66317994bbfab101a588a862ff183d12378dcc6c - explain with comments

In this commit I am just adding a few comments to explain what is going on more clearly

## 4. https://github.com/DemocracyClub/UK-Polling-Stations/pull/8221/commits/873cc0195ba22f3e1f8f05fe8647d2b741b7a45f - always read from primary in the admin

I'm trying to get ahead of some other problems here. Basically here I am saying that if we're editing things in the admin, also read from the primary. This then guards against the case where you edit something in the admin and it looks like it hasn't updated because it hasn't replicated.

## 5. Next Steps

As agreed, the next thing I'm going to do is review (and mostly remove) occurrences of `.using()` and `using=` throughout the codebase, but that will happen in a second follow-up PR.
