### PR TITLE
Fix/import slack notifications

### DIFF
--- a/.circleci/deploy-config.yml
+++ b/.circleci/deploy-config.yml
@@ -136,6 +136,7 @@ jobs:
             export CI_DB_NAME=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_NAME' --output text`
             export CI_DB_HOST=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_HOST' --output text`
             export SLACK_TOKEN=`aws ssm get-parameter --query Parameter.Value --name 'SLACK_TOKEN' --output text`
+            export BOTS_CHANNEL=`aws ssm get-parameter --query Parameter.Value --name 'BOTS_CHANNEL' --output text`
             export S3_DATA_BUCKET=pollingstations.elections.production
             uv run python manage.py run_new_imports --slack
       # In the event the imports have failed, alert the dev team
@@ -293,6 +294,7 @@ jobs:
             export CI_DB_NAME=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_NAME' --output text`
             export CI_DB_HOST=`aws ssm get-parameter --query Parameter.Value --name 'RDS_DB_HOST' --output text`
             export SLACK_TOKEN=`aws ssm get-parameter --query Parameter.Value --name 'SLACK_TOKEN' --output text`
+            export BOTS_CHANNEL=`aws ssm get-parameter --query Parameter.Value --name 'BOTS_CHANNEL' --output text`
             export S3_DATA_BUCKET=pollingstations.elections.production
             uv run python manage.py run_new_imports --post-deploy --slack
 

--- a/.circleci/deploy-config.yml
+++ b/.circleci/deploy-config.yml
@@ -176,10 +176,9 @@ jobs:
           uv run --group cdk npx cdk synth --all
     - persist_to_workspace:
         root: ~/repo/
-        paths: [
-          cdk.out,
-          cdk/lambdas/wdiv-s3-trigger/requirements.txt,
-        ]
+        paths:
+          - cdk.out
+          - cdk/lambdas/wdiv-s3-trigger/requirements.txt
     - slack/notify:
         event: fail
         template: basic_fail_1

--- a/polling_stations/apps/data_importers/management/commands/run_new_imports.py
+++ b/polling_stations/apps/data_importers/management/commands/run_new_imports.py
@@ -136,7 +136,7 @@ class Command(BaseCommand):
                 )
                 self.messages.append(
                     {
-                        "header_message": f":pollingstation: *Successfuly ran {script_path.stem}*",
+                        "header_message": f":pollingstation: *Successfully ran {script_path.stem}*",
                         "detail_message": f"```{out.getvalue()}```",
                     }
                 )

--- a/polling_stations/apps/data_importers/management/commands/run_new_imports.py
+++ b/polling_stations/apps/data_importers/management/commands/run_new_imports.py
@@ -1,3 +1,4 @@
+import os
 import re
 import subprocess
 from io import StringIO
@@ -11,10 +12,7 @@ from core.slack_client import SlackClient
 from django.apps import apps
 from django.conf import settings
 from django.core.management import BaseCommand, call_command
-from polling_stations.settings.constants.slack import (
-    BOTS_CHANNEL,
-    BOTS_TESTING_CHANNEL,
-)
+from polling_stations.settings.constants.slack import BOTS_TESTING_CHANNEL
 
 
 def get_paths_changed(from_sha, to_sha):
@@ -97,10 +95,7 @@ class Command(BaseCommand):
 
     @property
     def slack_channel(self):
-        if settings.DC_ENVIRONMENT == "production":
-            return BOTS_CHANNEL
-        else:
-            return BOTS_TESTING_CHANNEL
+        return os.environ.get("BOTS_CHANNEL", BOTS_TESTING_CHANNEL)
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/polling_stations/apps/data_importers/tests/test_run_new_imports.py
+++ b/polling_stations/apps/data_importers/tests/test_run_new_imports.py
@@ -346,7 +346,7 @@ class test_run_new_imports(TestCase):
             stdout=out,
         )
         expected_std_out = "Only import scripts have changed\n"
-        expected_message = ":pollingstation: *Successfuly ran import_glasgow_city*"
+        expected_message = ":pollingstation: *Successfully ran import_glasgow_city*"
 
         self.assertIn(expected_std_out, out.getvalue())
 


### PR DESCRIPTION
This PR adds the `DC_ENVIRONMENT` to the CI env for the `run_new_imports` and `run_new_imports_post_deploy`. That way the `run_new_imports` command will know what env it's running in to determine the correct slack channel to post to. 

(In the issue I say I need to change where were getting the `DC_ENVIRONMENT` variable from in the command. This is wrong because in `base.py`, we get the `DC_ENVIRONMENT` from the env and when the `manage.py run_new_imports --slack ` runs, it populates the django settings from the CI env.)

I also did a drive-by fix of the CI syntax that was causing my IDE to underline everything in red.

Fixes https://github.com/DemocracyClub/UK-Polling-Stations/issues/9431

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215160353214967