### PR TITLE
Ci import slack notifications

### DIFF
--- a/.circleci/deploy-config.yml
+++ b/.circleci/deploy-config.yml
@@ -135,8 +135,9 @@ jobs:
             export CI_DB_PASSWORD=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_PASSWORD' --output text`
             export CI_DB_NAME=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_NAME' --output text`
             export CI_DB_HOST=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_HOST' --output text`
+            export SLACK_TOKEN=`aws ssm get-parameter --query Parameter.Value --name 'SLACK_TOKEN' --output text`
             export S3_DATA_BUCKET=pollingstations.elections.production
-            uv run python manage.py run_new_imports
+            uv run python manage.py run_new_imports --slack
       # In the event the imports have failed, alert the dev team
       - slack/notify:
           event: fail
@@ -292,8 +293,9 @@ jobs:
             export CI_DB_PASSWORD=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_PASSWORD' --output text`
             export CI_DB_NAME=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_NAME' --output text`
             export CI_DB_HOST=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_HOST' --output text`
+            export SLACK_TOKEN=`aws ssm get-parameter --query Parameter.Value --name 'SLACK_TOKEN' --output text`
             export S3_DATA_BUCKET=pollingstations.elections.production
-            uv run python manage.py run_new_imports --post-deploy
+            uv run python manage.py run_new_imports --post-deploy --slack
 
       # In the event the deployment has failed, alert the dev team
       - slack/notify:

--- a/polling_stations/apps/data_importers/base_importers.py
+++ b/polling_stations/apps/data_importers/base_importers.py
@@ -268,7 +268,7 @@ class BaseImporter(BaseBaseImporter, BaseCommand, metaclass=abc.ABCMeta):
         )
 
         self.verbosity = kwargs.get("verbosity")
-        self.logger = LogHelper(self.verbosity)
+        self.logger = LogHelper(self.verbosity, stream=self.stdout)
         self.validation_checks = not (kwargs.get("nochecks"))
         self.allow_station_point_from_postcode = kwargs.get("use_postcode_centroids")
 

--- a/polling_stations/apps/data_importers/base_importers.py
+++ b/polling_stations/apps/data_importers/base_importers.py
@@ -192,7 +192,7 @@ class BaseImporter(BaseBaseImporter, BaseCommand, metaclass=abc.ABCMeta):
         record[0].num_stations = station_report.get_stations_imported()
         record[0].num_districts = district_report.get_districts_imported()
         record[0].num_addresses = address_report.get_addresses_with_station_id()
-        record[0].report = report.generate_string_report()
+        record[0].report = report.generate_string_report(file=self.stdout)
         record[0].save()
 
     @property

--- a/polling_stations/apps/data_importers/data_quality_report.py
+++ b/polling_stations/apps/data_importers/data_quality_report.py
@@ -6,6 +6,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
+from typing import Optional, TextIO
 
 
 # data quality stats for polling stations
@@ -521,7 +522,10 @@ class DataQualityReportBuilder:
         self.report.add_row(self.build_station_report())
         self.report.add_row(self.build_address_report())
 
-    def generate_string_report(self):
-        recorder = Console(record=True)
+    def generate_string_report(self, file: Optional[TextIO] = None):
+        console_kwargs = {"record": True}
+        if file is not None:
+            console_kwargs["file"] = file
+        recorder = Console(**console_kwargs)
         recorder.print(self.report)
         return recorder.export_text()

--- a/polling_stations/apps/data_importers/loghelper.py
+++ b/polling_stations/apps/data_importers/loghelper.py
@@ -5,9 +5,15 @@ import pprint
 class LogHelper:
     logger = None
 
-    def __init__(self, verbosity):
+    def __init__(self, verbosity, stream=None):
         logformat = "%(levelname)s: %(message)s"
-        logging.basicConfig(format=logformat)
+        config_kwargs = {"format": logformat}
+
+        if stream:
+            config_kwargs["stream"] = stream
+
+        logging.basicConfig(**config_kwargs)
+
         logger = logging.getLogger(__name__)
         if verbosity == 0:
             logger.setLevel(logging.ERROR)

--- a/polling_stations/apps/data_importers/management/commands/import_eoni.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni.py
@@ -3,6 +3,7 @@ import datetime
 from pathlib import Path
 from typing import Dict, Any
 
+import sentry_sdk
 from addressbase.models import Address, UprnToCouncil
 from core.slack_client import SlackClient
 from councils.models import Council
@@ -334,6 +335,7 @@ class Command(BaseStationsImporter, CsvMixin):
             )
         except Exception as slack_e:
             self.stderr.write(f"Error posting to Slack: {str(slack_e)}")
+            sentry_sdk.capture_exception(slack_e)
 
     def post_to_slack(self) -> None:
         try:

--- a/polling_stations/apps/data_importers/management/commands/run_new_imports.py
+++ b/polling_stations/apps/data_importers/management/commands/run_new_imports.py
@@ -92,6 +92,7 @@ class Command(BaseCommand):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.slack_client = None
+        self.messages = []
 
     @property
     def slack_channel(self):
@@ -132,11 +133,12 @@ class Command(BaseCommand):
                         f"Ran import script: {script_path.name}",
                     )
                 )
-                if should_post_to_slack:
-                    self.post_to_slack(
-                        header_message=f":pollingstation: *Successfuly ran {script_path.stem}*",
-                        detail_message=f"```{out.getvalue()}```",
-                    )
+                self.messages.append(
+                    {
+                        "header_message": f":pollingstation: *Successfuly ran {script_path.stem}*",
+                        "detail_message": f"```{out.getvalue()}```",
+                    }
+                )
             except Exception as e:
                 # usually we want to handle a specific exception, but in this situation
                 # if there is any issue (at all) trying to run the command,
@@ -144,11 +146,12 @@ class Command(BaseCommand):
                 self.summary.append(
                     ("WARNING", f"{script_path.name} could not be run. Due to {e}")
                 )
-                if should_post_to_slack:
-                    self.post_to_slack(
-                        header_message=f":warning: *Failed to run {script_path.stem}*",
-                        detail_message=f"Error: {str(e)}",
-                    )
+                self.messages.append(
+                    {
+                        "header_message": f":warning: *Failed to run {script_path.stem}*",
+                        "detail_message": f"Error: {str(e)}",
+                    }
+                )
                 continue
 
     def run_misc_fixes(self):
@@ -274,3 +277,7 @@ class Command(BaseCommand):
             self.stdout.write("Not running import scripts")
 
         self.output_summary()
+
+        if should_post_to_slack:
+            for message in self.messages:
+                self.post_to_slack(**message)

--- a/polling_stations/apps/data_importers/management/commands/run_new_imports.py
+++ b/polling_stations/apps/data_importers/management/commands/run_new_imports.py
@@ -1,12 +1,19 @@
 import re
 import subprocess
+from io import StringIO
 from pathlib import Path
+from typing import Any, Dict
 
 import boto3
 import botocore
+from core.slack_client import SlackClient
 from django.apps import apps
 from django.conf import settings
 from django.core.management import BaseCommand, call_command
+from polling_stations.settings.constants.slack import (
+    BOTS_CHANNEL,
+    BOTS_TESTING_CHANNEL,
+)
 
 
 def get_paths_changed(from_sha, to_sha):
@@ -82,6 +89,17 @@ class Command(BaseCommand):
 
     summary = []
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.slack_client = None
+
+    @property
+    def slack_channel(self):
+        if settings.DC_ENVIRONMENT == "production":
+            return BOTS_CHANNEL
+        else:
+            return BOTS_TESTING_CHANNEL
+
     def add_arguments(self, parser):
         parser.add_argument(
             "-f",
@@ -96,18 +114,29 @@ class Command(BaseCommand):
             default=git_rev_parse("HEAD"),
         )
         parser.add_argument("--post-deploy", action="store_true", default=False)
+        parser.add_argument(
+            "--slack",
+            help="Post a report to slack",
+            action="store_true",
+        )
 
-    def run_scripts(self, changed_paths, opts):
+    def run_scripts(self, changed_paths, should_post_to_slack, opts):
         for script in changed_paths:
             script_path = Path(script)
             try:
-                call_command(script_path.stem, **opts)
+                out = StringIO()
+                call_command(script_path.stem, stdout=out, **opts)
                 self.summary.append(
                     (
                         "INFO",
                         f"Ran import script: {script_path.name}",
                     )
                 )
+                if should_post_to_slack:
+                    self.post_to_slack(
+                        header_message=f":pollingstation: *Successfuly ran {script_path.stem}*",
+                        detail_message=f"```{out.getvalue()}```",
+                    )
             except Exception as e:
                 # usually we want to handle a specific exception, but in this situation
                 # if there is any issue (at all) trying to run the command,
@@ -115,6 +144,11 @@ class Command(BaseCommand):
                 self.summary.append(
                     ("WARNING", f"{script_path.name} could not be run. Due to {e}")
                 )
+                if should_post_to_slack:
+                    self.post_to_slack(
+                        header_message=f":warning: *Failed to run {script_path.stem}*",
+                        detail_message=f"Error: {str(e)}",
+                    )
                 continue
 
     def run_misc_fixes(self):
@@ -160,6 +194,26 @@ class Command(BaseCommand):
                 )
             )
 
+    def post_to_slack(self, header_message: str, detail_message: str = None) -> None:
+        try:
+            response = self.post_header(header_message)
+            if detail_message:
+                thread_ts = response.get("ts")
+                self.post_details(thread_ts, detail_message)
+        except Exception as e:
+            self.stderr.write(f"Error posting to Slack: {str(e)}")
+
+    def post_header(self, message: str) -> Dict[str, Any]:
+        return self.slack_client.send_message(
+            message=message,
+        )
+
+    def post_details(self, thread_ts: str, detail_message: str) -> None:
+        self.slack_client.send_message(
+            message=detail_message,
+            thread_ts=thread_ts,
+        )
+
     def handle(self, *args, **options):
         self.check(
             [
@@ -167,6 +221,11 @@ class Command(BaseCommand):
                 apps.get_app_config("pollingstations"),
             ]
         )
+        should_post_to_slack = False
+
+        if options.get("slack"):
+            self.slack_client = SlackClient(channel=self.slack_channel)
+            should_post_to_slack = True
 
         if not (from_sha := options.get("from_sha")):
             from_sha = get_last_import_sha_from_ssm()
@@ -196,12 +255,12 @@ class Command(BaseCommand):
         if has_imports and not has_application:
             self.stdout.write("Only import scripts have changed\n")
             self.stdout.write("Running import scripts\n")
-            self.run_scripts(changed_scripts, cmd_opts)
+            self.run_scripts(changed_scripts, should_post_to_slack, cmd_opts)
             self.run_misc_fixes()
             self.update_last_import_sha_on_ssm(to_sha)
         elif has_imports and has_application and is_post_deploy:
             self.stdout.write("App has deployed. OK to run import scripts")
-            self.run_scripts(changed_scripts, cmd_opts)
+            self.run_scripts(changed_scripts, should_post_to_slack, cmd_opts)
             self.run_misc_fixes()
             self.update_last_import_sha_on_ssm(to_sha)
         elif has_imports and has_application and not is_post_deploy:

--- a/polling_stations/apps/data_importers/management/commands/run_new_imports.py
+++ b/polling_stations/apps/data_importers/management/commands/run_new_imports.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 import boto3
 import botocore
+import sentry_sdk
 from core.slack_client import SlackClient
 from django.apps import apps
 from django.conf import settings
@@ -152,6 +153,7 @@ class Command(BaseCommand):
                         "detail_message": f"Error: {str(e)}",
                     }
                 )
+                sentry_sdk.capture_exception(e)
                 continue
 
     def run_misc_fixes(self):
@@ -205,6 +207,7 @@ class Command(BaseCommand):
                 self.post_details(thread_ts, detail_message)
         except Exception as e:
             self.stderr.write(f"Error posting to Slack: {str(e)}")
+            sentry_sdk.capture_exception(e)
 
     def post_header(self, message: str) -> Dict[str, Any]:
         return self.slack_client.send_message(

--- a/polling_stations/apps/data_importers/tests/test_run_new_imports.py
+++ b/polling_stations/apps/data_importers/tests/test_run_new_imports.py
@@ -208,6 +208,7 @@ class test_run_new_imports(TestCase):
         # To get these changes I just `git logged` the imports directory and picked some sensible pairs.
         self.cases = {
             "scripts_only": ("4173ae16", "13accc3f"),
+            "single_script": ("ecb31b9c6", "963f0576bd"),
             "app_only": ("f865aaf1", "557c71d6"),
             "scripts_and_app": ("4078f6ac", "cf57110a"),
         }
@@ -224,6 +225,7 @@ class test_run_new_imports(TestCase):
             self.run_new_imports_name,
             to_sha=to_sha,
             from_sha=from_sha,
+            slack=False,
             stdout=out,
         )
         expected_std_out = "Only import scripts have changed\n"
@@ -235,6 +237,7 @@ class test_run_new_imports(TestCase):
                 "polling_stations/apps/data_importers/management/commands/import_knowsley.py",
                 "polling_stations/apps/data_importers/management/commands/import_lambeth.py",
             ],
+            False,
             {
                 "nochecks": True,
                 "verbosity": 1,
@@ -279,6 +282,7 @@ class test_run_new_imports(TestCase):
             self.run_new_imports_name,
             to_sha=to_sha,
             from_sha=from_sha,
+            slack=False,
             stdout=out,
         )
         expected_std_out = "Need to deploy before running import scripts\n"
@@ -297,6 +301,7 @@ class test_run_new_imports(TestCase):
             to_sha=to_sha,
             from_sha=from_sha,
             post_deploy=True,
+            slack=False,
             stdout=out,
         )
         expected_std_out = "App has deployed. OK to run import scripts\n"
@@ -314,10 +319,76 @@ class test_run_new_imports(TestCase):
                 "polling_stations/apps/data_importers/management/commands/import_south_tyneside.py",
                 "polling_stations/apps/data_importers/management/commands/import_welwyn_hatfield.py",
             ],
+            False,
             {
                 "nochecks": True,
                 "verbosity": 1,
                 "use_postcode_centroids": False,
                 "include_past_elections": False,
             },
+        )
+
+    @patch(
+        "data_importers.management.commands.run_new_imports.call_command",
+    )
+    @patch(
+        "data_importers.management.commands.run_new_imports.SlackClient",
+    )
+    def test_posts_to_slack_success(self, slack_client_mock, call_command_mock):
+        out = StringIO()
+        (to_sha, from_sha) = self.cases["single_script"]
+
+        call_command(
+            self.run_new_imports_name,
+            to_sha=to_sha,
+            from_sha=from_sha,
+            slack=True,
+            stdout=out,
+        )
+        expected_std_out = "Only import scripts have changed\n"
+        expected_message = ":pollingstation: *Successfuly ran import_glasgow_city*"
+
+        self.assertIn(expected_std_out, out.getvalue())
+
+        mock_send_message = slack_client_mock.return_value.send_message
+        self.assertEqual(mock_send_message.call_count, 2)
+        self.assertEqual(
+            mock_send_message.call_args_list[0].kwargs["message"], expected_message
+        )
+
+    @patch(
+        "data_importers.management.commands.run_new_imports.call_command",
+    )
+    @patch(
+        "data_importers.management.commands.run_new_imports.SlackClient",
+    )
+    def test_posts_to_slack_failure(self, slack_client_mock, call_command_mock):
+        def side_effect(first_arg, *args, **kwargs):
+            # run_new_imports calls call_command multiple times,
+            # but we only want to raise an exception for the one
+            # that runs the import script
+            if first_arg == "import_glasgow_city":
+                raise Exception("Import failed")
+            return None
+
+        call_command_mock.side_effect = side_effect
+        (to_sha, from_sha) = self.cases["single_script"]
+
+        out = StringIO()
+        call_command(
+            self.run_new_imports_name,
+            to_sha=to_sha,
+            from_sha=from_sha,
+            slack=True,
+            stdout=out,
+        )
+        expected_std_out = "Only import scripts have changed\n"
+        expected_message = ":warning: *Failed to run import_glasgow_city*"
+
+        self.assertIn(expected_std_out, out.getvalue())
+
+        mock_send_message = slack_client_mock.return_value.send_message
+        self.assertEqual(mock_send_message.call_count, 2)
+        self.assertEqual(
+            mock_send_message.call_args_list[0].kwargs["message"], expected_message
         )


### PR DESCRIPTION
This PR makes it so imports scripts run in CI will report their success or failure to the bots channel in slack. This is meant to address the issue of us missing when import scripts fail to import after merging. We could have made `run_new_imports` fail instead, but this is less intrusive, while still achieving the goal of increasing visibility. I roughly copied the pattern for slack messaging used in [import_eoni](https://github.com/DemocracyClub/UK-Polling-Stations/blob/master/polling_stations/apps/data_importers/management/commands/import_eoni.py).



Rather than post one summary message per CI command, I chose to post one message per script, so that I could attach the data quality report or error message for each success/failure. 

In order to capture all of an import's logging in once place, I had to tweak the base importer command to pass its `stdout` to both the `LogHelper` and the `DataQualityReportBuilder`  ([898b191](https://github.com/DemocracyClub/UK-Polling-Stations/pull/9416/commits/898b191aa5013f1633d8fe0ca0f7e10937f22876) and [e37e49c](https://github.com/DemocracyClub/UK-Polling-Stations/pull/9416/commits/e37e49c7e184038f5e7f76195f0c803a82b0c2a8)).



Tested with unit tests and by deploying to dev.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213357905938200