### PR TITLE
convert FCS API election datetimes to local dates

### DIFF
--- a/polling_stations/apps/file_uploads/fcs_views.py
+++ b/polling_stations/apps/file_uploads/fcs_views.py
@@ -11,6 +11,8 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
+from django.utils import timezone
+
 from django.views.generic import TemplateView
 
 from councils.models import Council
@@ -83,7 +85,15 @@ class FcsElectionSelectView(StaffUserRequiredMixin, TemplateView):
         )
         resp.raise_for_status()
         elections = resp.json()
-        return [e for e in elections if e["electionDate"].startswith(date)]
+        # The FCS API returns election dates as UTC datetimes in ISO format
+        # so we need to convert them to local dates before comparing with the requested date
+        requested_date = dt.date.fromisoformat(date)
+        return [
+            e
+            for e in elections
+            if timezone.localdate(dt.datetime.fromisoformat(e["electionDate"]))
+            == requested_date
+        ]
 
     def get_context_data(self, form=None, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/polling_stations/apps/file_uploads/tests/test_fcs_views.py
+++ b/polling_stations/apps/file_uploads/tests/test_fcs_views.py
@@ -103,6 +103,11 @@ class TestFcsElectionSelectView(FcsViewTestCase):
             "file_uploads:fcs_election_select",
             kwargs={"council_id": self.council.council_id, "date": self.date},
         )
+        FcsCredential.objects.create(
+            council=self.council,
+            url="https://example.com",
+            token="fake-token",
+        )
 
     def patch_elections_for_date(self, elections):
         return mock.patch(
@@ -134,6 +139,34 @@ class TestFcsElectionSelectView(FcsViewTestCase):
                 kwargs={
                     "council_id": self.council.council_id,
                     "date": self.date,
+                    "election_id": 1,
+                },
+            ),
+            fetch_redirect_response=False,
+        )
+
+    def test_date_comparison_is_timezone_aware(self):
+        self.client.force_login(self.staff_user)
+        isoformat_date_during_bst = "2026-10-07T23:00:00Z"
+        election_date = "2026-10-08"
+        url = reverse(
+            "file_uploads:fcs_election_select",
+            kwargs={"council_id": self.council.council_id, "date": election_date},
+        )
+        mock_resp = mock.Mock(return_value=None)
+        mock_resp.json.return_value = [
+            {"id": 1, "name": "Election 1", "electionDate": isoformat_date_during_bst}
+        ]
+
+        with mock.patch("file_uploads.fcs_views.requests.get", return_value=mock_resp):
+            response = self.client.get(url)
+        self.assertRedirects(
+            response,
+            reverse(
+                "file_uploads:fcs_snapshot_data",
+                kwargs={
+                    "council_id": self.council.council_id,
+                    "date": election_date,
                     "election_id": 1,
                 },
             ),


### PR DESCRIPTION
The FCS API election date is an ISO format string of a datetime in UTC. The elections start on midnight of election day, which during BST, is showing up as the day before. For example, an election on `2026-10-08` is appearing as `2026-10-07T23:00:00Z`. 

When we check they're API for elections on a date, we were matching dates just using strings so we wouldn't get any matches.  This PR makes the matching more robust by converting election dates to a timezone aware format.