### PR TITLE
Pilot info url

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -69,9 +69,17 @@ class AddressSerializer(serializers.HyperlinkedModelSerializer):
 class AdvanceVotingStationSerializer(serializers.ModelSerializer):
     class Meta:
         model = AdvanceVotingStation
-        fields = ("name", "address", "postcode", "location", "opening_times")
+        fields = (
+            "name",
+            "address",
+            "postcode",
+            "location",
+            "opening_times",
+            "pilot_info_url",
+        )
 
     opening_times = serializers.SerializerMethodField()
+    pilot_info_url = serializers.SerializerMethodField()
 
     @extend_schema_field(
         {
@@ -85,6 +93,10 @@ class AdvanceVotingStationSerializer(serializers.ModelSerializer):
     def get_opening_times(self, obj: AdvanceVotingStation):
         #
         return obj.opening_times_table
+
+    @extend_schema_field(OpenApiTypes.URI)
+    def get_pilot_info_url(self, obj: AdvanceVotingStation):
+        return settings.PILOT_LINKS_2026.get(obj.council_id)
 
 
 class BallotSerializer(serializers.Serializer):

--- a/polling_stations/apps/api/tests/test_address.py
+++ b/polling_stations/apps/api/tests/test_address.py
@@ -266,6 +266,30 @@ class AddressTest(TestCase):
         self.assertEqual(len(stations), 1)
         self.assertEqual(stations[0].pk, avs.pk)
 
+    def test_advance_voting_station_includes_pilot_info_url(self):
+        CouncilFactory(council_id="CAB")
+        utc = UprnToCouncil.objects.get(pk="200")
+        avs = AdvanceVotingStationFactory(
+            council_id="CAB",
+            opening_times=[["2099-01-01", "08:00", "20:00"]],
+        )
+        utc.advance_voting_stations.add(avs)
+
+        response = self.endpoint.retrieve(
+            self.request,
+            "200",
+            "json",
+            geocoder=mock_geocode,
+            log=False,
+        )
+
+        stations = response.data["alternative_voting_stations"]
+        self.assertEqual(len(stations), 1)
+        self.assertEqual(
+            stations[0]["pilot_info_url"],
+            "https://www.cambridge.gov.uk/early-voting-trial/",
+        )
+
     def test_bad_slug(self):
         # this address is not in our fixture
         response = self.endpoint.retrieve(

--- a/polling_stations/apps/data_finder/tests/test_views.py
+++ b/polling_stations/apps/data_finder/tests/test_views.py
@@ -258,7 +258,10 @@ class AddressViewTestCase(TestCase):
         self.assertFalse(context["we_know_where_you_should_vote"])
         self.assertIsNone(context["station"])
 
-    @override_settings(SHOW_ADVANCE_VOTING_STATIONS=True)
+    @override_settings(
+        SHOW_ADVANCE_VOTING_STATIONS=True,
+        PILOT_LINKS_2026={"X01": "www.councilx.gov.uk/flexible-pilot-info/"},
+    )
     def test_advance_voting_stations_prefetched(self):
         address = Address.objects.get(uprn="100")
         uprn = address.uprntocouncil

--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -332,6 +332,12 @@ class BasePollingStationView(
         context["polling_day_hubs"] = polling_day_hubs
         context["advance_hubs"] = advance_hubs
 
+        context["pilot_info_url"] = None
+        if polling_day_hubs or advance_hubs:
+            context["pilot_info_url"] = settings.PILOT_LINKS_2026[
+                self.council.council_id
+            ]
+
         context["requires_voter_id"] = ee.get_voter_id_status()
         context["has_city_of_london_ballots"] = ee.has_city_of_london_ballots
 

--- a/polling_stations/settings/constants/councils.py
+++ b/polling_stations/settings/constants/councils.py
@@ -70,3 +70,9 @@ SP_CONSTITUENCY_26_BALLOT_TO_COUNCIL = {
     "sp.c.renfrewshire-west-and-levern-valley.2026-05-07": "RFW",  # Renfrewshire Council
     "sp.c.uddingston-and-bellshill.2026-05-07": "NLK",  # North Lanarkshire Council
 }
+
+PILOT_LINKS_2026 = {
+    "CAB": "https://www.cambridge.gov.uk/early-voting-trial/",
+    "MIK": "https://www.milton-keynes.gov.uk/your-council-and-elections/elections-and-register-vote/central-voting-hub-trial/",
+    "TUN": "https://tunbridgewells.gov.uk/council/voting-and-elections/elections/voter-hubs/",
+}

--- a/polling_stations/templates/fragments/polling_station_known.html
+++ b/polling_stations/templates/fragments/polling_station_known.html
@@ -10,6 +10,8 @@
 
 {% include "fragments/voting_pilot_intro.html" %}
 
+{% include "fragments/advance_hubs.html" %}
+
 <div class="ds-card" id="vote-on-polling-day">
     <div class="ds-card-body">
         {% if polling_day_hubs %}
@@ -63,5 +65,3 @@
         </div>
     {% endif %}
 {% endif %}
-
-{% include "fragments/advance_hubs.html" %}

--- a/polling_stations/templates/fragments/voting_pilot_intro.html
+++ b/polling_stations/templates/fragments/voting_pilot_intro.html
@@ -4,6 +4,7 @@
     <div class="ds-status-message" >
         {% trans "Your council is part of a flexible voting pilot." %}
         <br>
+
         {% if advance_hubs and polling_day_hubs %}
             {% blocktrans trimmed %}
                 You can vote at a voting hub
@@ -25,5 +26,9 @@
                 on polling day.
             {% endblocktrans %}
         {% endif %}
+        <br>
+        {% blocktrans with pilot_info_url as pilot_info_url %}
+            Your council has <a href="{{ pilot_info_url }}">more information on the pilot</a>
+        {% endblocktrans %}
     </div>
 {% endif %}


### PR DESCRIPTION
Snuck in the reordering too...

I've put the link on every `AdvanceVotingStation` object rather than change `alternative_voting_stations` to be an object. I figured this involved less change to the API even if we're the only ones to use it. I guess I could've put a top level sibling key, but not sure it matters given most of this code should be deleted.