### PR TITLE
add noindex header on multiple_councils

### DIFF
--- a/polling_stations/apps/data_finder/views.py
+++ b/polling_stations/apps/data_finder/views.py
@@ -560,6 +560,7 @@ class MultipleCouncilsView(TemplateView, LogLookUpMixin, LanguageMixin):
     def get_context_data(self, **context):
         context["councils"] = Council.objects.filter(council_id__in=self.council_ids)
         context["territory"] = self.postcode.territory
+        context["noindex"] = True
 
         log_data = {
             "we_know_where_you_should_vote": False,


### PR DESCRIPTION
This is a bit of an odd page. I wonder if it even needs to exist at all any more. That's a question for another day, but it definitely shouldn't be indexed by search engines. I randomly spotted one of these in my search results today.