### PR TITLE
disable EE sync jobs

### DIFF
--- a/deploy/files/conf/crontab
+++ b/deploy/files/conf/crontab
@@ -4,8 +4,8 @@
 MAILTO=developers@democracyclub.org.uk
 
 # Sync elections from EE
-*/5 * * * * every_election /usr/local/bin/ee-manage-py-command sync_elections
-0 2 * * * every_election cd /var/www/every_election/repo && ./serverscripts/rebuild_local_db.sh
+# */5 * * * * every_election /usr/local/bin/ee-manage-py-command sync_elections
+# 0 2 * * * every_election cd /var/www/every_election/repo && ./serverscripts/rebuild_local_db.sh
 
 # Per instance cloudwatch custom metrics
 */5  * * * * polling_stations /var/www/polling_stations/per_instance_custom_metrics.sh


### PR DESCRIPTION
We had these running in case we needed to switch back to embedded EE
Since we merged https://github.com/DemocracyClub/EveryElection/pull/2477 this is now throwing https://democracy-club-gp.sentry.io/issues/6710014055 because the model code in the image is out of sync with the DB schema.
Lets just disable these for now