### PR TITLE
Fix import EONI from s3

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
@@ -1,5 +1,4 @@
 import csv
-import re
 from pathlib import Path
 
 import chardet
@@ -43,33 +42,6 @@ def get_body_sample(body: bytes):
     if len(lines) > 20:
         return line_sep.join(lines[:20])
     return line_sep.join(lines)
-
-
-def is_eoni_export_key(key: str) -> bool:
-    """
-    Should return true for things like:
-    '2023-04-12-EONIextract.txt',
-    '2024-07-03-EONIextract-sample.txt',
-    '2024-11-21-EONIextract_NEW.txt'
-
-    """
-    eoni_export_key_pattern = re.compile(
-        r"""
-        ^           # Start of string
-        20[2-9]     # First 3 digits of year: 202-209
-        [0-9]       # Last digit of year: 0-9
-        -           # Separator
-        [0-9]{2}    # Month as 2 digits
-        -           # Separator
-        [0-9]{2}    # Day as 2 digits
-        -.+         # Hyphen followed by any text
-        \.txt       # Literal .txt extension
-        """,
-        re.VERBOSE,
-    )
-    if eoni_export_key_pattern.match(key):
-        return True
-    return False
 
 
 class EONIUploadValidationError(Exception):
@@ -252,16 +224,18 @@ class Command(BaseCommand):
             self.stdout.write(f"Using cached version found at:\n\t{self.local_path}")
 
     def get_latest_file_on_s3(self):
-        objects = self.s3_wrapper.bucket.objects.all()
-        object_keys = sorted(
-            [obj.key for obj in objects if is_eoni_export_key(obj.key)]
-        )
+        objects = [
+            o
+            for o in self.s3_wrapper.bucket.objects.all()
+            if o.key.endswith(".txt") and o.key.startswith("EONIPropsAndPrems")
+        ]
 
-        if len(object_keys) == 0:
+        if len(objects) == 0:
             raise CommandError(
                 f"Failed to find any EONI export keys for {self.bucket_name}"
             )
-        return object_keys[-1]
+
+        return sorted(objects, key=lambda obj: obj.last_modified, reverse=True)[0].key
 
     def decode_csv(self):
         with open(self.local_path, "rb") as csv_file:

--- a/polling_stations/apps/data_importers/tests/test_import_eoni_from_s3.py
+++ b/polling_stations/apps/data_importers/tests/test_import_eoni_from_s3.py
@@ -10,7 +10,6 @@ from moto import mock_aws
 
 from data_importers.management.commands.import_eoni_from_s3 import (
     Command,
-    is_eoni_export_key,
 )
 
 # A minimal CSV row using the current EONI header format.
@@ -81,17 +80,6 @@ def build_eoni_csv_bytes():
     writer.writeheader()
     writer.writerow(EONI_CSV_ROW)
     return buf.getvalue().encode("utf-8")
-
-
-class TestIsEoniExportKey:
-    def test_standard_key(self):
-        assert is_eoni_export_key("2026-04-01-EONIextract.txt") is True
-
-    def test_key_with_suffix(self):
-        assert is_eoni_export_key("2024-11-21-EONIextract_NEW.txt") is True
-
-    def test_non_matching_key(self):
-        assert is_eoni_export_key("readme.txt") is False
 
 
 class TestImportEoniFromS3:


### PR DESCRIPTION
EONI changed how they name the files they upload, and that broke this command. This means we've been showing stale data. But also they've been updating the LC scheme, so there haven't been many updates to the WM scheme.

This uses s3 'last modified' rather than file name to figure out the most recent file. I'm not certain that is better, but hopefully.

This can be tested locally by changing
applying:
```diff
diff --git a/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py b/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
index 86d7aafc5..3ca2105db 100644
--- a/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
@@ -150,7 +150,7 @@ class Command(BaseCommand):
         try:
             # Set env.
             # Command works without, but requires '--input-uri' and will only post to test channel in slack.
-            self.dc_environment = settings.DC_ENVIRONMENT
+            self.dc_environment = "production"  # settings.DC_ENVIRONMENT
 
             # Set up s3 config
             self.set_s3_key_and_wrapper(options)
```

and running: `AWS_PROFILE=prod-wdiv-dc uv run ./manage.py import_eoni_from_s3`

