### PR TITLE
Explicitly specify DB connection when we need to, and don't when we don't need to

### DIFF
--- a/polling_stations/apps/addressbase/management/commands/create_uprn_council_lookup.py
+++ b/polling_stations/apps/addressbase/management/commands/create_uprn_council_lookup.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
-from django.db import connection
+from polling_stations.db_routers import get_principal_db_connection
 
 
 class Command(BaseCommand):
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):
-        self.cursor = connection.cursor()
+        self.cursor = get_principal_db_connection().cursor()
         # Set where we'll write the join query to.
         if kwargs["destination"]:
             self.dst = Path(kwargs["destination"])

--- a/polling_stations/apps/addressbase/management/commands/import_uprn_council_lookup.py
+++ b/polling_stations/apps/addressbase/management/commands/import_uprn_council_lookup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from addressbase.models import Address, UprnToCouncil
 from django.core.management.base import BaseCommand
-from django.db import connection
+from polling_stations.db_routers import get_principal_db_connection
 
 
 class Command(BaseCommand):
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         if not self.path.exists():
             raise FileNotFoundError(f"No csv found at {kwargs['path']}")
 
-        cursor = connection.cursor()
+        cursor = get_principal_db_connection().cursor()
         self.stdout.write("clearing existing data..")
         cursor.execute("TRUNCATE TABLE %s;" % (self.table_name))
 

--- a/polling_stations/apps/addressbase/management/commands/update_addressbase.py
+++ b/polling_stations/apps/addressbase/management/commands/update_addressbase.py
@@ -178,7 +178,7 @@ class Command(BaseCommand):
             uprntocouncil_updater.build_temp_indexes()
 
             # Perform the table swaps in a single transaction
-            with transaction.atomic():
+            with transaction.atomic(using=database_name):
                 self.stdout.write("Starting atomic transaction for table swaps...")
 
                 # Drop all foreign keys first

--- a/polling_stations/apps/addressbase/tests/test_update_addressbase.py
+++ b/polling_stations/apps/addressbase/tests/test_update_addressbase.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 from django.core.management import call_command
-from django.db import connection
 from django.test import TestCase, TransactionTestCase
 from uk_geo_utils.base_importer import BaseImporter
 
@@ -14,10 +13,11 @@ from addressbase.management.commands.update_addressbase import (
 from councils.tests.factories import CouncilFactory
 from pollingstations.models import PollingStation
 from pollingstations.tests.factories import PollingStationFactory
+from polling_stations.db_routers import get_principal_db_connection
 
 
 def get_primary_key_name(table):
-    with connection.cursor() as cursor:
+    with get_principal_db_connection().cursor() as cursor:
         cursor.execute(f"""
             SELECT conname
             FROM pg_constraint
@@ -32,7 +32,7 @@ def get_primary_key_name(table):
 
 
 def get_foreign_key_names(table):
-    with connection.cursor() as cursor:
+    with get_principal_db_connection().cursor() as cursor:
         cursor.execute(f"""
             SELECT conname
             FROM pg_constraint
@@ -44,7 +44,7 @@ def get_foreign_key_names(table):
 
 class HelpersTest(TestCase):
     def setUp(self):
-        with connection.cursor() as cursor:
+        with get_principal_db_connection().cursor() as cursor:
             # Create table with named primary key
             cursor.execute("""
                 CREATE TABLE foo (
@@ -53,7 +53,7 @@ class HelpersTest(TestCase):
                     CONSTRAINT foo_primary_key PRIMARY KEY (id)
                 );
             """)
-        with connection.cursor() as cursor:
+        with get_principal_db_connection().cursor() as cursor:
             # Create table with named foreign key
             cursor.execute("""
                 CREATE TABLE bar (
@@ -64,7 +64,7 @@ class HelpersTest(TestCase):
             """)
 
     def tearDown(self):
-        with connection.cursor() as cursor:
+        with get_principal_db_connection().cursor() as cursor:
             cursor.execute("""
             DROP TABLE IF EXISTS foo CASCADE;
             DROP TABLE IF EXISTS bar CASCADE;

--- a/polling_stations/apps/councils/management/commands/import_councils.py
+++ b/polling_stations/apps/councils/management/commands/import_councils.py
@@ -10,12 +10,16 @@ from django.core.management.base import BaseCommand
 from django.db import DEFAULT_DB_ALIAS, transaction
 from requests.exceptions import HTTPError
 from retry import retry
+from polling_stations.db_routers import get_principal_db_name
+
 
 from polling_stations.settings.constants.councils import (
     COUNCIL_ID_FIELD,
     NIR_IDS,
     WELSH_COUNCIL_NAMES,
 )
+
+DB_NAME = get_principal_db_name()
 
 
 def union_areas(a1, a2):
@@ -243,7 +247,7 @@ class Command(BaseCommand):
 
             council.save()
 
-    @transaction.atomic
+    @transaction.atomic(using=DB_NAME)
     def handle(self, **options):
         """
         Manually run system checks for the

--- a/polling_stations/apps/councils/models.py
+++ b/polling_stations/apps/councils/models.py
@@ -16,6 +16,9 @@ from file_uploads.models import File, Upload
 from pollingstations.models import PollingStation
 
 from polling_stations.i18n.cy import WelshNameMutationMixin
+from polling_stations.db_routers import get_principal_db_name
+
+DB_NAME = get_principal_db_name()
 
 
 class UnsafeToDeleteCouncil(Exception):
@@ -23,7 +26,7 @@ class UnsafeToDeleteCouncil(Exception):
 
 
 class CouncilQueryset(models.QuerySet):
-    @transaction.atomic
+    @transaction.atomic(using=DB_NAME)
     def delete(self, force_cascade=False):
         if force_cascade:
             return super().delete()
@@ -113,7 +116,7 @@ class Council(WelshNameMutationMixin, models.Model):
     def save(
         self, force_insert=False, force_update=False, using=None, update_fields=None
     ):
-        with transaction.atomic():
+        with transaction.atomic(using=DB_NAME):
             new = self._state.adding
             super().save(
                 force_insert=force_insert,

--- a/polling_stations/apps/data_importers/data_types.py
+++ b/polling_stations/apps/data_importers/data_types.py
@@ -8,9 +8,9 @@ from collections import namedtuple
 
 from addressbase.models import Address, UprnToCouncil, get_uprn_hash_table
 from councils.models import Council
-from django.db import connection
 from pollingstations.models import PollingDistrict, PollingStation
 from uk_geo_utils.helpers import Postcode
+from polling_stations.db_routers import get_principal_db_connection
 
 Station = namedtuple(
     "Station",
@@ -116,7 +116,7 @@ class DistrictSet(CustomSet, AssignPollingStationsMixin):
         self.saved = True
 
     def get_uprns_by_district(self):
-        cursor = connection.cursor()
+        cursor = get_principal_db_connection().cursor()
         cursor.execute(
             """
                 SELECT a.uprn, d.polling_station_id
@@ -133,7 +133,7 @@ class DistrictSet(CustomSet, AssignPollingStationsMixin):
         return cursor.fetchall()
 
     def get_uprns_by_district_join_stations(self):
-        cursor = connection.cursor()
+        cursor = get_principal_db_connection().cursor()
         cursor.execute(
             """
                 SELECT a.uprn, s.internal_council_id

--- a/polling_stations/apps/data_importers/management/commands/teardown.py
+++ b/polling_stations/apps/data_importers/management/commands/teardown.py
@@ -7,6 +7,9 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from pollingstations.models import AdvanceVotingStation, PollingDistrict, PollingStation
 from polling_stations.settings.constants.councils import NIR_IDS
+from polling_stations.db_routers import get_principal_db_name
+
+DB_NAME = get_principal_db_name()
 
 """
 Clear PollingDistrict, PollingStation, and AdvancedVotingStation models
@@ -70,7 +73,7 @@ class Command(BaseCommand):
         record_teardown_event(council_id)
         print("..done")
 
-    @transaction.atomic
+    @transaction.atomic(using=DB_NAME)
     def handle(self, *args, **kwargs):
         """
         Manually run system checks for the

--- a/polling_stations/apps/file_uploads/accessibility_information_handler.py
+++ b/polling_stations/apps/file_uploads/accessibility_information_handler.py
@@ -6,6 +6,10 @@ from councils.models import Council
 from django.db import transaction
 from pollingstations.models import AccessibilityInformation, PollingStation
 
+from polling_stations.db_routers import get_principal_db_name
+
+DB_NAME = get_principal_db_name()
+
 
 class AccessibilityInformationHandler:
     def __init__(self, council):
@@ -55,7 +59,7 @@ class AccessibilityInformationHandler:
     def header(self, header: list[str]):
         self._header = header
 
-    @transaction.atomic
+    @transaction.atomic(using=DB_NAME)
     def handle(self, accessibility_info: list[str]):
         sys.stdout.write("Checking accessibility information csv")
         data: csv.DictReader = self.parse_data(accessibility_info)

--- a/polling_stations/apps/file_uploads/api.py
+++ b/polling_stations/apps/file_uploads/api.py
@@ -3,6 +3,9 @@ from rest_framework import serializers, viewsets
 from rest_framework.exceptions import PermissionDenied
 
 from .models import File, Upload
+from polling_stations.db_routers import get_principal_db_name
+
+DB_NAME = get_principal_db_name()
 
 
 class FileSerializer(serializers.ModelSerializer):
@@ -18,7 +21,7 @@ class UploadSerializer(serializers.ModelSerializer):
         model = Upload
         fields = ("gss", "timestamp", "github_issue", "file_set", "election_date")
 
-    @transaction.atomic
+    @transaction.atomic(using=DB_NAME)
     def create(self, validated_data):
         def update_file_set(validated_data):
             upload = Upload.objects.get(

--- a/polling_stations/apps/file_uploads/models.py
+++ b/polling_stations/apps/file_uploads/models.py
@@ -8,7 +8,6 @@ from django.contrib.auth.models import User
 from django.contrib.gis.db import models
 from django.contrib.postgres.aggregates import BoolAnd, StringAgg
 from django.core.mail import EmailMessage
-from django.db import transaction
 from django.db.models import Case, Exists, Func, OuterRef, Q, Value, When
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -219,7 +218,6 @@ class Upload(models.Model):
         )
         email.send()
 
-    @transaction.atomic
     def send_error_email(self):
         subject = "File upload failed"
         message = f"File upload failure: {self}. Please investigate further."

--- a/polling_stations/apps/pollingstations/admin.py
+++ b/polling_stations/apps/pollingstations/admin.py
@@ -9,6 +9,9 @@ from pollingstations.models import (
     PollingStation,
     VisibilityChoices,
 )
+from polling_stations.db_routers import get_principal_db_name
+
+DB_NAME = get_principal_db_name()
 
 
 class AccessibilityInformationInline(admin.StackedInline):
@@ -84,7 +87,7 @@ class PollingStationAdmin(admin.ModelAdmin):
     @admin.action(
         description="Unpublish selected Polling Stations. This will hide them from users."
     )
-    @transaction.atomic
+    @transaction.atomic(using=DB_NAME)
     def unpublish(self, request, queryset):
         queryset.update(visibility=VisibilityChoices.UNPUBLISHED)
         for station in queryset:
@@ -99,7 +102,7 @@ class PollingStationAdmin(admin.ModelAdmin):
     @admin.action(
         description="Republish selected Polling Stations. This will make them visible to users."
     )
-    @transaction.atomic
+    @transaction.atomic(using=DB_NAME)
     def publish(self, request, queryset):
         queryset.update(visibility=VisibilityChoices.PUBLISHED)
         for station in queryset:

--- a/polling_stations/apps/pollingstations/tests/test_factories.py
+++ b/polling_stations/apps/pollingstations/tests/test_factories.py
@@ -8,6 +8,9 @@ from pollingstations.tests.factories import (
     PollingDistrictFactory,
     PollingStationFactory,
 )
+from polling_stations.db_routers import get_principal_db_name
+
+DB_NAME = get_principal_db_name()
 
 
 class TestPollingStationFactory(TestCase):
@@ -38,7 +41,7 @@ class TestAccessibilityInformationFactory(TestCase):
         self.assertEqual(len(PollingStation.objects.all()), 1)
 
     def test_accessibility_information_factory_constraint(self):
-        with self.assertRaises(IntegrityError), transaction.atomic():
+        with self.assertRaises(IntegrityError), transaction.atomic(using=DB_NAME):
             AccessibilityInformationFactory(level_access=True, temporary_ramp=True)
 
         AccessibilityInformationFactory(level_access=True, temporary_ramp=False)

--- a/polling_stations/db_routers.py
+++ b/polling_stations/db_routers.py
@@ -3,6 +3,7 @@ import os
 from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
 from django_middleware_global_request import get_request
+from django.db import connections
 
 
 PRINCIPAL = settings.PRINCIPAL_DB_NAME
@@ -54,3 +55,7 @@ def get_principal_db_name():
     if PRINCIPAL in settings.DATABASES:
         return PRINCIPAL
     return REPLICA
+
+
+def get_principal_db_connection():
+    return connections[get_principal_db_name()]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -37,7 +37,7 @@ rtree
 ruff==0.4.6
 sentry_sdk
 slack_sdk
-uk-geo-utils
+uk-geo-utils==0.17.1
 
 
 https://github.com/DemocracyClub/design-system/archive/refs/tags/0.7.0.zip

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1063,9 +1063,9 @@ typing-extensions==4.11.0 \
     # via
     #   -c requirements/constraints.txt
     #   dj-database-url
-uk-geo-utils==0.17.0 \
-    --hash=sha256:09d8f3683288400acf599c99bf4681a2b9b2e96bb8504e23458cb6612c9072fb \
-    --hash=sha256:40b36dc152de7860009ce5b7b6da90d804717c596ac9b0451303e7ca081d5253
+uk-geo-utils==0.17.1 \
+    --hash=sha256:072e8d38b22bb1e7636fb98a56b73c89fc9d091228ae779c32484ba16488c73b \
+    --hash=sha256:bb227dc79bfa3e38e575ed3c09bc018cc5d1ca8efd9ae805a7e98609bd2beb71
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1705,9 +1705,9 @@ typing-extensions==4.11.0 \
     #   pydantic
     #   pyee
     #   selenium
-uk-geo-utils==0.17.0 \
-    --hash=sha256:09d8f3683288400acf599c99bf4681a2b9b2e96bb8504e23458cb6612c9072fb \
-    --hash=sha256:40b36dc152de7860009ce5b7b6da90d804717c596ac9b0451303e7ca081d5253
+uk-geo-utils==0.17.1 \
+    --hash=sha256:072e8d38b22bb1e7636fb98a56b73c89fc9d091228ae779c32484ba16488c73b \
+    --hash=sha256:bb227dc79bfa3e38e575ed3c09bc018cc5d1ca8efd9ae805a7e98609bd2beb71
     # via -r requirements/base.in
 uritemplate==4.1.1 \
     --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208838937595665/f

This PR is a bit of a mashup of several different things. There are 3 core things I'm doing in this PR.

Prior to #8221 our "solution" to this problem was to pepper `.using()` and `using=` across scripts we thought we might want to run via SSH. #8221 should make this less necessary (but not completely unnecessary - we'll come on to this) so one of the things I'm doing in this PR is removing a lot of that stuff from places where we had done it explicitly and relying on the DB router to route queries to the right DB.

Then that said.. Django's DB routers are a somewhat leaky abstraction. They apply to ORM operations, but that doesn't mean they apply to all database I/O. Specifically there are 2 things we need to worry about:

**connection.cursor**

This one is kind of obvious if you think about it. The DB router expects a model class as one of the inputs so anything where you're running raw SQL doesn't make sense in that world. There is also no way to enforce `allow_relation` if we're working with raw SQL so if you think about it, it is obvious that the DB routers won't work if you're using raw SQL.
There's a thread about this on the django community forum https://forum.djangoproject.com/t/allow-database-router-to-override-default-connection/34529
Anyway, I can't see this changing soon. Also, we use raw SQL in several places in this application. Usually for valid reasons. So we do need to think about this.
In this PR, I've broadly done 2 things:
- Where it is possible to remove raw SQL and replace with ORM calls I have done that. Replacing raw SQL where we don't strictly need it puts us back on the happy path and allows the DB routers to do their thing.
- Where it is not possible to remove raw SQL (either because the ORM doesn't implement stuff we need or for performance reasons) I've made sure we are explicitly specifying the DB connection when using `.cursor()` to execute SQL because if we don't explicitly specify it, django just uses the default DB connection.

**transaction.atomic**

This one is perhaps less obvious.
Regardless of what your database routers say, transaction atomic blocks use the default DB connection unless you explicitly specify it with `using=`.

https://github.com/django/django/blob/5a2c1bc07d126ce32efaa157e712a8f3a7457b74/django/db/transaction.py#L182-L183
https://github.com/django/django/blob/5a2c1bc07d126ce32efaa157e712a8f3a7457b74/django/db/transaction.py#L18-L25

In our case, because the default DB is the replica rather than the primary in production this means that when we write code like this:

```py
@transaction.atomic
def do_the_things():
    this = This(foo='bar')
    that = That(foo='bar')
    this.save()
    that.save()
```

The transaction applies to database IO over the replica connection but the writes we are doing are happening on the primary.
So it looks like that code is safely wrapped in a transaction, but it isn't really when we run it in prod :scream:

Maybe this is telling us we should actually make the primary DB the default connection? (I accept there are tradeoffs either way round). For now I have chosen to just explicitly pass a `using=` to every `transaction.atomic` so that transactions actually working as intended·

Anyway, the point is: If we're using raw SQL or transactions it is up to us to manually specify what connection we're using or django will just use the default and it doesn't matter what we put in DB routers.

What I **haven't** attempted to do in this PR is prevent us from writing wrong code in future. That is another issue/PR.

The scope of this PR is only to make sure all the code we have already written is talking to the correct DB and remove code that is no longer needed following #8221

I have attempted to split this down into commits which are easy to digest one at a time.