### PR TITLE
remove most usage of NEXT_CHARISMATIC_ELECTION_DATE(S)

### DIFF
--- a/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
+++ b/polling_stations/apps/data_finder/tests/test_ee_wrapper.py
@@ -111,7 +111,6 @@ def get_data_with_elections():
 class EveryElectionWrapperTests(TestCase):
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_error(self):
         ee = EEWrapper([], request_success=False)
@@ -124,7 +123,6 @@ class EveryElectionWrapperTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_no_elections(self):
         ee = EEWrapper(get_data_no_elections(), request_success=True)
@@ -137,7 +135,6 @@ class EveryElectionWrapperTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_elections(self):
         ee = EEWrapper(get_data_with_elections(), request_success=True)
@@ -152,24 +149,6 @@ class EveryElectionWrapperTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[
-            (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
-        ],
-    )
-    def test_non_charismatic_elections(self):
-        # there are upcoming elections
-        # but they aren't in NEXT_CHARISMATIC_ELECTION_DATES
-        ee = EEWrapper(get_data_with_elections(), request_success=True)
-        self.assertFalse(ee.has_election())
-        self.assertEqual([], ee.get_explanations())
-        cancelled_info = ee.get_cancelled_election_info()
-        self.assertEqual(cancelled_info["cancelled"], False)
-        self.assertEqual(None, ee.get_metadata())
-        self.assertFalse(ee.multiple_elections)
-
-    @override_settings(
-        EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_elections_only_group(self):
         ee = EEWrapper(get_data_only_group(), request_success=True)
@@ -182,7 +161,6 @@ class EveryElectionWrapperTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_elections_group_and_ballot(self):
         ee = EEWrapper(get_data_group_and_ballot(), request_success=True)
@@ -195,7 +173,6 @@ class EveryElectionWrapperTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": False},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_settings_override_false(self):
         ee = EEWrapper(get_data_group_and_ballot(), request_success=True)
@@ -208,7 +185,6 @@ class EveryElectionWrapperTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": False},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_settings_override_true(self):
         ee = EEWrapper(get_data_only_group(), request_success=True)
@@ -222,7 +198,6 @@ class EveryElectionWrapperTests(TestCase):
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
         ELECTION_BLACKLIST=["foo.bar.baz.date"],
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_some_blacklisted(self):
         ee = EEWrapper(get_data_with_elections(), request_success=True)
@@ -232,7 +207,6 @@ class EveryElectionWrapperTests(TestCase):
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
         ELECTION_BLACKLIST=["foo.bar.baz.date", "foo.bar.qux.date"],
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_all_blacklisted(self):
         ee = EEWrapper(get_data_with_elections(), request_success=True)
@@ -375,7 +349,6 @@ def get_data_one_cancelled_ballot_with_metadata():
 class CancelledElectionTests(TestCase):
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_two_ballots_one_cancelled(self):
         ee = EEWrapper(get_data_two_ballots_one_cancelled(), request_success=True)
@@ -390,7 +363,6 @@ class CancelledElectionTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_two_ballots_both_cancelled(self):
         ee = EEWrapper(get_data_two_ballots_both_cancelled(), request_success=True)
@@ -405,7 +377,6 @@ class CancelledElectionTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_one_cancelled_ballot_no_replacement(self):
         ee = EEWrapper(
@@ -422,7 +393,6 @@ class CancelledElectionTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_one_cancelled_ballot_with_replacement(self):
         ee = EEWrapper(
@@ -442,7 +412,6 @@ class CancelledElectionTests(TestCase):
 
     @override_settings(
         EVERY_ELECTION={"CHECK": True, "HAS_ELECTION": True},
-        NEXT_CHARISMATIC_ELECTION_DATES=[],
     )
     def test_one_cancelled_ballot_with_metadata(self):
         ee = EEWrapper(

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -285,6 +285,12 @@ class BasePollingStationView(
 
         ee = self.get_ee_wrapper(context.get("rh"))
         context["has_election"] = ee.has_election()
+        next_election_date = ee.get_next_election_date()
+        context["next_election_date"] = (
+            datetime.strptime(next_election_date, "%Y-%m-%d").date()
+            if next_election_date
+            else None
+        )
         context["multiple_elections"] = ee.multiple_elections
         context["election_explainers"] = ee.get_explanations()
         context["cancelled_election"] = ee.get_cancelled_election_info()

--- a/polling_stations/templates/fragments/advance_opening_times.html
+++ b/polling_stations/templates/fragments/advance_opening_times.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+<div class="ds-table">
+    <table>
+        <tr>
+            <th>{% trans "Date" %}</th>
+            {% comment %}Translators: Opening times, from and to{% endcomment %}
+            <th>{% trans "Open" %}</th>
+        </tr>
+        {% for opening_time in advance_voting_station.opening_times_table %}
+            <tr>
+                <td>{% ifchanged opening_time.0 %}{{ opening_time.0 }}{% endifchanged %}</td>
+                <td>{{ opening_time.1 }} — {{ opening_time.2 }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+</div>

--- a/polling_stations/templates/fragments/advance_voting_station.html
+++ b/polling_stations/templates/fragments/advance_voting_station.html
@@ -11,7 +11,7 @@
 
         {% if advance_voting_station.opening_times %}
             <h4>{% trans "Opening times" %}</h4>
-            {% include "fragments/opening_times.html" %}
+            {% include "fragments/advance_opening_times.html" %}
 
         {% endif %}
 

--- a/polling_stations/templates/fragments/opening_times.html
+++ b/polling_stations/templates/fragments/opening_times.html
@@ -1,16 +1,21 @@
-{% load i18n %}
-<div class="ds-table">
-    <table>
-        <tr>
-            <th>{% trans "Date" %}</th>
-            {% comment %}Translators: Opening times, from and to{% endcomment %}
-            <th>{% trans "Open" %}</th>
-        </tr>
-        {% for opening_time in advance_voting_station.opening_times_table %}
-            <tr>
-                <td>{% ifchanged opening_time.0 %}{{ opening_time.0 }}{% endifchanged %}</td>
-                <td>{{ opening_time.1 }} — {{ opening_time.2 }}</td>
-            </tr>
-        {% endfor %}
-    </table>
-</div>
+{% load i18n_with_welsh %}
+
+<p>
+    {% if has_city_of_london_ballots %}
+        <strong>
+            {% blocktrans %}
+                Polling stations are open from 8am to 8pm for City of London local elections{% endblocktrans %}{% if multiple_elections %}.{% endif %}
+            {% if not multiple_elections and next_election_date %}
+                {% blocktrans %}on {{ next_election_date }}{% endblocktrans %}.
+            {% endif %}
+        </strong>
+        {% blocktrans %}
+            For elections to other organisations (e.g: GLA or Parliament) polling stations will be open from 7am to 10pm.
+        {% endblocktrans %}
+    {% else %}
+        <strong>
+            {% blocktrans %}Polling stations are open from 7am to 10pm{% endblocktrans %}{% if not next_election_date %}.{% endif %}
+            {% if next_election_date %}{% blocktrans %} on {{ next_election_date }}{% endblocktrans %}.{% endif %}
+        </strong>
+    {% endif %}
+</p>

--- a/polling_stations/templates/fragments/polling_station_known.html
+++ b/polling_stations/templates/fragments/polling_station_known.html
@@ -8,7 +8,7 @@
     {% endblocktrans %}
 </h2>
 
-{% if not show_polls_open_card and advance_voting_station and advance_voting_station.open_in_future %}
+{% if advance_voting_station and advance_voting_station.open_in_future %}
     <p>
         {% if NEXT_CHARISMATIC_ELECTION_DATE %}
             {% blocktrans trimmed %}
@@ -53,18 +53,8 @@
             {% endif %}
         </address>
 
-        <p><strong>
-            {% if has_city_of_london_ballots %}
-                {% blocktrans %}Polling stations are open from 8am to 8pm for City of London local elections{% endblocktrans %}{% if not NEXT_CHARISMATIC_ELECTION_DATE %}.{% endif %}
-            {% else %}
-                {% blocktrans %}Polling stations are open from 7am to 10pm{% endblocktrans %}{% if not NEXT_CHARISMATIC_ELECTION_DATE %}.{% endif %}
-            {% endif %}
-            {% if NEXT_CHARISMATIC_ELECTION_DATE %}{% blocktrans %} on {{ NEXT_CHARISMATIC_ELECTION_DATE }}{% endblocktrans %}.{% endif %}
-        </strong>
-            {% if has_city_of_london_ballots %}
-                For elections to other organisations (e.g: GLA or Parliament) polling stations will be open from 7am to 10pm.
-            {% endif %}
-        </p>
+        {% include "fragments/opening_times.html" %}
+
         {% comment %} {% if territory != 'NI' %}
             <p>
                 {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
@@ -89,7 +79,7 @@
     </div>
 {% endif %}
 
-{% if show_polls_open_card and advance_voting_station and not advance_voting_station.open_in_future %}
+{% if advance_voting_station and not advance_voting_station.open_in_future %}
     <div class="ds-card">
         <div class="ds-card-body">
             {% blocktrans %}

--- a/polling_stations/templates/fragments/polling_station_unknown.html
+++ b/polling_stations/templates/fragments/polling_station_unknown.html
@@ -38,15 +38,4 @@
     {% endif %}
 </p>
 
-<p><strong>
-    {% if has_city_of_london_ballots %}
-        {% blocktrans %}Polling stations are open from 8am to 8pm for City of London local elections{% endblocktrans %}{% if not NEXT_CHARISMATIC_ELECTION_DATE %}.{% endif %}
-    {% else %}
-        {% blocktrans %}Polling stations are open from 7am to 10pm{% endblocktrans %}{% if not NEXT_CHARISMATIC_ELECTION_DATE %}.{% endif %}
-    {% endif %}
-    {% if NEXT_CHARISMATIC_ELECTION_DATE %}{% blocktrans %} on {{ NEXT_CHARISMATIC_ELECTION_DATE }}{% endblocktrans %}.{% endif %}
-</strong>
-    {% if has_city_of_london_ballots %}
-        For elections to other organisations (e.g: GLA or Parliament) polling stations will be open from 7am to 10pm.
-    {% endif %}
-</p>
+{% include "fragments/opening_times.html" %}


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1210123314406393?focus=true

First off, a statement of the core problem this PR solves:

If we set one or more `NEXT_CHARISMATIC_ELECTION_DATES` and we also have polling station data imported for other elections happening after that date, we will say "We don't know of any upcoming elections in your area" for areas with "non-charismatic" elections instead of showing a result.
To reproduce this state locally with a checkout from master:

Import data for upcoming `local.nottinghamshire.2025-06-12` and `local.greenwich.2025-06-26`:
- `./manage.py import_mansfield`
- `./manage.py import_greenwich`

Now you will find that if you set `NEXT_CHARISMATIC_ELECTION_DATES = []` searching for SE18 3JL will serve a result (correct/expected) but if you set `NEXT_CHARISMATIC_ELECTION_DATES = ["2025-06-12"]` it will tell you "We don't know of any upcoming elections in your area" (wrong/unexpected).

To fix this, I have mostly removed the use of `NEXT_CHARISMATIC_ELECTION_DATE` and replaced it with `next_election_date` from EE

There are two places where I've kept `NEXT_CHARISMATIC_ELECTION_DATE`.

1. The "polling day is today" card we sometimes show on the homepage. In this case the user hasn't searched for anything yet so we have to rely on a hard-coded value. We can't rely on getting a value from EE.
2. The advance voting stations pilot feature. This is not currently in use and I've slated it as something to possibly remove in https://app.asana.com/1/1204880536137786/project/1205090401342417/task/1210055377993847?focus=true so let's review that then