### PR TITLE
ignore fake scripts in import_script_path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           # It can probably be robustified by sticking all the council imports in their own subdir.
           mapping: |
             polling_stations\/apps\/data_importers\/management\/commands\/misc_fixes\.py imports-changed true
-            polling_stations\/apps\/data_importers\/management\/commands\/import_(?!eoni).+\.py imports-changed true
+            polling_stations\/apps\/data_importers\/management\/commands\/import_(?!(?:fake_|eoni)).+\.py imports-changed true
             (?!polling_stations\/apps\/data_importers\/management\/commands\/import_.+\.py).* application-changed true
             polling_stations\/apps\/data_importers\/management\/commands\/import_eoni.py eoni-changed true
           base-revision: master

--- a/polling_stations/apps/councils/models.py
+++ b/polling_stations/apps/councils/models.py
@@ -214,6 +214,8 @@ class Council(WelshNameMutationMixin, models.Model):
             "./polling_stations/apps/data_importers/management/commands/"
         ).glob("import_*.py")
         for script in scripts:
+            if "_fake_" in script.name:
+                continue
             if f'council_id = "{self.council_id}"' in script.read_text():
                 import_script_path = script
         if not import_script_path:

--- a/polling_stations/apps/councils/tests/test_council.py
+++ b/polling_stations/apps/councils/tests/test_council.py
@@ -1,4 +1,6 @@
 import datetime
+from pathlib import Path
+from unittest.mock import patch
 
 from councils.models import Council, UnsafeToDeleteCouncil
 from councils.tests.factories import CouncilFactory
@@ -62,6 +64,20 @@ class CouncilTest(TestCase):
     def test_nation(self):
         newport = Council.objects.get(pk="NWP")
         self.assertEqual("Wales", newport.nation)
+
+    def test_import_script_path_ignores_fake_scripts(self):
+        exeter = CouncilFactory(council_id="EXE", name="Exeter")
+        fake_script = Path("/mock/import_fake_exeter.py")
+        real_script = Path("/mock/import_exeter.py")
+
+        with (
+            patch("councils.models.Path.glob", return_value=[fake_script, real_script]),
+            patch("councils.models.Path.read_text", return_value='council_id = "EXE"'),
+        ):
+            import_script_name = Path(exeter.import_script_path).name
+
+        self.assertEqual("import_exeter.py", import_script_name)
+        self.assertNotEqual("import_fake_exeter.py", import_script_name)
 
     def test_latest_data_event(self):
         self.assertEqual(


### PR DESCRIPTION
This PR fixes some issues with the fake import scripts. 

- Makes sure `Council.import_script_path` only returns real import scripts
- Makes the `check-updated-files` CI job ignore fake import scripts

closes #8035

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214148515788482