### PR TITLE
Update SECURE_REFERRER_POLICY to strict-origin-when-cross-origin

### DIFF
--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -299,6 +299,17 @@ CORS_ORIGIN_WHITELIST = ()
 CORS_URLS_REGEX = r"^/(api|embed)/.*$"
 
 INTERNAL_IPS = "127.0.0.1"
+
+# Django's SecurityMiddleware defaults to "same-origin", which prevents the browser from sending
+# the Referer header on cross-origin requests, e.g. to tile.openstreetmap.org.
+# "strict-origin-when-cross-origin" sends the origin (i.e. up to, and including the tld) as the
+# referer on cross-origin requests.
+# This doesn't give any information about which specific page on our site a user was visiting
+# (i.e. which might contain postcode/uprn) just that they came from one of our sits.
+# refs:
+#       - https://docs.djangoproject.com/en/5.2/ref/middleware/#referrer-policy
+#       - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 SITE_TITLE = _("Where Do I Vote?")
 
 TEST_RUNNER = "django.test.runner.DiscoverRunner"


### PR DESCRIPTION
I went with `strict-origin-when-cross-origin` mainly because [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy#strict-origin-when-cross-origin_2) suggests it is a default. 

I think the reason django says "don't send a referrer header" is because of the privacy concern with showing that a user has visited our site. This is actually really relevant on our sites where we will often have captured a users postcode or even uprn in the url. Since we do need to send something in the referrer header to OSM sending just the 'origin', (eg `www.wheredoivote.co.uk`) this seems like a reasonable compromise.

You can see the change by running the dev server on this branch, and then running `curl -I http://localhost:8000/` to get the response headers. If you then look at a map page (requires some imported stations) and open dev tools you can see there's a referrer header set on the requests to OSM. 

<img width="834" height="439" alt="image" src="https://github.com/user-attachments/assets/fcec380b-3926-4177-a92c-054bcd901533" />
 