### PR TITLE
improve performance when deleting lots of councils

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/teardown_expired_data.py
+++ b/polling_stations/apps/data_importers/management/commands/teardown_expired_data.py
@@ -2,8 +2,8 @@ from data_importers.models import DataEvent
 from councils.models import Council
 from django.core.management.base import BaseCommand
 from django.utils import timezone
-from data_importers.management.commands.teardown import Command as TeardownCommand
 from django.core.management.base import CommandParser
+from data_importers.management.commands.teardown import Command as TeardownCommand
 
 
 class Command(BaseCommand):
@@ -51,8 +51,7 @@ class Command(BaseCommand):
                 )
         else:
             cmd = TeardownCommand()
-            for council in councils_to_teardown:
-                cmd.teardown_council(council.council_id)
+            cmd.teardown_councils(councils_to_teardown)
 
             self.stdout.write("")
 

--- a/polling_stations/apps/data_importers/tests/test_teardown_expired_data.py
+++ b/polling_stations/apps/data_importers/tests/test_teardown_expired_data.py
@@ -64,7 +64,7 @@ class TestCleanup(TestCase):
         call_command("teardown_expired_data", stdout=out)
 
         # Should call teardown_council for councilA only
-        mock_cmd_instance.teardown_council.assert_called_once_with("AAA")
+        mock_cmd_instance.teardown_councils.assert_called_once_with([self.councilA])
         output = out.getvalue()
         self.assertIn("Preserving data for: Council B (BBB)...", output)
         self.assertIn("Preserving data for: Council C (CCC)", output)


### PR DESCRIPTION
Fundamentally, this moves us from doing

```py
for council in councils:
    Thing.objects.filter(council=council).delete()
    ...
```

which is slow with lots of councils
to doing

```py
council_ids = [c.id for c in councils]
Thing.objects.filter(council_id__in=council_ids).delete()
...
```

which is much faster.

I'd like to try this again on production to see how it performs with real-life data volume/DB latency before I go ahead and schedule it, but my instinct is this should get the job done well enough without us having to spend a bunch of time on optimising it more :crossed_fingers:

I also tidied up a couple of other bits while I was here.