### PR TITLE
set error on form

### DIFF
--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -226,6 +226,7 @@ class BasePollingStationView(
         except PostcodeError as e:
             context["error"] = str(e)
             context["postcode_form"] = PostcodeLookupForm({"postcode": self.postcode})
+            context["postcode_form"].add_error("postcode", "Enter a valid postcode.")
             return context
 
         if loc is None:


### PR DESCRIPTION
Sigh
Turns out https://github.com/DemocracyClub/UK-Polling-Stations/pull/8626 was not quite right :see_no_evil: 
The code in that PR dumps the user back to the form with the postcode pre-filled, but if it passes the picture check (regex) but failed geocoding then there's no error set on the form :facepalm: 

Example postcode to test with WV148LF