### PR TITLE
expose timetable dict in API responses

### DIFF
--- a/polling_stations/apps/api/address.py
+++ b/polling_stations/apps/api/address.py
@@ -110,6 +110,7 @@ class BallotSerializer(serializers.Serializer):
     replaced_by = serializers.CharField(read_only=True, allow_null=True)
     replaces = serializers.CharField(read_only=True, allow_null=True)
     requires_voter_id = serializers.CharField(read_only=True, allow_null=True)
+    timetable = serializers.DictField(read_only=True)
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_ballot_paper_id(self, obj) -> str:


### PR DESCRIPTION
Now that EE exposes this in the API, also expose it here.
Merging this here will also add the key to the devs.DC API because it just exposes the WDIV ballot object unfiltered.