### PR TITLE
fix example page maps

### DIFF
--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -321,7 +321,6 @@ class BasePollingStationView(
         context["show_map"] = self.show_map(context)
 
         self.log_postcode(self.postcode, context, type(self).__name__)
-
         return context
 
 
@@ -446,6 +445,7 @@ class ExamplePostcodeView(BasePollingStationView):
         context["error"] = None
         context["requires_voter_id"] = True
         context["noindex"] = True
+        context["show_map"] = True
         return context
 
 


### PR DESCRIPTION
This PR fixes the missing map on the example page. Have deployed to dev (https://dev.wdiv.club/example/) to test and it did fix the issue.

(Can also test locally by settings EVERY_ELECTION["CHECK"] = True in local.py to simulate prod)

The reason the map disappeared is because [`show_map`](https://github.com/DemocracyClub/UK-Polling-Stations/blob/43db8b3560d7fb1c67e649ce453c94d92c8f8275/polling_stations/apps/data_finder/views.py#L222) was added the context of `BasePollingStationView`, but it wasn't overwritten in `ExamplePostcodeView`'s [context](https://github.com/DemocracyClub/UK-Polling-Stations/blob/43db8b3560d7fb1c67e649ce453c94d92c8f8275/polling_stations/apps/data_finder/views.py#L438C15-L449C23).

The problem didn't show up in local dev because [has_election](https://github.com/DemocracyClub/UK-Polling-Stations/blob/43db8b3560d7fb1c67e649ce453c94d92c8f8275/polling_stations/apps/data_finder/views.py#L231) is always set to True locally, so show_map returns True locally, but False in production. And the `has_election` [override](https://github.com/DemocracyClub/UK-Polling-Stations/blob/43db8b3560d7fb1c67e649ce453c94d92c8f8275/polling_stations/apps/data_finder/views.py#L444) in `ExamplePostcodeView` didn't have any effect because show_map was only set in the `BasePollingStationView` context.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211063976539354