### PR TITLE
Add termination hook to deployment group

### DIFF
--- a/cdk/stacks/command_runner_stack.py
+++ b/cdk/stacks/command_runner_stack.py
@@ -74,6 +74,17 @@ class WDIVOncePerTagCommandRunner(Stack):
                 command,
             )
 
+        if dc_environment in ["development", "staging", "production"]:
+            command = "runuser -l polling_stations -c '/usr/bin/manage-py-command drop_failed_replication_slots --send-slack-report'"
+            if dc_environment == "staging":
+                # Don't bother to post to bots on staging.
+                command = "runuser -l polling_stations -c '/usr/bin/manage-py-command drop_failed_replication_slots'"
+            self.add_job(
+                "drop_failed_replication_slots",
+                "cron(30 2 * * ? *)",
+                command,
+            )
+
     def add_job(
         self,
         command_name,

--- a/cdk/stacks/command_runner_stack.py
+++ b/cdk/stacks/command_runner_stack.py
@@ -52,6 +52,16 @@ class WDIVOncePerTagCommandRunner(Stack):
                 "cron(1 * * * ? *)",
                 "/usr/bin/manage-py-command import_councils --only-contact-details --database principal",
             )
+            self.add_job(
+                "teardown_expired_data",
+                "cron(0 3 ? * SUN *)",
+                "runuser -l polling_stations -c '/usr/bin/manage-py-command teardown_expired_data",
+            )
+            self.add_job(
+                "run_once_custom_metrics",
+                "rate(5 minutes)",
+                "/var/www/polling_stations/run_once_custom_metrics.sh",
+            )
 
         if dc_environment in ["development", "staging", "production"]:
             command = "runuser -l polling_stations -c '/usr/bin/manage-py-command import_eoni_from_s3 --send-slack-report'"
@@ -62,20 +72,6 @@ class WDIVOncePerTagCommandRunner(Stack):
                 "import_eoni_data_from_s3",
                 "cron(30 1 * * ? *)",
                 command,
-            )
-
-        if dc_environment in ["development", "staging", "production"]:
-            self.add_job(
-                "run_once_custom_metrics",
-                "rate(5 minutes)",
-                "/var/www/polling_stations/run_once_custom_metrics.sh",
-            )
-
-        if dc_environment in ["development", "staging", "production"]:
-            self.add_job(
-                "teardown_expired_data",
-                "cron(0 3 ? * SUN *)",
-                "runuser -l polling_stations -c '/usr/bin/manage-py-command teardown_expired_data",
             )
 
     def add_job(

--- a/polling_stations/apps/core/slack_client.py
+++ b/polling_stations/apps/core/slack_client.py
@@ -12,7 +12,13 @@ class SlackChannelNotFoundError(Exception):
 
 
 class SlackClient:
-    def __init__(self, token: Optional[str] = None, channel: str = "bots", stdout=None):
+    def __init__(
+        self,
+        token: Optional[str] = None,
+        channel: str = "bots",
+        stdout=None,
+        username: str = "WDIV Bot",
+    ):
         self.stdout = stdout or sys.stdout
         self.token = token or os.getenv("SLACK_TOKEN")
         if not self.token:
@@ -23,6 +29,7 @@ class SlackClient:
         self.client = WebClient(token=self.token)
         self.channel = channel
         self.channel_id = self.get_channel_id_from_name(self.channel)
+        self.username = username
 
     def get_channel_id_from_name(self, channel_name: str) -> Optional[str]:
         conversation_id = None
@@ -54,6 +61,7 @@ class SlackClient:
                 thread_ts=thread_ts,
                 blocks=blocks,
                 icon_emoji=":robot_face:",
+                username=self.username,
             )
 
             return response.data

--- a/polling_stations/apps/core/tests/test_slack_client.py
+++ b/polling_stations/apps/core/tests/test_slack_client.py
@@ -87,6 +87,7 @@ class TestSlackClient:
             thread_ts=None,
             blocks=None,
             icon_emoji=":robot_face:",
+            username="WDIV Bot",
         )
         assert response == {"ok": True, "ts": "1234567890.123456"}
 
@@ -104,6 +105,7 @@ class TestSlackClient:
             thread_ts="1234567890.123456",
             blocks=None,
             icon_emoji=":robot_face:",
+            username="WDIV Bot",
         )
 
     def test_send_message_with_blocks(self, mock_webclient, mock_env_token):
@@ -121,6 +123,7 @@ class TestSlackClient:
             thread_ts=None,
             blocks=blocks,
             icon_emoji=":robot_face:",
+            username="WDIV Bot",
         )
 
     def test_send_message_api_error(self, mock_webclient, mock_env_token):

--- a/polling_stations/management/commands/drop_failed_replication_slots.py
+++ b/polling_stations/management/commands/drop_failed_replication_slots.py
@@ -1,0 +1,149 @@
+from datetime import date
+from typing import Dict, Any
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from core.slack_client import SlackClient
+from settings.constants.slack import BOTS_CHANNEL, BOTS_TESTING_CHANNEL
+from polling_stations.db_routers import (
+    get_principal_db_name,
+    get_principal_db_connection,
+)
+
+DB_NAME = get_principal_db_name()
+
+
+class Command(BaseCommand):
+    help = "Checks for failed replication slots in RDS and drops them, then reports to Slack"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.post_to_slack = False
+        self.dc_environment = None
+        self.cursor = get_principal_db_connection().cursor()
+        self.slack_client = SlackClient(channel=self.slack_channel)
+        self.failed_slots = []
+        self.drop_succeeded = []
+        self.drop_failed = []
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--send-slack-report",
+            action="store_true",
+            help="Ask import_eoni command to report to slack",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            self.dc_environment = settings.DC_ENVIRONMENT
+            self.post_to_slack = options.get("post_to_slack")
+            self.check_replication_slots()
+
+            if self.failed_slots:
+                self.drop_failed_slots()
+                self.report_to_slack()
+                return
+
+            if date.today().weekday() == 0:
+                # Report once a week even if no failed slots found, so we know bot is working.
+                self.report_to_slack()
+                return
+
+        except Exception as e:
+            self.send_failure_to_slack(e)
+            raise e
+
+    @property
+    def slack_channel(self):
+        if self.dc_environment == "production":
+            return BOTS_CHANNEL
+        else:
+            return BOTS_TESTING_CHANNEL
+
+    def check_replication_slots(self):
+        with get_principal_db_connection().cursor() as cursor:
+            query = """
+                    SELECT
+                        slot_name
+                    FROM pg_replication_slots
+                    WHERE
+                       active = 'f'
+                       AND database = %s
+                    ORDER BY slot_name;
+                    """
+
+            cursor.execute(query, [DB_NAME])
+
+            for row in cursor.fetchall():
+                self.failed_slots.append(row[0])
+
+    def report_to_slack(self):
+        if not self.post_to_slack:
+            return
+        try:
+            response = self.post_thread_header()
+            thread_ts = response.get("ts")
+            if self.failed_slots:
+                self.post_failed_details(thread_ts)
+            else:
+                self.post_check_running(thread_ts)
+        except Exception as e:
+            self.stderr.write(self.style.ERROR(f"Error posting to Slack: {str(e)}"))
+            raise e
+
+    def post_thread_header(self) -> Dict[str, Any]:
+        return self.slack_client.send_message(
+            message=":clipboard: *Replication Slot Check*"
+        )
+
+    def post_failed_details(self, thread_ts):
+        if self.drop_succeeded:
+            self.slack_client.send_message(
+                message=f":white_check_mark: Dropped {len(self.drop_succeeded)} failed replication slots:\n{'\n'.join(self.drop_succeeded)}",
+                thread_ts=thread_ts,
+            )
+        if self.drop_failed:
+            self.slack_client.send_message(
+                message=f":warning: Failed to drop {len(self.drop_failed)} failed replication slots:\n{'\n'.join(self.drop_failed)}",
+                thread_ts=thread_ts,
+            )
+
+    def post_check_running(self, thread_ts):
+        self.slack_client.send_message(
+            "No failed slots found. Nightly checks are still running.",
+            thread_ts=thread_ts,
+        )
+
+    def drop_replication_slot(self, cursor, slot_name):
+        """Drop a replication slot"""
+        try:
+            self.stdout.write(f"Dropping slot {slot_name}...")
+            cursor.execute("SELECT pg_drop_replication_slot(%s);", [slot_name])
+            self.drop_succeeded.append(slot_name)
+        except Exception as e:
+            self.stdout.write(
+                self.style.ERROR(f"Error dropping slot '{slot_name}': {str(e)}")
+            )
+            self.drop_failed.append(slot_name)
+
+    def drop_failed_slots(self):
+        with get_principal_db_connection().cursor() as cursor:
+            for slot in self.failed_slots:
+                self.drop_replication_slot(cursor, slot)
+
+    def send_failure_to_slack(self, exception: Exception):
+        if not self.post_to_slack:
+            return
+        try:
+            response = self.slack_client.send_message(
+                message=":warning: *drop_failed_replication_slots command failed*",
+            )
+            self.slack_client.send_message(
+                message=f"Error: {str(exception)}", thread_ts=response.get("ts")
+            )
+
+        except Exception as slack_err:
+            self.stderr.write(f"Error posting to Slack: {str(slack_err)}")
+            raise slack_err


### PR DESCRIPTION
### What this pr is doing

Setting up a cron job to drop failed replication slots and report to slack. This will hopefully give us some visibility on the issue, and let us debug it better. It will also stop the stored wal files getting too big and causing problems. 

-----------------
Below this line is not so relevant for the PR as it currently stands.

------------------

### What's the problem?

When we do more deploys/deploys involving more instances we end up with inactive replication slots on RDS.
These can be seen by running:

```sql
=> select * from pg_replication_slots where active = 'f';
```

### What's been done here?

Add an `AfterBlockTraffic` hook, and make sure it runs when we drop the instance count in the ASG.

We're running codedeploy blue/green deployments. The order of the hooks in a deployment are described
[here](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html#reference-appspec-file-structure-hooks-run-order) (scroll down to `Blue/green deployments` section).

This makes it seem like the `AfterBlockTraffic` hook would be the perfect place to run:

```
systemctl stop polling_stations_db_replication.service
```

This should call the `ExecStop` section of `deploy/files/systemd/db_replication.service`. Which in turn runs the script at `deploy/files/scripts/remove_db_replication.sh`.
Which in turn drops the subscription which should tell the publisher to get rid of any replication slots.

There are two kinds of deployments which happen.

1. User action
These are normally the result of a new commit on `master`. As part of CI the `deploy/create_deployment.py` script is called. This kicks of a new deploy.

2. Auto Scaling group action
This results from bumping the desired instance count on the ASG. This might be done in the console, or in code, which will then be implemented by the `deploy/update_autoscaling_group.py`

My reading of the docs is that the `AfterBlockTraffic` hook will be picked up by the instances terminated as part of User Action deploys, but maybe not in the case of AutoScaling deploys.
However AWS seems to have a mechanism for this, 'termination deploys' [docs](https://docs.aws.amazon.com/codedeploy/latest/userguide/integrations-aws-auto-scaling.html#integrations-aws-auto-scaling-behaviors-hook-enable).
I've enabled these with `terminationHookEnabled=True,` in the `deploy/create_deployment_group.py` script. That's really just record keeping though, because the deployment group is only created once, (and so that script is normally a no-op). So I actually just went in and did it in the 

In summary there are two things this PR does. First adding in an `AfterBlockTraffic` hook to `appspec.yml`. Second making sure this runs on AutoScaling scale out (dropping the instance number) events.

The second part works (i.e. we get termination deploys when dropping the ASG desired count). Sadly afaict the `AfterBlockTraffic` hook doesn't run in either case. My way of verifying this is to look at the syslog in cloudwatch. Also when playing with cranking the ASG desired count up and down I got a few failed slots.

#### Gotcha when working with  the `AfterBlockTraffic` hook

The hook needs to be on the instance where you want it to run.
So if you update `appspec.yml` and do a deploy, the outgoing instances in that deploy won't have your latest changes on them, so they won't do the thing you want.
You need to do _another_ deploy, so that the instances being removed are the ones with your new `appspec.yml`. This is obviously boring.


### Next steps.

The simplest option is probably still to just write a cron job that does:

 ```sql
 select pg_drop_replication_slot(slot_name) from pg_replication_slots where active = 'f';
```

Otherwise I think creating an `AfterBlockTraffic` hook that explicitly logs something, and trying to get that to run is the next step. the [docs](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html) say  `AfterBlockTraffic – You can use this deployment lifecycle event to run tasks on instances after they are deregistered from their respective load balancer.` I haven't looked at what's going on with the load balancer during a deployment, but that's maybe something to check.
