### PR TITLE
Report EONI file to slack

### DIFF
--- a/polling_stations/apps/data_importers/management/commands/import_eoni.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni.py
@@ -73,6 +73,11 @@ class Command(BaseStationsImporter, CsvMixin):
             action="store_true",
         )
         parser.add_argument(
+            "--s3-source",
+            help="Original s3 source file for reporting to slack",
+            action="store",
+        )
+        parser.add_argument(
             "--slack",
             help="Post a report to slack in the channel specified",
             action="store",
@@ -82,6 +87,8 @@ class Command(BaseStationsImporter, CsvMixin):
         if slack_channel := options.get("slack"):
             self.slack_client = SlackClient(channel=slack_channel)
             self.should_post_to_slack = True
+
+        self.s3_source = options.get("s3_source", "unset")
 
         try:
             self.eoni_export_path = Path(options["eoni_csv"])
@@ -332,6 +339,10 @@ class Command(BaseStationsImporter, CsvMixin):
                 message=":warning: *EONI Data Import Failed*",
             )
             self.slack_client.send_message(
+                message=f"Tried to import {self.s3_source}.",
+                thread_ts=response.get("ts"),
+            )
+            self.slack_client.send_message(
                 message=f"Error: {str(exception)}", thread_ts=response.get("ts")
             )
         except Exception as slack_e:
@@ -352,6 +363,10 @@ class Command(BaseStationsImporter, CsvMixin):
         )
 
     def post_details(self, thread_ts: str) -> None:
+        self.slack_client.send_message(
+            message=f"Imported data from {self.s3_source}.",
+            thread_ts=thread_ts,
+        )
         # Post address counts
         address_counts_text = ["*Address Counts by Council:*"]
         for council_id, count in self.address_counts.items():

--- a/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
+++ b/polling_stations/apps/data_importers/management/commands/import_eoni_from_s3.py
@@ -411,6 +411,7 @@ class Command(BaseCommand):
             "eoni_csv": self.output_path,
             "verbosity": 1,
             "include_past_elections": True,
+            "s3_source": f"s3://{self.bucket_name}/{self.input_key}",
         }
 
         if options.get("send_slack_report"):
@@ -423,6 +424,10 @@ class Command(BaseCommand):
         try:
             response = slack_client.send_message(
                 message=":warning: *import_eoni_from_s3 command failed*",
+            )
+            slack_client.send_message(
+                message=f"Tried to import s3://{self.bucket_name}/{self.input_key}.",
+                thread_ts=response.get("ts"),
             )
             slack_client.send_message(
                 message=f"Error: {str(exception)}", thread_ts=response.get("ts")


### PR DESCRIPTION
We can fail in two places - the import_eoni_from_s3.py command and the import_eoni.py command. That's why both files are changed. We only report success from import_eoni.py.




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217011285414717