### PR TITLE
add 'has a11y info' to stations table

### DIFF
--- a/polling_stations/apps/file_uploads/templates/file_uploads/council_detail.html
+++ b/polling_stations/apps/file_uploads/templates/file_uploads/council_detail.html
@@ -160,7 +160,10 @@
                         <th>Station Address</th>
                         <th>Station Postcode</th>
                         <th>Map Showing<br><small style="font-weight: normal;"><a href="https://democracyclub.org.uk/projects/polling-stations/upload/#Mapping">More Info</a></small></th>
-                        <th>Examples</th>
+                        {% if council.nation == "Wales" and user.is_staff %}
+                            <th>A11y info</th>
+                        {% endif %}
+                        <th>Example</th>
                     </tr>
                     {% for station in STATIONS %}
                         {% if station.example_uprn %}
@@ -184,6 +187,9 @@
                                 </td>
                                 <td>{{ station.postcode }}</td>
                                 <td>{{ station.location }} </td>
+                                {% if council.nation == "Wales" and user.is_staff %}
+                                    <td>{{ station.accessibility_information }}</td>
+                                {% endif %}
                                 <td>
                                     <a href={%  url "address_view" station.example_uprn %}>Example page</a>
                                     <br>

--- a/polling_stations/apps/file_uploads/views.py
+++ b/polling_stations/apps/file_uploads/views.py
@@ -284,12 +284,17 @@ class CouncilDetailView(CouncilFileUploadAllowedMixin, CouncilView, DetailView):
         station_to_example_uprn_map = get_station_to_example_uprn_map(
             council_from_default_db
         )
-        for station in council_from_default_db.pollingstation_set.all():
+        for station in council_from_default_db.pollingstation_set.all().select_related(
+            "accessibility_information"
+        ):
             context["STATIONS"].append(
                 {
                     "address": station.address,
                     "postcode": station.postcode,
                     "location": "✔️" if station.location else "❌",
+                    "accessibility_information": "✔️"
+                    if getattr(station, "accessibility_information", None)
+                    else "❌",
                     "example_uprn": get_example_uprn(
                         station, station_to_example_uprn_map
                     ),


### PR DESCRIPTION
This adds a column to the stations table showing if we've got accessibility info for this station.

Because only admins can upload this info, the column is only showed to admins.

I also filtered it to just Wales because I think it is better not to waste a column on information we don't expect to hold in other areas for the time being.