### PR TITLE
scale up production

### DIFF
--- a/.circleci/deploy-config.yml
+++ b/.circleci/deploy-config.yml
@@ -424,9 +424,9 @@ workflows:
         context: [deployment-production-wdiv, slack-secrets]
         filters: { branches: { only: [ main, master ] } }
         dc-environment: production
-        min-size: 3
+        min-size: 4
         max-size: 30
-        desired-capacity: 3
+        desired-capacity: 4
     - run_new_imports_post_deploy:
         # NB if no imports have changed this is a no-op
         name: "Production: Run New Imports Post Deploy"

--- a/cdk/stacks/wdiv_stack.py
+++ b/cdk/stacks/wdiv_stack.py
@@ -138,8 +138,8 @@ class WDIVStack(Stack):
         instance_types_per_env = {
             "development": "t3a.large",
             "staging": "t3a.large",
-            "production": "t3a.large",
-            # "production": "c6a.2xlarge",
+            # "production": "t3a.large",
+            "production": "c6a.2xlarge",
         }
         return ec2.LaunchTemplate(
             self,


### PR DESCRIPTION
- Go up to `c6a.2xlarge` instance type
- Run a minimum of 4 instances

This is the configuration we used for polling day last year