### PR TITLE
use the right DB in RunPython migrations

### DIFF
--- a/deploy/files/scripts/setup_db_replication.sh
+++ b/deploy/files/scripts/setup_db_replication.sh
@@ -24,7 +24,7 @@ psql "$DB" -U "$DB_USER" -c 'create extension postgis;'
 source /var/www/polling_stations/code/venv/bin/activate
 
 # Migrate db - this builds the schema before syncing
-IGNORE_ROUTERS=True /var/www/polling_stations/code/manage.py migrate --database=local
+/var/www/polling_stations/code/manage.py migrate --database=local
 
 # Truncate some tables that are populated by the above steps
 psql "$DB" -U "$DB_USER" -c 'TRUNCATE "spatial_ref_sys", "auth_permission", "django_migrations", "django_content_type", "django_site", RESTART IDENTITY CASCADE;'

--- a/polling_stations/apps/pollingstations/migrations/0013_customfinders.py
+++ b/polling_stations/apps/pollingstations/migrations/0013_customfinders.py
@@ -7,7 +7,7 @@ from django.db import migrations
 def create_custom_finders(apps, schema_editor):
     CustomFinder = apps.get_model("pollingstations", "CustomFinder")
 
-    CustomFinder.objects.update_or_create(
+    CustomFinder.objects.using(schema_editor.connection.alias).update_or_create(
         area_code="N07000001",
         base_url="http://www.eoni.org.uk/"
         + "Offices/Postcode-Search-Results?postcode=",
@@ -19,7 +19,9 @@ def create_custom_finders(apps, schema_editor):
 
 def remove_custom_finders(apps, schema_editor):
     CustomFinder = apps.get_model("pollingstations", "CustomFinder")
-    CustomFinder.objects.filter(area_code__in=["N07000001"]).delete()
+    CustomFinder.objects.using(schema_editor.connection.alias).filter(
+        area_code__in=["N07000001"]
+    ).delete()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Another Django/multiple DBs pitfall.

Here's the sequence of events: In https://github.com/DemocracyClub/UK-Polling-Stations/pull/8214 I deleted the old custom finders model.

After importing ONSPD on prod yesterday, I found that replication wasn't working. Looking a at the logs, https://github.com/DemocracyClub/UK-Polling-Stations/blob/767a02668b35719e7136d74fc478fbd184d4d72c/deploy/files/scripts/setup_db_replication.sh#L27 was failing with `ProgrammingError: relation "pollingstations_customfinder" does not exist` trying to apply `pollingstations.0013_customfinders`

This is kind of a pointless migration because we're inserting records into a table and then later on in the migrations we delete that table. But fundamentally, this migration should apply cleanly to an empty DB. So I wanted to actually understand the problem rather than just replace the migration with a no-op and move on.


It turns out this is another multiple DBs gotcha. Even though we were running `manage.py migrate --database=local`, the `update_or_create()` statement was running against the default DB, and that's why it was failing. Importantly, it has _always_ been doing this. We just never noticed before because it didn't throw. But now it does because we just created the table on the `local` DB but we've already deleted it on the `default`.

This happens because the model retrieved via `apps.get_model()` is unaware of the database being used in the migration process. When we execute `CustomFinder.objects.update_or_create(...)`, Django uses the default database unless explicitly specified. So the fix for this is relatively simple. We need to add `.using(schema_editor.connection.alias)` and then everything happens on the right DB connection.

There's a bit more info on this at:
- https://forum.djangoproject.com/t/when-to-use-db-alias-in-migration/3859
- https://docs.djangoproject.com/en/5.2/ref/migration-operations/#django.db.migrations.operations.RunPython

but this is another one of those things where it is really easy to accidentally write "wrong code that looks right"

I guess the final thing here is: If `setup_db_replication.sh` fails, that's something I really want to know about, but this failed silently and we didn't notice because production is "working" (just without replication). I'd like to have a think about how to make this fail loudly, but I have not done that in this PR.