### PR TITLE
councils: don't pick import_fake_*.py as the import script

### DIFF
--- a/polling_stations/apps/councils/models.py
+++ b/polling_stations/apps/councils/models.py
@@ -210,10 +210,17 @@ class Council(WelshNameMutationMixin, models.Model):
     def import_script_path(self):
         import_script_path = None
 
+        # Skip import_fake_*.py - those are mock importers used in tests and
+        # local dev, not the real script for a council. When both
+        # import_exeter.py and import_fake_exeter.py declare the same
+        # council_id, the glob iteration order means the fake one wins
+        # without this filter (#8035).
         scripts = Path(
             "./polling_stations/apps/data_importers/management/commands/"
         ).glob("import_*.py")
         for script in scripts:
+            if script.name.startswith("import_fake_"):
+                continue
             if f'council_id = "{self.council_id}"' in script.read_text():
                 import_script_path = script
         if not import_script_path:


### PR DESCRIPTION
When two scripts declare the same \`council_id\` — the real importer plus its \`import_fake_*.py\` twin for tests/local dev — \`Council.import_script_path\` returns whichever the glob iterator hits last. For \`EXE\` that means \`import_fake_exeter.py\` wins, not \`import_exeter.py\`.

Teignbridge isn't affected because \`import_fake_teignbridge.py\` sorts before \`import_teignbridge.py\`, so the real script gets the last assignment. That's why the bug looks specific to Exeter — it's actually glob-order-dependent.

Filtered \`import_fake_*.py\` out of the loop. The fake scripts exist for tests and aren't a real council's import path under any condition.

closes #8035