### PR TITLE
Update council importer 202403

### DIFF
--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -2,8 +2,8 @@
 
 EC_COUNCIL_CONTACT_EMAIL = "digitalcommunications@electoralcommission.org.uk"
 
-BOUNDARIES_URL = "https://s3.eu-west-2.amazonaws.com/pollingstations.public.data/ons/boundaries/Local_Authority_Districts_December_2023_UK_BFE.geojson"
-COUNCIL_ID_FIELD = "LAD23CD"
+BOUNDARIES_URL = "https://s3.eu-west-2.amazonaws.com/pollingstations.public.data/ons/boundaries/Local_Authority_Districts_December_2024_Boundaries_UK_BFE.geojson"
+COUNCIL_ID_FIELD = "LAD24CD"
 EC_COUNCIL_CONTACT_DETAILS_API_URL = (
     "https://electoralcommission.org.uk/api/v1/data/local-authorities.json"
 )


### PR DESCRIPTION

This should get us ready to import the new boundaries once the EC updates their API. 
They will get rid of the old districts for Somerset Council and Westmorland and Furness Council, and replace them with a single entry for each. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205086760793639