### PR TITLE
log/handle errors 2

### DIFF
--- a/cdk/lambdas/wdiv-s3-trigger/requirements.txt
+++ b/cdk/lambdas/wdiv-s3-trigger/requirements.txt
@@ -129,9 +129,9 @@ requests-paginator==0.2.0 \
     # via
     #   -c cdk/lambdas/wdiv-s3-trigger/requirements/../../../../requirements/constraints.txt
     #   -r cdk/lambdas/wdiv-s3-trigger/requirements/base.in
-sentry-sdk==2.1.1 \
-    --hash=sha256:95d8c0bb41c8b0bc37ab202c2c4a295bb84398ee05f4cdce55051cd75b926ec1 \
-    --hash=sha256:99aeb78fb76771513bd3b2829d12613130152620768d00cd3e45ac00cb17950f
+sentry-sdk==2.23.1 \
+    --hash=sha256:2288320465065f3f056630ce55936426204f96f63f1208edb79e033ed03774db \
+    --hash=sha256:42ef3a6cc1db3d22cb2ab24163d75b23f291ad9892b1a8c44075ce809a32b191
     # via
     #   -c cdk/lambdas/wdiv-s3-trigger/requirements/../../../../requirements/constraints.txt
     #   -r cdk/lambdas/wdiv-s3-trigger/requirements/base.in

--- a/polling_stations/apps/data_finder/helpers/baked_data_helper.py
+++ b/polling_stations/apps/data_finder/helpers/baked_data_helper.py
@@ -19,6 +19,7 @@ session = Session()
 
 retries = Retry(
     total=1,
+    connect=1,
     backoff_factor=0.1,
     status_forcelist=[502, 503, 504],
     allowed_methods={"GET"},

--- a/polling_stations/apps/data_finder/tests/test_baked_data_helper.py
+++ b/polling_stations/apps/data_finder/tests/test_baked_data_helper.py
@@ -6,6 +6,7 @@ from uk_geo_utils.helpers import Postcode
 
 import pytest
 import polars
+import responses
 
 
 @pytest.fixture()
@@ -276,3 +277,95 @@ def test_uprn_with_elections(temp_data_root, sample_data_writer):
         "request_success": True,
     }
     assert helper.get_ballot_list(postcode, uprn="000001") == expected
+
+
+@responses.activate
+def test_ee_requests_all_success(temp_data_root, sample_data_writer, caplog):
+    ballot_ids = [
+        "local.north-kesteven.bracebridge-heath.by.2025-03-20",
+        "mayor.greater-lincolnshire-cca.2025-05-01",
+        "local.lincolnshire.washingborough.2025-05-01",
+    ]
+
+    sample_data_writer(
+        [
+            {
+                "postcode": "AA1 1AA",
+                "uprn": "000001",
+                "current_elections": ballot_ids,
+            }
+        ]
+    )
+
+    responses.add(
+        responses.GET,
+        "https://elections.democracyclub.org.uk/api/elections/local.north-kesteven.bracebridge-heath.by.2025-03-20/",
+        json={"election_id": "local.north-kesteven.bracebridge-heath.by.2025-03-20"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://elections.democracyclub.org.uk/api/elections/mayor.greater-lincolnshire-cca.2025-05-01/",
+        json={"election_id": "mayor.greater-lincolnshire-cca.2025-05-01"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://elections.democracyclub.org.uk/api/elections/local.lincolnshire.washingborough.2025-05-01/",
+        json={"election_id": "local.lincolnshire.washingborough.2025-05-01"},
+        status=200,
+    )
+
+    helper = LocalParquetElectionsHelper(elections_parquet_path=Path(temp_data_root))
+
+    result = helper.get_response(Postcode("AA1 1AA"))
+    assert result["request_success"]
+    assert len(result["ballots"]) == 3
+    assert len(caplog.records) == 0
+
+
+@responses.activate
+def test_ee_requests_with_failure(temp_data_root, sample_data_writer, caplog):
+    ballot_ids = [
+        "local.north-kesteven.bracebridge-heath.by.2025-03-20",
+        "mayor.greater-lincolnshire-cca.2025-05-01",
+        "local.lincolnshire.washingborough.2025-05-01",
+    ]
+
+    sample_data_writer(
+        [
+            {
+                "postcode": "AA1 1AA",
+                "uprn": "000001",
+                "current_elections": ballot_ids,
+            }
+        ]
+    )
+
+    responses.add(
+        responses.GET,
+        "https://elections.democracyclub.org.uk/api/elections/local.north-kesteven.bracebridge-heath.by.2025-03-20/",
+        json={"election_id": "local.north-kesteven.bracebridge-heath.by.2025-03-20"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://elections.democracyclub.org.uk/api/elections/mayor.greater-lincolnshire-cca.2025-05-01/",
+        json={"election_id": "mayor.greater-lincolnshire-cca.2025-05-01"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://elections.democracyclub.org.uk/api/elections/local.lincolnshire.washingborough.2025-05-01/",
+        json={"error": "oh no"},
+        status=500,
+    )
+
+    helper = LocalParquetElectionsHelper(elections_parquet_path=Path(temp_data_root))
+
+    result = helper.get_response(Postcode("AA1 1AA"))
+    assert not result["request_success"]
+    assert (
+        len([rec for rec in caplog.records if rec.message.startswith("Error fetching")])
+        == 1
+    )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1033,9 +1033,9 @@ s3transfer==0.10.1 \
     # via
     #   -c requirements/constraints.txt
     #   boto3
-sentry-sdk==2.1.1 \
-    --hash=sha256:95d8c0bb41c8b0bc37ab202c2c4a295bb84398ee05f4cdce55051cd75b926ec1 \
-    --hash=sha256:99aeb78fb76771513bd3b2829d12613130152620768d00cd3e45ac00cb17950f
+sentry-sdk==2.23.1 \
+    --hash=sha256:2288320465065f3f056630ce55936426204f96f63f1208edb79e033ed03774db \
+    --hash=sha256:42ef3a6cc1db3d22cb2ab24163d75b23f291ad9892b1a8c44075ce809a32b191
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1478,6 +1478,7 @@ responses==0.25.3 \
     --hash=sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba
     # via
     #   -r requirements/../cdk/lambdas/wdiv-s3-trigger/requirements/testing.in
+    #   -r requirements/testing.in
     #   moto
 retry==0.9.2 \
     --hash=sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606 \

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1631,9 +1631,9 @@ selenium==4.26.1 \
     --hash=sha256:1db3f3a0cd5bb07624fa8a3905a6fdde1595a42185a0617077c361dc53d104fb \
     --hash=sha256:7640f3f08ae7f4e450f895678e8a10a55eb4e4ca18311ed675ecc4684b96b683
     # via -r requirements/testing.in
-sentry-sdk==2.1.1 \
-    --hash=sha256:95d8c0bb41c8b0bc37ab202c2c4a295bb84398ee05f4cdce55051cd75b926ec1 \
-    --hash=sha256:99aeb78fb76771513bd3b2829d12613130152620768d00cd3e45ac00cb17950f
+sentry-sdk==2.23.1 \
+    --hash=sha256:2288320465065f3f056630ce55936426204f96f63f1208edb79e033ed03774db \
+    --hash=sha256:42ef3a6cc1db3d22cb2ab24163d75b23f291ad9892b1a8c44075ce809a32b191
     # via
     #   -r requirements/../cdk/lambdas/wdiv-s3-trigger/requirements/base.in
     #   -r requirements/base.in

--- a/requirements/testing.in
+++ b/requirements/testing.in
@@ -14,3 +14,4 @@ playwright
 pytest-playwright
 pytest-ruff
 pytest-vcr
+responses

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -526,6 +526,7 @@ pyyaml==6.0.1 \
     --hash=sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f
     # via
     #   -c requirements/constraints.txt
+    #   responses
     #   vcrpy
 requests==2.31.0 \
     --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
@@ -533,6 +534,13 @@ requests==2.31.0 \
     # via
     #   -c requirements/constraints.txt
     #   pytest-base-url
+    #   responses
+responses==0.25.3 \
+    --hash=sha256:521efcbc82081ab8daa588e08f7e8a64ce79b91c39f6e62199b19159bea7dbcb \
+    --hash=sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/testing.in
 ruff==0.4.6 \
     --hash=sha256:04a80acfc862e0e1630c8b738e70dcca03f350bad9e106968a8108379e12b31f \
     --hash=sha256:0cf5cc02d3ae52dfb0c8a946eb7a1d6ffe4d91846ffc8ce388baa8f627e3bd50 \
@@ -610,6 +618,7 @@ urllib3==1.26.18 \
     # via
     #   -c requirements/constraints.txt
     #   requests
+    #   responses
     #   selenium
 vcrpy==6.0.1 \
     --hash=sha256:9e023fee7f892baa0bbda2f7da7c8ac51165c1c6e38ff8688683a12a4bde9278


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1209455180573675/f

This PR is a the follow up to https://github.com/DemocracyClub/UK-Polling-Stations/pull/8366#discussion_r1991541110
and replaces https://github.com/DemocracyClub/UK-Polling-Stations/pull/8468

The core things happening in this PR are:


- If we get an error from EE fetching any ballots handle this cleanly
- Improve logging so we have proper visibility on errors
- If we fail fetching data from EE, throw an error on the API rather than return `ballots: []`

I'll leave some more comments inline