### PR TITLE
Creates a file that looks like addressbase_cleaned.csv from onspd

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,6 @@ repos:
       exclude: cdk/lambdas/wdiv-s3-trigger/tests/fixtures/.*
     - id: check-json
 - repo: https://github.com/rtts/djhtml
-  rev: v1.5.0
+  rev: 3.0.6
   hooks:
     - id: djhtml

--- a/polling_stations/apps/addressbase/management/commands/create_dummy_cleaned_addresses_from_onspd.py
+++ b/polling_stations/apps/addressbase/management/commands/create_dummy_cleaned_addresses_from_onspd.py
@@ -1,0 +1,97 @@
+import csv
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.db.models import F, Value, CharField, OuterRef, Subquery, Func
+from django.db.models.functions import Concat, Replace
+
+from addressbase.models import Address
+from uk_geo_utils.models import Onspd
+
+
+class AsEWKT(Func):
+    """Calls the postgis ST_AsEWKT function to get strings like: SRID=4326;POINT(0.088849 51.43053)"""
+
+    function = "ST_AsEWKT"
+    output_field = CharField()
+
+
+class Command(BaseCommand):
+    help = (
+        "Export postcodes that exist in ONSPD but not in AddressBase to a CSV file."
+        "It's a good idea to name the output file according to the version of onspd it's derived from."
+        "eg: python manage.py create_dummy_cleaned_addresses_from_onspd ONSPD_AUG_2024_addressbase_cleaned.csv"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("output_file", type=str, help="Path to output CSV file")
+
+    def handle(self, *args, **options):
+        output_file = options["output_file"]
+
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # First, create a queryset for postcodes that exist in the Address model
+        existing_postcodes = Address.objects.filter(postcode=OuterRef("pcds")).values(
+            "postcode"
+        )
+
+        # Main query
+        results = (
+            Onspd.objects.annotate(
+                # Create "ONSPD:{postcode}" with whitespace removed
+                uprn=Concat(
+                    Value("ONSPD-", output_field=CharField()),
+                    Replace("pcds", Value(" "), Value(""), output_field=CharField()),
+                    output_field=CharField(),
+                ),
+                address=Value("", output_field=CharField()),
+                postcode=F("pcds"),
+                location_wkt=AsEWKT("location"),
+                address_type=Value("", output_field=CharField()),
+            )
+            .filter(
+                doterm="",  # Active postcodes (not terminated)
+                usertype="0",  # Standard geographic postcodes
+            )
+            .exclude(
+                # Exclude postcodes that exist in the Address model
+                pk__in=Subquery(existing_postcodes)
+            )
+            .exclude(
+                pcds__startswith="BT"  # Exclude postcodes in Northern Ireland
+            )
+            .exclude(
+                pcds__startswith="GY"  # Exclude postcodes in Guernsey
+            )
+            .exclude(
+                pcds__startswith="IM"  # Exclude postcodes in Isle of Man
+            )
+            .exclude(
+                pcds__startswith="JE"  # Exclude postcodes in Jersey
+            )
+            .exclude(
+                pcds__startswith="GIR"  # Exclude postcodes for banks
+            )
+        )
+
+        # Write results to CSV without header
+        with open(output_file, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+
+            # Get all results as a list of tuples
+            results_list = list(
+                results.values_list(
+                    "uprn", "address", "postcode", "address_type", "location_wkt"
+                )
+            )
+
+            # Write all rows at once
+            writer.writerows(results_list)
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully exported {len(results_list)} records to {output_file}"
+                )
+            )

--- a/polling_stations/apps/data_finder/helpers/geocoders.py
+++ b/polling_stations/apps/data_finder/helpers/geocoders.py
@@ -39,12 +39,17 @@ class OnspdGeocoderAdapter(BaseGeocoder):
             raise PostcodeError("No location information")
 
         local_auth = geocoder.get_code("lad")
-        error_values = [
+        lad_error_values = [
             "L99999999",  # Channel Islands
             "M99999999",  # Isle of Man
             "",  # Terminated Postcode or other
         ]
-        if not local_auth or local_auth in error_values:
+        usertype = geocoder.get_code("usertype")
+        if (
+            not local_auth
+            or local_auth in lad_error_values
+            or usertype == "1"  # large users
+        ):
             raise PostcodeError("No location information")
 
         return geocoder

--- a/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
+++ b/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
@@ -100,7 +100,9 @@ def test_invalid_postcode(page, live_server):
     with check_for_console_errors(page):
         page.goto(f"{live_server.url}/postcode/foo")
         expect(
-            page.locator("text=This doesn't appear to be a valid postcode.")
+            page.locator(
+                "text=We don't hold data for this postcode, or it is an invalid postcode."
+            )
         ).not_to_be_empty()
 
 
@@ -179,7 +181,6 @@ def test_northern_ireland_with_station_no_election(
         expect(page.locator("h1")).to_have_text("Find your polling station")
         expect(page.locator("#id_postcode")).to_have_count(1)
         page.query_selector("#id_postcode").fill("BT15 3JX")
-
         with page.expect_navigation():
             page.query_selector("#submit-postcode").click()
         expect(

--- a/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
+++ b/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
@@ -101,7 +101,7 @@ def test_invalid_postcode(page, live_server):
         page.goto(f"{live_server.url}/postcode/foo")
         expect(
             page.locator(
-                "text=We don't hold data for this postcode, or it is an invalid postcode."
+                "text=We don't hold information for this postcode, or it is an invalid postcode."
             )
         ).not_to_be_empty()
 

--- a/polling_stations/templates/fragments/errors.html
+++ b/polling_stations/templates/fragments/errors.html
@@ -3,7 +3,7 @@
 
 <div class="ds-text-centered">
     <h2>{% blocktrans %}Sorry, we can't find {{ postcode }}{% endblocktrans %}</h2>
-    <p>{% trans "This doesn't appear to be a valid postcode." %}</p>
+    <p>{% trans "We don't hold information for this postcode, or it is an invalid postcode." %}</p>
     <form method="post" action="{% url 'home' %}" class="form form-inline">
         {% csrf_token %}
         {{ postcode_form|dc_form }}

--- a/polling_stations/templates/home.html
+++ b/polling_stations/templates/home.html
@@ -12,8 +12,7 @@
             <div class="ds-card">
                 <div class="ds-card-body ds-text-centered">
                     {% if form.errors %}
-                        <h2>{% blocktrans %}Sorry, we can't find {{ postcode }}{% endblocktrans %}</h2>
-                        <p>{% trans "This doesn't appear to be a valid postcode." %}</p>
+                        {% include "fragments/errors.html" with postcode=postcode %}
                     {% endif %}
 
                     {% if not is_whitelabel %}


### PR DESCRIPTION
This gets all the postcodes that aren't in addressbase, aren't large users, and, are on mainland GB (i.e. no Northern Ireland, Channel Islands, Isle of Man) and creates a csv that has the same shape as addressbase_cleaned.csv. However there's a dummy uprn in the form:
  ONSPD:TE11ST
Also the address field is blank. This should let us chuck it into the data-baker pipeline to end up in the parquet.


The next step will be to generate the csv and add it to the s3 bucket that databaker produces the parquet files from. 
