### PR TITLE
halarose base importer: only use uprn if location is null

### DIFF
--- a/polling_stations/apps/data_importers/ems_importers.py
+++ b/polling_stations/apps/data_importers/ems_importers.py
@@ -346,7 +346,7 @@ class BaseHalaroseCsvImporter(
             location = Point(x_coord, y_coord, srid=27700)
 
         # try UPRN next, if available
-        if (
+        if location is None and (
             hasattr(record, self.station_uprn_field)
             and getattr(record, self.station_uprn_field).strip()
         ):


### PR DESCRIPTION
The way this worked previously, if we had both UPRNs and points we would overwrite with the point from UPRN.
This PR switches it so that we perfer the easting/northing to UPRN if we have both (refs https://github.com/DemocracyClub/UK-Polling-Stations/pull/8328 )