### PR TITLE
Disable welsh translations on frontend

### DIFF
--- a/polling_stations/settings/base.py
+++ b/polling_stations/settings/base.py
@@ -252,9 +252,10 @@ LOGGING = {
 }
 
 LANGUAGE_CODE = "en"
+# Welsh is temporarily disabled while translations are being sorted out.
 LANGUAGES = [
     ("en", "English"),
-    ("cy", "Welsh"),
+    # ("cy", "Welsh"),
 ]
 USE_I18N = (True,)
 

--- a/polling_stations/templates/base.html
+++ b/polling_stations/templates/base.html
@@ -29,25 +29,27 @@
 {% endblock top_banner %}
 
 {% block base_language_menu %}
-    <aside class="ds-language" aria-labelledby="language-label">
-        <form action="{% url 'set_language' %}" method="post">
-            {% csrf_token %}
-            <input name="next" type="hidden" value="{{ request.get_full_path }}">
-            <ul>
-                <li id="language-label" aria-hidden="true">{% trans "Language:" %}</li>
-                {% get_current_language as LANGUAGE_CODE %}
-                {% get_available_languages as LANGUAGES %}
-                {% get_language_info_list for LANGUAGES as languages %}
-                {% for language in languages %}
-                    <li>
-                        <button name="language" value="{{ language.code }}" lang="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} aria-current="true"{% endif %}>
-                            {{ language.name_local }}
-                        </button>
-                    </li>
-                {% endfor %}
-            </ul>
-        </form>
-    </aside>
+    {% get_available_languages as LANGUAGES %}
+    {% if LANGUAGES|length > 1 %}
+        <aside class="ds-language" aria-labelledby="language-label">
+            <form action="{% url 'set_language' %}" method="post">
+                {% csrf_token %}
+                <input name="next" type="hidden" value="{{ request.get_full_path }}">
+                <ul>
+                    <li id="language-label" aria-hidden="true">{% trans "Language:" %}</li>
+                    {% get_current_language as LANGUAGE_CODE %}
+                    {% get_language_info_list for LANGUAGES as languages %}
+                    {% for language in languages %}
+                        <li>
+                            <button name="language" value="{{ language.code }}" lang="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} aria-current="true"{% endif %}>
+                                {{ language.name_local }}
+                            </button>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </form>
+        </aside>
+    {% endif %}
 {% endblock base_language_menu %}
 
 {% block messages %}


### PR DESCRIPTION
Add a conditional to only show language picker menu if there are more than one languages configured in settings.

This should only touch the frontend. It's not intended to change the output of the API e.g. for welsh accessibility info.

