### PR TITLE
fix npm install / tell libuv not use use io_uring

### DIFF
--- a/deploy/hooks/afterinstall/install_frontend_deps.sh
+++ b/deploy/hooks/afterinstall/install_frontend_deps.sh
@@ -2,4 +2,4 @@
 set -xeE
 
 cd /var/www/polling_stations/code/
-npm ci
+UV_USE_IO_URING=0 npm ci


### PR DESCRIPTION
This is not precisely https://github.com/nodejs/node/issues/55587 (our kernel version is `Linux 6.8.0-1026-aws x86_64`) or https://github.com/amazonlinux/amazon-linux-2023/issues/840 but it is the same genre of issue (node goes into an uninterruptible sleep state), and the same workaround seems to work in this case :crossed_fingers:
Hopefully we can upgrade to a fixed base image and remove this, but I am hoping this will do the job for now.