### PR TITLE
prevent call to EE under test

### DIFF
--- a/polling_stations/apps/data_finder/tests/test_views.py
+++ b/polling_stations/apps/data_finder/tests/test_views.py
@@ -24,6 +24,7 @@ from unittest import mock
 
 
 class LogTestMixin:
+    @override_settings(EVERY_ELECTION={"CHECK": False, "HAS_ELECTION": False})
     def test_dc_logging(self):
         with self.assertLogs(level="DEBUG") as captured:
             self.client.get(


### PR DESCRIPTION
Build is currently failing on main.
The error sits at the intersection of 2 bad decisions:
1. A long time ago, Chris-from-the-past decided that AA1 1AA, BB1 1BB, CC1 1CC, DD1 1DD were good postcodes to use in the test data. This was a bad decision because while AA1 1AA and CC1 1CC are definitely not real postcodes, BB1 1BB is a real postcode in Blackburn and DD1 1DD is a real postcode in Dundee. We should probably make all the test data postcodes that look real but use an outcode that definitely doesn't exist but I am not going to shave that yak today.
2. This code wasn't faking or mocking the call to EE, so creating an election in Blackburn and Darwen changed the result of the test.

So I've fixed problem 2 by making the test not call out to EE but problem 1 still exists.