### PR TITLE
remove double emojis in feedback section

### DIFF
--- a/polling_stations/apps/feedback/templates/feedback/feedback_form.html
+++ b/polling_stations/apps/feedback/templates/feedback/feedback_form.html
@@ -19,7 +19,6 @@
     <h3>
         <span aria-hidden="true">🔎</span>
         {% trans "Did you find what you were looking for?" %}
-        <span aria-hidden="true">🔎</span>
     </h3>
     <span id="feedback_choices_container">
         {% for choice in feedback_form.found_useful %}
@@ -30,7 +29,7 @@
     <div id="vote_choices_container">
         <h3><span aria-hidden="true">🗳️</span>
             {% trans "Has this service changed your likelihood of voting?" %}
-            <span aria-hidden="true">🗳️</span></h3>
+        </h3>
         {% for choice in feedback_form.vote %}
             {{ choice.tag }}
             <label class="link-button" for="{{ choice.id_for_label }}"> {{ choice.choice_label }}</label>


### PR DESCRIPTION
This brings this section into line with the others that only have an emoji at the start of the line.

Depending on where the line breaks on your screen, this sometimes looks odd e.g:

<img width="911" height="213" alt="Screenshot at 2026-04-30 15-56-15" src="https://github.com/user-attachments/assets/73601c95-851b-42f6-9c8c-6c96580c3702" />
