### PR TITLE
councils app: do all the reads/writes on the right DBs

### DIFF
--- a/deploy/files/conf/crontab
+++ b/deploy/files/conf/crontab
@@ -2,8 +2,6 @@
 # HOWEVER: these commands will NOT run on instances booted from the EE AMI
 # If you want to have a command run only once per env / once globally, use SSM Run Command
 MAILTO=developers@democracyclub.org.uk
-# Import councils from EC hourly
-1 * * * * polling_stations /usr/bin/manage-py-command import_councils --only-contact-details --database default
 # Sync elections from EE
 */5 * * * * every_election /usr/local/bin/ee-manage-py-command sync_elections
 # Per instance cloudwatch custom metrics


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1209717073277337?focus=true

The problems here turned out to be a bit of a mixed bag.
Some of it is stuff I messed up in https://github.com/DemocracyClub/UK-Polling-Stations/pull/8224
Some of it is code that was never doing quite what we thought it was

One of the key things going on here is that there's a number of places where we wrote something like.

```py
thing = Thing.objects.using(db).get_or_create(this='that')
```

From reading the code, I think our assumption/hope was that this would do something like:

```py
try:
    thing = Thing.objects.using(db).get(this='that')
except Thing.DoesNotExist:
    thing = Thing(this='that')
    thing.save(using=db)
```

but it actually behaves more like:

```py
try:
    thing = Thing.objects.using(db).get(this='that')
except Thing.DoesNotExist:
    thing = Thing(this='that')
    thing.save(using=None) # crucial difference!!
```