### PR TITLE
use coordinate columns from halarose exports

### DIFF
--- a/polling_stations/apps/data_importers/ems_importers.py
+++ b/polling_stations/apps/data_importers/ems_importers.py
@@ -339,8 +339,13 @@ class BaseHalaroseCsvImporter(
 
     def get_station_point(self, record):
         location = None
+        # Try coords first
+        x_coord = float(record.pollingvenueeasting)
+        y_coord = float(record.pollingvenuenorthing)
+        if x_coord > 0 and y_coord > 0:
+            location = Point(x_coord, y_coord, srid=27700)
 
-        # try UPRN first, if available
+        # try UPRN next, if available
         if (
             hasattr(record, self.station_uprn_field)
             and getattr(record, self.station_uprn_field).strip()

--- a/polling_stations/apps/data_importers/tests/fixtures/halarose_importer/test.csv
+++ b/polling_stations/apps/data_importers/tests/fixtures/halarose_importer/test.csv
@@ -1,7 +1,7 @@
-HouseID,HouseName,HouseNumber,HousePostCode,UPRN,SubStreetName,StreetNumber,StreetName,Locality,Town,AdminArea,PollingStationName,PollingStationNumber,PollingStationAddress_1,PollingStationAddress_2,PollingStationAddress_3,PollingStationAddress_4,PollingStationAddress_5,PollingStationPostCode
-6238,,,,,,,Other Electors,Gorseinon,Swansea,,Penyrheol Boxing Club,10,Gower View Road,Penyrheol,Swansea,,,SA4 4YL
-1328,,,,,,,Other Voters,,Bournemouth,,St Ambrose Church Hall,58,West Cliff Road,Bournemouth,,,,BH4 8BE
-9006744,"2, Dogkennel Farm Cottages",,BA15 2BB,1,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a
-12000362,,47,SA4 4LR,2,,,Heol Dylan,Gorseinon,Swansea,,Penyrheol Boxing Club,10,Gower View Road,Penyrheol,Swansea,,,SA4 4YL
-2010325,,1,SA4 4GH,3,n/a,n/a,Heol Elfed,Gorseinon,Swansea,,Penyrheol Boxing Club,10,Gower View Road,Penyrheol,Swansea,,,SA4 4YL
-2010325,,2,,4,n/a,n/a,Heol Elfed,Gorseinon,Swansea,,Penyrheol Boxing Club,10,Gower View Road,Penyrheol,Swansea,,,SA4 4YL
+HouseID,HouseName,HouseNumber,HousePostCode,UPRN,SubStreetName,StreetNumber,StreetName,Locality,Town,AdminArea,PollingStationName,PollingStationNumber,PollingStationAddress_1,PollingStationAddress_2,PollingStationAddress_3,PollingStationAddress_4,PollingStationAddress_5,PollingStationPostCode,PollingVenueNorthing,PollingVenueEasting
+6238,,,,,,,Other Electors,Gorseinon,Swansea,,Penyrheol Boxing Club,10,Gower View Road,Penyrheol,Swansea,,,SA4 4YL,0,0
+1328,,,,,,,Other Voters,,Bournemouth,,St Ambrose Church Hall,58,West Cliff Road,Bournemouth,,,,BH4 8BE,0,0
+9006744,"2, Dogkennel Farm Cottages",,BA15 2BB,1,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,n/a,0,0
+12000362,,47,SA4 4LR,2,,,Heol Dylan,Gorseinon,Swansea,,Penyrheol Boxing Club,10,Gower View Road,Penyrheol,Swansea,,,SA4 4YL,0,0
+2010325,,1,SA4 4GH,3,n/a,n/a,Heol Elfed,Gorseinon,Swansea,,Penyrheol Boxing Club,10,Gower View Road,Penyrheol,Swansea,,,SA4 4YL,0,0
+2010325,,2,,4,n/a,n/a,Heol Elfed,Gorseinon,Swansea,,Penyrheol Boxing Club,10,Gower View Road,Penyrheol,Swansea,,,SA4 4YL,0,0


### PR DESCRIPTION
Halarose exports seem to have consistent polling station coordinate columns now so we might as well use them if they're populated.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209626808958245