### PR TITLE
revise cancelled elections template

### DIFF
--- a/polling_stations/templates/fragments/cancelled_election.html
+++ b/polling_stations/templates/fragments/cancelled_election.html
@@ -1,32 +1,22 @@
 {% load i18n_with_welsh %}
-{% load markdown_filter %}
 {% if cancelled_election.metadata.cancelled_election.title %}
     <h2>{{ cancelled_election.metadata.cancelled_election.title }}</h2>
 {% else %}
     <h2>{% trans "Cancelled Election" %}</h2>
 {% endif %}
 
-{% if cancelled_election.name %}
-    {% if cancelled_election.rescheduled_date %}
-        <p>{% blocktrans with cancelled_election_name=cancelled_election.name %}The poll for <strong>{{ cancelled_election_name }}</strong> has been rescheduled.{% endblocktrans %}</p>
-        {% comment %}Translators: 'it' is a postponed election{% endcomment %}
-        <p>{% blocktrans with cancelled_election_rescheduled_date=cancelled_election.rescheduled_date %}It will now take place on {{ cancelled_election_rescheduled_date }}.{% endblocktrans %}</p>
-    {% else %}
-        <p>{% blocktrans with cancelled_election_name=cancelled_election.name %}The poll for <strong>{{ cancelled_election_name }}</strong> has been cancelled.{% endblocktrans %}</p>
-    {% endif %}
-    <p>To learn more, please visit <a href="https://whocanivotefor.co.uk/elections/{{ postcode }}/">Who Can I Vote For?</a></p>
+{% if cancelled_election.rescheduled_date %}
+    <p>{% blocktrans with cancelled_election_name=cancelled_election.name %}The poll for <strong>{{ cancelled_election_name }}</strong> has been rescheduled.{% endblocktrans %}</p>
+    {% comment %}Translators: 'it' is a postponed election{% endcomment %}
+    <p>{% blocktrans with cancelled_election_rescheduled_date=cancelled_election.rescheduled_date %}It will now take place on {{ cancelled_election_rescheduled_date }}.{% endblocktrans %}</p>
+{% elif cancelled_election.metadata.cancelled_election.detail %}
+    {{ cancelled_election.metadata.cancelled_election.detail | linebreaks }}
+{% else %}
+    <p>{% blocktrans with cancelled_election_name=cancelled_election.name %}The poll for <strong>{{ cancelled_election_name }}</strong> will not go ahead as planned.{% endblocktrans %}</p>
 {% endif %}
 
-{% if cancelled_election.metadata.cancelled_election.detail %}
-    {{ cancelled_election.metadata.cancelled_election.detail | markdown }}
+{% if cancelled_election.metadata.cancelled_election.url %}
+    <p><a href="{{ cancelled_election.metadata.cancelled_election.url }}">Learn More</a></p>
 {% else %}
-    {% if council.electoral_services_phone_numbers %}
-        <p>
-            {% blocktrans trimmed with phone_number=council.electoral_services_phone_numbers.0 %}
-                For more information contact {{ council }} on <strong><a href="tel:{{ phone_number }}">{{ phone_number }}</a></strong>.
-            {% endblocktrans %}
-        </p>
-    {% else %}
-        <p>{% blocktrans %}For more information contact {{ council }}.{% endblocktrans %}</p>
-    {% endif %}
+    <p>To learn more, please visit <a href="https://whocanivotefor.co.uk/elections/{{ postcode }}/">Who Can I Vote For?</a></p>
 {% endif %}


### PR DESCRIPTION
Refs https://app.asana.com/0/1209332771640377/1209290265508276/f
Refs https://app.asana.com/0/1209332771640377/1209332771640386/f

This is the PR when I am making the most changes.. bit of a general revamp/improvement to the cancelled elections messaging.

I started off thinking the best way to get rid of "cancelled" would be to properly implement cancellations reasons. I've decided that unpicking what is going on with the ballot cache and the 2 different EE backends is just too much to deal with right now. Lets circle back and look at https://app.asana.com/0/1209332771640377/1209332771640406/f after we've re-thought that under the banner of "remove embedded EE". I'm hoping we will simplify a lot of the things that are making this hard in that process :crossed_fingers: 