### PR TITLE
use correct words for Scotland: Council/Returning Officer

### DIFF
--- a/polling_stations/templates/fragments/contact_details.html
+++ b/polling_stations/templates/fragments/contact_details.html
@@ -10,7 +10,11 @@
         {% else %}
             <h3>
                 <span aria-hidden="true">📇</span>
-                {% trans "Council Contact info" %}
+                {% if council.nation == "Scotland" %}
+                    {% trans "Returning Officer Contact info" %}
+                {% else %}
+                    {% trans "Council Contact info" %}
+                {% endif %}
             </h3>
         {% endif %}
         <address>


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1213760944792634?focus=true

Fortunately, we don't refer to this in many places on this site