### PR TITLE
add line about election coverage to upload page

### DIFF
--- a/polling_stations/apps/file_uploads/templates/file_uploads/council_detail.html
+++ b/polling_stations/apps/file_uploads/templates/file_uploads/council_detail.html
@@ -68,6 +68,7 @@
 
         {% else %}
             <p>We've not received any data for future elections yet.</p>
+            <p>Please note that this service does not support town, parish, or community council elections. </p>
         {% endif %}
         <div class="ds-cluster">
             <a href="{% url 'file_uploads:file_upload' gss=object.council_id %}" class="ds-cta ds-cta-blue" style="margin: 0.85rem;">


### PR DESCRIPTION
Adds a line about the types of elections we don't cover to the upload page.

before:
<img width="974" height="679" alt="image" src="https://github.com/user-attachments/assets/43b641fa-5e90-4371-aa09-2c79198be8c0" />

after:
<img width="742" height="580" alt="image" src="https://github.com/user-attachments/assets/67f9391f-55c1-40a5-bc7e-58301939c690" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212474924285160