### PR TITLE
Improve import logging

### DIFF
--- a/polling_stations/apps/data_importers/data_types.py
+++ b/polling_stations/apps/data_importers/data_types.py
@@ -6,6 +6,7 @@ import abc
 import logging
 from collections import namedtuple
 
+
 from addressbase.models import Address, UprnToCouncil, get_uprn_hash_table
 from councils.models import Council
 from pollingstations.models import PollingDistrict, PollingStation
@@ -301,21 +302,29 @@ class AddressList(AssignPollingStationsMixin):
                 )
         self.elements = [e for e in self.elements if e["uprn"].isdigit()]
 
-    # TODO be more clever to report on duplicates.
     def remove_duplicate_uprns(self):
         uprn_lookup = self.get_uprn_lookup()
-
-        duplicate_count = len(
-            [e for e in self.elements if len(uprn_lookup[e["uprn"]]) > 1]
-        )
-        if duplicate_count >= 1:
+        duplicate_uprns = {
+            uprn: stations
+            for uprn, stations in uprn_lookup.items()
+            if len(stations) > 1
+        }
+        if duplicate_uprns:
+            duplicate_address_count = sum(
+                1 for e in self.elements if e["uprn"] in duplicate_uprns
+            )
             self.logger.log_message(
                 logging.WARNING,
-                f"{duplicate_count} UPRNs are assigned to more than one station in council data. These have been discarded.",
+                f"{duplicate_address_count} UPRNs are assigned to more than one station in council data. These have been discarded.",
             )
+            for uprn, stations in sorted(duplicate_uprns.items()):
+                self.logger.log_message(
+                    logging.INFO,
+                    f'"UPRN_ASSIGNED_MULTIPLE_STATIONS","{uprn}","{stations}"',
+                )
 
         self.elements = [
-            record for record in self.elements if len(uprn_lookup[record["uprn"]]) == 1
+            record for record in self.elements if record["uprn"] not in duplicate_uprns
         ]
 
     def get_polling_station_lookup(self):
@@ -330,14 +339,20 @@ class AddressList(AssignPollingStationsMixin):
         return polling_station_lookup
 
     def remove_records_not_in_addressbase(self, addressbase_data):
-        not_in_address_base_count = len(
-            [e for e in self.elements if e["uprn"] not in addressbase_data]
-        )
-        if not_in_address_base_count >= 1:
+        not_in_addressbase = [
+            e for e in self.elements if e["uprn"] not in addressbase_data
+        ]
+        if not_in_addressbase:
             self.logger.log_message(
                 logging.WARNING,
-                f"{not_in_address_base_count} UPRNs from council data not found in addressbase. These have been discarded.",
+                f"{len(not_in_addressbase)} UPRNs from council data not found in addressbase. These have been discarded.",
             )
+            for record in not_in_addressbase:
+                self.logger.log_message(
+                    logging.INFO,
+                    f'"UPRN_MISSING_IN_ADDRESSBASE","{record.get("uprn")}", "{record.get("address")}", "{record.get("postcode")}"',
+                )
+
         self.elements = [e for e in self.elements if e["uprn"] in addressbase_data]
 
     def remove_records_that_dont_match_addressbase(self, addressbase_data):
@@ -357,15 +372,26 @@ class AddressList(AssignPollingStationsMixin):
                 logging.WARNING,
                 f"{len(to_remove)} council records UPRNs found in addressbase but postcodes don't match. These have been discarded.",
             )
+            for record in to_remove:
+                self.logger.log_message(
+                    logging.INFO,
+                    f'"POSTCODE_DIFFERS","{record.get("uprn")}", "{record.get("address")}", "{record.get("postcode")}"',
+                )
         self.elements = [e for e in self.elements if e not in to_remove]
 
     def remove_records_missing_uprns(self):
-        uprn_missing_count = len([e for e in self.elements if not e.get("uprn")])
-        if uprn_missing_count >= 1:
+        missing_uprn_records = [e for e in self.elements if not e.get("uprn")]
+        if missing_uprn_records:
             self.logger.log_message(
                 logging.WARNING,
-                f"{uprn_missing_count} Addresses are missing a UPRN in council data. These have been discarded",
+                f"{len(missing_uprn_records)} Addresses are missing a UPRN in council data. These have been discarded",
             )
+            for record in missing_uprn_records:
+                self.logger.log_message(
+                    logging.INFO,
+                    f'"UPRN_MISSING_IN_COUNCIL_DATA","{record.get("address")}", "{record.get("postcode")}"',
+                )
+
         self.elements = [e for e in self.elements if e.get("uprn", None)]
 
     def check_split_postcodes_are_split(self, split_postcodes):


### PR DESCRIPTION
* Councils seem to often have a 'placeholder' for when they don't have a UPRN, eg `N/A`. The duplicate uprn check did inadvertent double duty at stripping this. [6c82d0a](https://github.com/DemocracyClub/UK-Polling-Stations/pull/9196/commits/6c82d0a1d6bca112e79b2bdc08ce63fc65844b84) catches non numeric uprns, reducing the false positives in the duplicate check. This doesn't deal with placeholders like `99999999999`. 
* Previously we didn't get loads more information when running an import with `-v 3`. [e2cb7de](https://github.com/DemocracyClub/UK-Polling-Stations/pull/9196/commits/e2cb7ded5de021951c9f5ec1aaac7dd9bdfe6fb7) improves that.

I've added in pseudo 'error codes'. I'd like to actually enumerate these in a class, and eventually write these infos to the db so we can expose them on the site somewhere. But thought I'd do this as a first pass since it was mostly needed to deal with a query we had. 
