### PR TITLE
use ds-map-leaflet for polling station dashboard maps

### DIFF
--- a/polling_stations/apps/dashboard/templates/dashboard/postcode.html
+++ b/polling_stations/apps/dashboard/templates/dashboard/postcode.html
@@ -80,7 +80,7 @@
     <h1>{{ postcode }}</h1>
 
 
-    <div id="area_map" class="ds-image-card">
+    <div id="area_map" class="ds-map-leaflet">
 
     </div>
 


### PR DESCRIPTION
use ds-map-leaflet for polling station dashboard maps, otherwise they won't show up in the postcode view.