### PR TITLE
Include postcode in postcode location properties

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -181,9 +181,12 @@ class AddressViewSet(ViewSet):
         try:
             geocoded_postcode = geocoder(address.postcode)
             location = geocoded_postcode.centroid
+            ret["postcode_location"] = {
+                "point": location,
+                "properties": {"postcode": address.postcode},
+            }
         except PostcodeError:
-            location = None
-        ret["postcode_location"] = location
+            ret["postcode_location"] = None
 
         ret["polling_station_known"] = False
         ret["polling_station"] = None

--- a/polling_stations/apps/api/fields.py
+++ b/polling_stations/apps/api/fields.py
@@ -11,12 +11,17 @@ class PointField(serializers.Field):
     def to_representation(self, value):
         """
         Transform POINT object to a geojson feature.
+        Value should be a dict with 'point' and 'properties' keys, where the values are a GEOS Point and a dict.
         """
+
         if value is None:
             return value
 
+        point = value["point"]
+        properties = value.get("properties", None)
+
         return {
             "type": "Feature",
-            "properties": None,
-            "geometry": {"type": "Point", "coordinates": [value.x, value.y]},
+            "properties": properties,
+            "geometry": {"type": "Point", "coordinates": [point.x, point.y]},
         }

--- a/polling_stations/apps/api/postcode.py
+++ b/polling_stations/apps/api/postcode.py
@@ -91,7 +91,10 @@ class PostcodeViewSet(ViewSet):
         except PostcodeError as e:
             return Response({"detail": e.args[0]}, status=400)
 
-        ret["postcode_location"] = location
+        ret["postcode_location"] = {
+            "point": location,
+            "properties": {"postcode": postcode.with_space},
+        }
 
         # council object
         if rh.councils or not loc:


### PR DESCRIPTION
This adds the postcode to the properties of the `postcode_location` field. 

The reason for doing this is to make it easier to log the postcode associated with a uprn in the aggregator api and the EC api. 

I've tested it locally on aggregator api, and it just funnels the `properties` value through as expected. I don't think there's any need to update response builder, because `properties` is defined as `Optional[Dict[str, Any]]` ([src](https://github.com/DemocracyClub/dc_response_builder/blob/cd645bdd6db2b704bb23d6e077e6700d36f12773/response_builder/v1/models/base.py#L232)).

If this is merged it will  change the responses from aggregator api and ec api, so we'll need to update sandbox responses/doc examples in those repos. 