### PR TITLE
Add NI polling place consultation to FE

### DIFF
--- a/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
+++ b/polling_stations/apps/data_finder/tests/playwright/test_postcode_lookup.py
@@ -135,7 +135,7 @@ def test_northern_ireland_has_election(
         with page.expect_navigation():
             page.query_selector("#submit-postcode").click()
         expect(
-            page.locator("text=The Electoral Office for Northern Ireland")
+            page.locator('h3:has-text("The Electoral Office for Northern Ireland")')
         ).not_to_be_empty()
         expect(
             page.locator(

--- a/polling_stations/settings/constants/importers.py
+++ b/polling_stations/settings/constants/importers.py
@@ -17,6 +17,6 @@ class EONIImportScheme(models.TextChoices):
 
 EONI_IMPORT_SCHEME = EONIImportScheme.NATIONAL
 
-SHOW_EONI_STATIONS_ALL_THE_TIME = os.environ.get(
-    "SHOW_EONI_STATIONS_ALL_THE_TIME", False
-)
+SHOW_EONI_STATIONS_ALL_THE_TIME = False
+if os.environ.get("SHOW_EONI_STATIONS_ALL_THE_TIME", False) in ("True", "true", "1"):
+    SHOW_EONI_STATIONS_ALL_THE_TIME = True

--- a/polling_stations/templates/fragments/ni_out_of_cycle_station.html
+++ b/polling_stations/templates/fragments/ni_out_of_cycle_station.html
@@ -15,6 +15,8 @@
     </p>
 {% endif %}
 
+{% include "fragments/ni_polling_place_consultation.html" %}
+
 <h2>{% trans "Your Polling Station" %}</h2>
 <p>
     {% trans "This polling station is for elections for your" %}

--- a/polling_stations/templates/fragments/ni_polling_place_consultation.html
+++ b/polling_stations/templates/fragments/ni_polling_place_consultation.html
@@ -1,0 +1,13 @@
+<div class="ds-card">
+    <div class="ds-card-body">
+        <h3>Polling Place Consultation</h3>
+        <p>
+            The Electoral Office is consulting on Polling Places for the NI Assembly & Local Council elections planned for May 2027.
+        </p>
+        <p>
+            You can view a map of the proposed 2027 election Polling Places at
+            <a href="https://nielectoral-maps.wheredoivote.co.uk/">nielectoral-maps.wheredoivote.co.uk</a>
+            and respond at <a href="https://www.eoni.org.uk/consultations">www.eoni.org.uk/consultations</a>
+        </p>
+    </div>
+</div>

--- a/polling_stations/templates/fragments/polling_station_unknown.html
+++ b/polling_stations/templates/fragments/polling_station_unknown.html
@@ -2,6 +2,10 @@
 
 <h2>{% blocktrans %}Contact {{ council }}{% endblocktrans %}</h2>
 
+{% if territory == 'NI' %}
+    {% include "fragments/ni_polling_place_consultation.html" %}
+{% endif %}
+
 <p>
     {% trans "Your polling station address should be printed on your polling card, which is delivered by post before an election." %}
 </p>


### PR DESCRIPTION
Don't merge until the EONI site is public.

I've put this in a card, but could also be in a CTA banner. I thought a card was slightly more prominent.

<details><summary>Screenshot</summary>
<p>
<img width="1411" height="1180" alt="image" src="https://github.com/user-attachments/assets/e5af60b8-3da9-47dc-b50f-00aa1e8867aa" />
</p>
</details> 


There's a dev deploy, that commit needs to be dropped before merge. 

EONI have asked that no stations be shown on WDIV during the consultation, so in parameter store change `SHOW_EONI_STATIONS_ALL_THE_TIME` to `False`. This has been done in dev, but needs to be done in stage and prod before merging. 







---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216950735609598