### PR TITLE
only show a11y note blocks if we have text in target language

### DIFF
--- a/polling_stations/templates/fragments/at_the_station.html
+++ b/polling_stations/templates/fragments/at_the_station.html
@@ -42,7 +42,7 @@
         </li>
     {% endif %}
 </ul>
-{% if station.accessibility_information.at_the_station %}
+{% if station.accessibility_information.at_the_station_text %}
     <p>
         <strong>{% trans "The electoral services team have added a note about this station:" %}</strong>
     </p>

--- a/polling_stations/templates/fragments/getting_to_the_station.html
+++ b/polling_stations/templates/fragments/getting_to_the_station.html
@@ -9,7 +9,7 @@
 {% if directions.time %}
     {% include "fragments/travel_time.html" %}
 {% endif %}
-{% if station.accessibility_information.getting_to_the_station %}
+{% if station.accessibility_information.getting_to_the_station_text %}
     <p>
         <strong>{% trans "The electoral services team have added a note about getting to this station:" %}</strong>
     </p>


### PR DESCRIPTION
Before we were showing these blocks for both languages, even if we had English text but no translation